### PR TITLE
fix(bridge,hub): announce session loss when a gateway reconnect replaces the session

### DIFF
--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -5063,9 +5063,7 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 		for k, v := range subagentFields {
 			heartbeatPayload[k] = v
 		}
-		if usage.sessionKey != "" {
-			heartbeatPayload["session_key"] = usage.sessionKey
-		}
+		addHeartbeatSessionKeys(heartbeatPayload, usage.sessionKey, gwSession.getSessionKey())
 		if usage.inputTokens != nil {
 			heartbeatPayload["input_tokens"] = usage.inputTokens
 		}
@@ -5191,6 +5189,18 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 		default:
 			// ignore unknown message types
 		}
+	}
+}
+
+// addHeartbeatSessionKeys keeps the usage snapshot and the live gateway
+// identity separate. The hub uses only gateway_session_key for session-loss
+// detection, since sessions.describe may be stale while a gateway recovers.
+func addHeartbeatSessionKeys(payload map[string]interface{}, snapshotKey, gatewayKey string) {
+	if snapshotKey != "" {
+		payload["session_key"] = snapshotKey
+	}
+	if gatewayKey != "" {
+		payload["gateway_session_key"] = gatewayKey
 	}
 }
 

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -2564,7 +2564,8 @@ func reportSessionRecovery(agentErr error, reply *string, gwSession *gatewaySess
 		}
 		writeActivity(agentActivity{Kind: "session_rotated", Message: activityMessage})
 		*reply = ""
-		edge := hubMsg{Type: "session_rotated"}
+		keyPayload, _ := json.Marshal(map[string]string{"session_key": gwSession.getSessionKey()})
+		edge := hubMsg{Type: "session_rotated", Payload: keyPayload}
 		if err := writeHub(edge); err != nil {
 			log.Printf("[bridge] recovery edge write failed, queuing for replay: %v", err)
 			queue.pushControl(edge)
@@ -5015,7 +5016,8 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 	gwSession.setOnSessionReplaced(func() {
 		activityMessage := "OpenClaw session was replaced after gateway reconnect; waiting for the hub to resume the task"
 		writeActivity(agentActivity{Kind: "session_rotated", Message: activityMessage})
-		edge := hubMsg{Type: "session_rotated"}
+		keyPayload, _ := json.Marshal(map[string]string{"session_key": gwSession.getSessionKey()})
+		edge := hubMsg{Type: "session_rotated", Payload: keyPayload}
 		if err := writeHub(edge); err != nil {
 			log.Printf("[bridge] session replacement edge write failed, queuing for replay: %v", err)
 			queue.pushControl(edge)

--- a/cmd/claw-bridge/main.go
+++ b/cmd/claw-bridge/main.go
@@ -1130,6 +1130,12 @@ type gatewaySession struct {
 
 	reconnectMu sync.Mutex
 
+	// onSessionReplaced reports a reconnect that had to create a fresh session
+	// and therefore lost the transcript. runHubLoop installs it for the active
+	// hub connection; it is nil during startup and in focused tests.
+	onSessionReplacedMu sync.Mutex
+	onSessionReplaced   func()
+
 	// pending req/res tracking (reqID → response channel)
 	pendMu  sync.Mutex
 	pending map[string]chan gwFrame
@@ -1230,6 +1236,21 @@ func (gs *gatewaySession) setSessionKey(key string) {
 	gs.infMu.RUnlock()
 	if inf != nil {
 		deliverInFlight(inf, agentResult{err: fmt.Errorf("gateway session key rotated")})
+	}
+}
+
+func (gs *gatewaySession) setOnSessionReplaced(fn func()) {
+	gs.onSessionReplacedMu.Lock()
+	gs.onSessionReplaced = fn
+	gs.onSessionReplacedMu.Unlock()
+}
+
+func (gs *gatewaySession) notifySessionReplaced() {
+	gs.onSessionReplacedMu.Lock()
+	fn := gs.onSessionReplaced
+	gs.onSessionReplacedMu.Unlock()
+	if fn != nil {
+		fn()
 	}
 }
 
@@ -1422,17 +1443,17 @@ func (gs *gatewaySession) createFreshSessionOnConn(ctx context.Context, conn *we
 	return nil
 }
 
-func (gs *gatewaySession) reconnectGateway(ctx context.Context, expectedOld *websocket.Conn) (bool, error) {
+func (gs *gatewaySession) reconnectGateway(ctx context.Context, expectedOld *websocket.Conn) (reconnected bool, replacedSession bool, err error) {
 	gs.reconnectMu.Lock()
 	defer gs.reconnectMu.Unlock()
 
 	if expectedOld != nil && !gs.isCurrentConn(expectedOld) {
-		return false, nil
+		return false, false, nil
 	}
 
 	conn, err := gs.client.connectToGateway(ctx)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 	installed := false
 	defer func() {
@@ -1448,22 +1469,22 @@ func (gs *gatewaySession) reconnectGateway(ctx context.Context, expectedOld *web
 		} else {
 			log.Printf("[gateway] re-subscribe failed after reconnect: %v", err)
 			if !isMissingGatewaySessionError(err) {
-				return false, err
+				return false, false, err
 			}
 			if err := gs.createFreshSessionOnConn(ctx, conn, "gateway reconnect"); err != nil {
-				return false, err
+				return false, false, err
 			}
 			createdFresh = true
 		}
 	} else {
 		if err := gs.createFreshSessionOnConn(ctx, conn, "gateway reconnect"); err != nil {
-			return false, err
+			return false, false, err
 		}
 		createdFresh = true
 	}
 
 	if expectedOld != nil && !gs.isCurrentConn(expectedOld) {
-		return false, nil
+		return false, false, nil
 	}
 	gs.failPendingRequests(fmt.Errorf("gateway disconnected"))
 	gs.connMu.Lock()
@@ -1477,14 +1498,14 @@ func (gs *gatewaySession) reconnectGateway(ctx context.Context, expectedOld *web
 	if createdFresh {
 		gs.setReady()
 	}
-	return true, nil
+	return true, createdFresh, nil
 }
 
-func (gs *gatewaySession) reconnectGatewayWithTimeout(ctx context.Context, expectedOld *websocket.Conn, timeout time.Duration) (bool, error) {
+func (gs *gatewaySession) reconnectGatewayWithTimeout(ctx context.Context, expectedOld *websocket.Conn, timeout time.Duration) (reconnected bool, replacedSession bool, err error) {
 	reconnectCtx, cancel := context.WithTimeout(ctx, timeout)
-	reconnected, err := gs.reconnectGateway(reconnectCtx, expectedOld)
+	reconnected, replacedSession, err = gs.reconnectGateway(reconnectCtx, expectedOld)
 	cancel()
-	return reconnected, err
+	return reconnected, replacedSession, err
 }
 
 // readLoop reads frames from the gateway forever, dispatching responses to
@@ -1526,7 +1547,7 @@ func (gs *gatewaySession) readLoop(ctx context.Context) {
 				if !gs.isCurrentConn(conn) {
 					break
 				}
-				_, err := gs.reconnectGatewayWithTimeout(ctx, conn, gatewayReconnectTimeout)
+				_, replacedSession, err := gs.reconnectGatewayWithTimeout(ctx, conn, gatewayReconnectTimeout)
 				if err != nil {
 					if !gs.isCurrentConn(conn) {
 						break
@@ -1534,6 +1555,9 @@ func (gs *gatewaySession) readLoop(ctx context.Context) {
 					log.Printf("[gateway] reconnect failed: %v — retrying in 5s", err)
 					time.Sleep(5 * time.Second)
 					continue
+				}
+				if replacedSession {
+					gs.notifySessionReplaced()
 				}
 				log.Printf("[gateway] reconnected and re-subscribed")
 				break
@@ -2598,12 +2622,15 @@ func (gs *gatewaySession) SendMessage(ctx context.Context, message string, onChu
 				return "", ctxErr
 			}
 			reconnectCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-			reconnected, reconnectErr := gs.reconnectGateway(reconnectCtx, conn)
+			reconnected, replacedSession, reconnectErr := gs.reconnectGateway(reconnectCtx, conn)
 			cancel()
 			if reconnectErr != nil {
 				return "", fmt.Errorf("%w; gateway reconnect failed: %v", err, reconnectErr)
 			}
 			if reconnected {
+				if replacedSession {
+					gs.notifySessionReplaced()
+				}
 				gatewayRetried = true
 				log.Printf("[gateway] retrying message after reconnecting closed gateway connection")
 			} else {
@@ -4981,6 +5008,19 @@ func runHubLoop(ctx context.Context, wsURL, clawID, clawName, templateName, toke
 		return writeHub(msg)
 	}
 	proxy.mu.Unlock()
+
+	// Capture this connection's writer. If this hub connection has died by the
+	// time a gateway reconnect replaces the session, the callback queues the
+	// edge for replay instead of writing through a newer connection implicitly.
+	gwSession.setOnSessionReplaced(func() {
+		activityMessage := "OpenClaw session was replaced after gateway reconnect; waiting for the hub to resume the task"
+		writeActivity(agentActivity{Kind: "session_rotated", Message: activityMessage})
+		edge := hubMsg{Type: "session_rotated"}
+		if err := writeHub(edge); err != nil {
+			log.Printf("[bridge] session replacement edge write failed, queuing for replay: %v", err)
+			queue.pushControl(edge)
+		}
+	})
 
 	// Heartbeats run on a single goroutine (the ticker in startHubKeepalives),
 	// so this needs no lock. It quiets the sessions.list failure log after the

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -4022,19 +4022,29 @@ func TestSendMessageAnnouncesSessionReplacementOnReconnect(t *testing.T) {
 	replaced := make(chan struct{}, 1)
 	gs.setOnSessionReplaced(func() { replaced <- struct{}{} })
 
-	// reconnectGateway (subscribe/create/resubscribe) reads its own
-	// responses synchronously off the wire and needs no read pump. Only the
-	// retried sessions.send after that goes through the normal pending-map
-	// path, which readLoop services. Starting readLoop only once the
-	// synchronous reconnect is done keeps this test pinned to the
-	// SendMessage call site instead of racing readLoop's own reconnect.
+	// reconnectGateway (subscribe/create/resubscribe) reads its own responses
+	// synchronously. Only the retried sessions.send needs readLoop. Wait for
+	// the connection swap, rather than the re-subscribe response: the latter
+	// can arrive before reconnectGateway installs the new connection.
 	go func() {
 		select {
 		case <-resubscribeDone:
 		case <-ctx.Done():
 			return
 		}
-		gs.readLoop(ctx)
+		ticker := time.NewTicker(time.Millisecond)
+		defer ticker.Stop()
+		for {
+			if gs.currentConn() != conn {
+				gs.readLoop(ctx)
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
 	}()
 
 	type sendResult struct {

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -3248,12 +3248,15 @@ func TestReconnectGatewayReportsStaleConnectionNoop(t *testing.T) {
 	stale := &websocket.Conn{}
 	gs := &gatewaySession{conn: current}
 
-	reconnected, err := gs.reconnectGateway(context.Background(), stale)
+	reconnected, replacedSession, err := gs.reconnectGateway(context.Background(), stale)
 	if err != nil {
 		t.Fatalf("reconnectGateway returned error: %v", err)
 	}
 	if reconnected {
 		t.Fatal("reconnectGateway reported reconnect for stale expected connection")
+	}
+	if replacedSession {
+		t.Fatal("reconnectGateway reported replacement for stale expected connection")
 	}
 	if got := gs.currentConn(); got != current {
 		t.Fatalf("current connection changed on stale reconnect: got %p, want %p", got, current)
@@ -3286,12 +3289,255 @@ func TestReconnectGatewayWithTimeoutWhenChallengeNeverArrives(t *testing.T) {
 		pending: make(map[string]chan gwFrame),
 	}
 	started := time.Now()
-	_, err = gs.reconnectGatewayWithTimeout(context.Background(), current, 100*time.Millisecond)
+	_, _, err = gs.reconnectGatewayWithTimeout(context.Background(), current, 100*time.Millisecond)
 	if err == nil {
 		t.Fatal("reconnectGatewayWithTimeout error = nil, want timeout")
 	}
 	if elapsed := time.Since(started); elapsed > time.Second {
 		t.Fatalf("reconnect returned after %s, want roughly the timeout", elapsed)
+	}
+}
+
+// TestReconnectGatewayReportsReplacementWhenSessionMissing covers the loss
+// path: the gateway forgot the session, so reconnectGateway must fall back
+// to sessions.create and report replacedSession=true so callers can announce
+// the loss to the hub. Without this signal, readLoop and SendMessage would
+// silently keep going on an empty transcript.
+func TestReconnectGatewayReportsReplacementWhenSessionMissing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		defer conn.CloseNow()
+		ctx := r.Context()
+
+		challengePayload, _ := json.Marshal(map[string]string{"nonce": "nonce"})
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "event", Event: "connect.challenge", Payload: challengePayload}); err != nil {
+			t.Errorf("write challenge: %v", err)
+			return
+		}
+		var connectReq gwFrame
+		if err := wsjson.Read(ctx, conn, &connectReq); err != nil {
+			t.Errorf("read connect request: %v", err)
+			return
+		}
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: connectReq.ID, OK: true}); err != nil {
+			t.Errorf("write connect response: %v", err)
+			return
+		}
+
+		var subReq gwFrame
+		if err := wsjson.Read(ctx, conn, &subReq); err != nil {
+			t.Errorf("read subscribe request: %v", err)
+			return
+		}
+		if subReq.Method != "sessions.subscribe" {
+			t.Errorf("request method = %q, want sessions.subscribe", subReq.Method)
+			return
+		}
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: subReq.ID, OK: false, Error: &gwError{Code: "not_found", Message: "session not found"}}); err != nil {
+			t.Errorf("write subscribe error: %v", err)
+			return
+		}
+
+		var createReq gwFrame
+		if err := wsjson.Read(ctx, conn, &createReq); err != nil {
+			t.Errorf("read create request: %v", err)
+			return
+		}
+		if createReq.Method != "sessions.create" {
+			t.Errorf("request method = %q, want sessions.create", createReq.Method)
+			return
+		}
+		createPayload, _ := json.Marshal(map[string]string{"key": "session-2"})
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: createReq.ID, OK: true, Payload: createPayload}); err != nil {
+			t.Errorf("write create response: %v", err)
+			return
+		}
+
+		var resubReq gwFrame
+		if err := wsjson.Read(ctx, conn, &resubReq); err != nil {
+			t.Errorf("read resubscribe request: %v", err)
+			return
+		}
+		if resubReq.Method != "sessions.subscribe" {
+			t.Errorf("request method = %q, want sessions.subscribe", resubReq.Method)
+			return
+		}
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: resubReq.ID, OK: true}); err != nil {
+			t.Errorf("write resubscribe response: %v", err)
+			return
+		}
+		<-ctx.Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	client := &gatewayClient{
+		addr:  strings.TrimPrefix(wsURL, "ws://"),
+		token: "token",
+		device: &deviceIdentity{
+			DeviceID:      "device-1",
+			PublicKeyPem:  testPEM("PUBLIC KEY"),
+			PrivateKeyPem: testPEM("PRIVATE KEY"),
+		},
+		home: t.TempDir(),
+	}
+	gs := &gatewaySession{
+		client:     client,
+		sessionKey: "session-1",
+		pending:    make(map[string]chan gwFrame),
+	}
+
+	reconnected, replacedSession, err := gs.reconnectGateway(ctx, nil)
+	if err != nil {
+		t.Fatalf("reconnectGateway returned error: %v", err)
+	}
+	if !reconnected {
+		t.Fatal("reconnectGateway reported reconnected=false, want true")
+	}
+	if !replacedSession {
+		t.Fatal("reconnectGateway reported replacedSession=false, want true after a missing-session error")
+	}
+	if got := gs.getSessionKey(); got != "session-2" {
+		t.Fatalf("session key = %q, want session-2 (fresh session)", got)
+	}
+}
+
+// TestReadLoopAnnouncesSessionReplacementOnBackgroundReconnect covers the
+// readLoop call site specifically (as opposed to reconnectGateway directly):
+// a background reconnect after a dropped read must still fire
+// onSessionReplaced when the gateway had forgotten the session, or the hub
+// never learns the transcript was lost.
+func TestReadLoopAnnouncesSessionReplacementOnBackgroundReconnect(t *testing.T) {
+	var connections atomic.Int32
+	firstHandshakeDone := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		defer conn.CloseNow()
+		ctx := r.Context()
+
+		connID := connections.Add(1)
+		challengePayload, _ := json.Marshal(map[string]string{"nonce": "nonce"})
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "event", Event: "connect.challenge", Payload: challengePayload}); err != nil {
+			t.Errorf("write challenge: %v", err)
+			return
+		}
+		var connectReq gwFrame
+		if err := wsjson.Read(ctx, conn, &connectReq); err != nil {
+			t.Errorf("read connect request: %v", err)
+			return
+		}
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: connectReq.ID, OK: true}); err != nil {
+			t.Errorf("write connect response: %v", err)
+			return
+		}
+
+		if connID == 1 {
+			// First connection: let readLoop start reading, then drop it so
+			// readLoop's background reconnect kicks in.
+			close(firstHandshakeDone)
+			conn.CloseNow()
+			return
+		}
+
+		var subReq gwFrame
+		if err := wsjson.Read(ctx, conn, &subReq); err != nil {
+			t.Errorf("read subscribe request: %v", err)
+			return
+		}
+		if subReq.Method != "sessions.subscribe" {
+			t.Errorf("request method = %q, want sessions.subscribe", subReq.Method)
+			return
+		}
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: subReq.ID, OK: false, Error: &gwError{Code: "not_found", Message: "session not found"}}); err != nil {
+			t.Errorf("write subscribe error: %v", err)
+			return
+		}
+
+		var createReq gwFrame
+		if err := wsjson.Read(ctx, conn, &createReq); err != nil {
+			t.Errorf("read create request: %v", err)
+			return
+		}
+		if createReq.Method != "sessions.create" {
+			t.Errorf("request method = %q, want sessions.create", createReq.Method)
+			return
+		}
+		createPayload, _ := json.Marshal(map[string]string{"key": "session-2"})
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: createReq.ID, OK: true, Payload: createPayload}); err != nil {
+			t.Errorf("write create response: %v", err)
+			return
+		}
+
+		var resubReq gwFrame
+		if err := wsjson.Read(ctx, conn, &resubReq); err != nil {
+			t.Errorf("read resubscribe request: %v", err)
+			return
+		}
+		if resubReq.Method != "sessions.subscribe" {
+			t.Errorf("request method = %q, want sessions.subscribe", resubReq.Method)
+			return
+		}
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: resubReq.ID, OK: true}); err != nil {
+			t.Errorf("write resubscribe response: %v", err)
+			return
+		}
+		<-ctx.Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	client := &gatewayClient{
+		addr:  strings.TrimPrefix(wsURL, "ws://"),
+		token: "token",
+		device: &deviceIdentity{
+			DeviceID:      "device-1",
+			PublicKeyPem:  testPEM("PUBLIC KEY"),
+			PrivateKeyPem: testPEM("PRIVATE KEY"),
+		},
+		home: t.TempDir(),
+	}
+	conn, err := client.connectToGateway(ctx)
+	if err != nil {
+		t.Fatalf("connect to gateway: %v", err)
+	}
+	select {
+	case <-firstHandshakeDone:
+	case <-time.After(time.Second):
+		t.Fatal("first gateway handshake did not complete")
+	}
+
+	gs := &gatewaySession{
+		client:     client,
+		sessionKey: "session-1",
+		conn:       conn,
+		pending:    make(map[string]chan gwFrame),
+	}
+	replaced := make(chan struct{}, 1)
+	gs.setOnSessionReplaced(func() { replaced <- struct{}{} })
+	go gs.readLoop(ctx)
+
+	select {
+	case <-replaced:
+	case <-time.After(3 * time.Second):
+		t.Fatal("readLoop's background reconnect did not announce a session replacement")
+	}
+	if got := gs.getSessionKey(); got != "session-2" {
+		t.Fatalf("session key = %q, want session-2 (fresh session)", got)
 	}
 }
 
@@ -3555,6 +3801,8 @@ func TestGatewaySessionRetriesSendAfterClosedGatewayWrite(t *testing.T) {
 		conn:       conn,
 		pending:    make(map[string]chan gwFrame),
 	}
+	replaced := make(chan struct{}, 1)
+	gs.setOnSessionReplaced(func() { replaced <- struct{}{} })
 	go gs.readLoop(ctx)
 
 	var chunks []string
@@ -3579,6 +3827,246 @@ func TestGatewaySessionRetriesSendAfterClosedGatewayWrite(t *testing.T) {
 	}
 	if got := connections.Load(); got != 2 {
 		t.Fatalf("connections = %d, want 2", got)
+	}
+	select {
+	case <-replaced:
+		t.Fatal("successful re-subscribe announced a session replacement")
+	default:
+	}
+}
+
+// TestSendMessageAnnouncesSessionReplacementOnReconnect covers the
+// SendMessage call site specifically: a retryable send-write failure forces
+// a reconnect, and when that reconnect finds the session gone it must still
+// announce the replacement even though the retried send itself succeeds.
+func TestSendMessageAnnouncesSessionReplacementOnReconnect(t *testing.T) {
+	var connections atomic.Int32
+	firstHandshakeDone := make(chan struct{})
+	resubscribeDone := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		defer conn.CloseNow()
+		ctx := r.Context()
+
+		connID := connections.Add(1)
+		challengePayload, _ := json.Marshal(map[string]string{"nonce": "nonce"})
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "event", Event: "connect.challenge", Payload: challengePayload}); err != nil {
+			t.Errorf("write challenge: %v", err)
+			return
+		}
+		var connectReq gwFrame
+		if err := wsjson.Read(ctx, conn, &connectReq); err != nil {
+			t.Errorf("read connect request: %v", err)
+			return
+		}
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: connectReq.ID, OK: true}); err != nil {
+			t.Errorf("write connect response: %v", err)
+			return
+		}
+
+		if connID == 1 {
+			// First connection: handshake only, then get closed by the test
+			// so the first sessions.send write fails.
+			close(firstHandshakeDone)
+			<-ctx.Done()
+			return
+		}
+
+		var subReq gwFrame
+		if err := wsjson.Read(ctx, conn, &subReq); err != nil {
+			t.Errorf("read subscribe request: %v", err)
+			return
+		}
+		if subReq.Method != "sessions.subscribe" {
+			t.Errorf("request method = %q, want sessions.subscribe", subReq.Method)
+			return
+		}
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: subReq.ID, OK: false, Error: &gwError{Code: "not_found", Message: "session not found"}}); err != nil {
+			t.Errorf("write subscribe error: %v", err)
+			return
+		}
+
+		var createReq gwFrame
+		if err := wsjson.Read(ctx, conn, &createReq); err != nil {
+			t.Errorf("read create request: %v", err)
+			return
+		}
+		if createReq.Method != "sessions.create" {
+			t.Errorf("request method = %q, want sessions.create", createReq.Method)
+			return
+		}
+		createPayload, _ := json.Marshal(map[string]string{"key": "session-2"})
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: createReq.ID, OK: true, Payload: createPayload}); err != nil {
+			t.Errorf("write create response: %v", err)
+			return
+		}
+
+		var resubReq gwFrame
+		if err := wsjson.Read(ctx, conn, &resubReq); err != nil {
+			t.Errorf("read resubscribe request: %v", err)
+			return
+		}
+		if resubReq.Method != "sessions.subscribe" {
+			t.Errorf("request method = %q, want sessions.subscribe", resubReq.Method)
+			return
+		}
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: resubReq.ID, OK: true}); err != nil {
+			t.Errorf("write resubscribe response: %v", err)
+			return
+		}
+		close(resubscribeDone)
+
+		// Creating a fresh session makes gatewaySession.setReady() kick off an
+		// unrelated background sessions.describe (context-usage refresh) on
+		// the same connection; it can arrive before or after the retried
+		// sessions.send, so answer whichever request shows up first.
+		var sendReq gwFrame
+		for {
+			var req gwFrame
+			if err := wsjson.Read(ctx, conn, &req); err != nil {
+				t.Errorf("read request after resubscribe: %v", err)
+				return
+			}
+			if req.Method == "sessions.describe" {
+				describePayload, _ := json.Marshal(map[string]interface{}{"session": map[string]interface{}{}})
+				if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: req.ID, OK: true, Payload: describePayload}); err != nil {
+					t.Errorf("write sessions.describe response: %v", err)
+					return
+				}
+				continue
+			}
+			sendReq = req
+			break
+		}
+		if sendReq.Method != "sessions.send" {
+			t.Errorf("retry request method = %q, want sessions.send", sendReq.Method)
+			return
+		}
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: sendReq.ID, OK: true}); err != nil {
+			t.Errorf("write sessions.send response: %v", err)
+			return
+		}
+		assistantPayload, _ := json.Marshal(map[string]interface{}{
+			"stream":     "assistant",
+			"sessionKey": "session-2",
+			"data":       map[string]string{"delta": "hello"},
+		})
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "event", Event: "agent", Payload: assistantPayload}); err != nil {
+			t.Errorf("write assistant event: %v", err)
+			return
+		}
+		endPayload, _ := json.Marshal(map[string]interface{}{
+			"stream":     "lifecycle",
+			"sessionKey": "session-2",
+			"data":       map[string]string{"phase": "end"},
+		})
+		if err := wsjson.Write(ctx, conn, gwFrame{Type: "event", Event: "agent", Payload: endPayload}); err != nil {
+			t.Errorf("write lifecycle event: %v", err)
+			return
+		}
+		// Drain and answer any further requests (e.g. a still-pending
+		// context-usage sessions.describe) instead of leaving them unread,
+		// which would otherwise surface as a goroutine panic once the test
+		// itself has already returned.
+		for {
+			var req gwFrame
+			if err := wsjson.Read(ctx, conn, &req); err != nil {
+				return
+			}
+			if req.Method == "sessions.describe" {
+				describePayload, _ := json.Marshal(map[string]interface{}{"session": map[string]interface{}{}})
+				_ = wsjson.Write(ctx, conn, gwFrame{Type: "res", ID: req.ID, OK: true, Payload: describePayload})
+			}
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	client := &gatewayClient{
+		addr:  strings.TrimPrefix(wsURL, "ws://"),
+		token: "token",
+		device: &deviceIdentity{
+			DeviceID:      "device-1",
+			PublicKeyPem:  testPEM("PUBLIC KEY"),
+			PrivateKeyPem: testPEM("PRIVATE KEY"),
+		},
+		home: t.TempDir(),
+	}
+	conn, err := client.connectToGateway(ctx)
+	if err != nil {
+		t.Fatalf("connect to gateway: %v", err)
+	}
+	select {
+	case <-firstHandshakeDone:
+	case <-time.After(time.Second):
+		t.Fatal("first gateway handshake did not complete")
+	}
+	// Close from the client side so the first sessions.send write fails
+	// immediately, without relying on readLoop to notice the drop first.
+	conn.CloseNow()
+
+	gs := &gatewaySession{
+		client:     client,
+		sessionKey: "session-1",
+		conn:       conn,
+		pending:    make(map[string]chan gwFrame),
+	}
+	replaced := make(chan struct{}, 1)
+	gs.setOnSessionReplaced(func() { replaced <- struct{}{} })
+
+	// reconnectGateway (subscribe/create/resubscribe) reads its own
+	// responses synchronously off the wire and needs no read pump. Only the
+	// retried sessions.send after that goes through the normal pending-map
+	// path, which readLoop services. Starting readLoop only once the
+	// synchronous reconnect is done keeps this test pinned to the
+	// SendMessage call site instead of racing readLoop's own reconnect.
+	go func() {
+		select {
+		case <-resubscribeDone:
+		case <-ctx.Done():
+			return
+		}
+		gs.readLoop(ctx)
+	}()
+
+	type sendResult struct {
+		reply string
+		err   error
+	}
+	resultCh := make(chan sendResult, 1)
+	go func() {
+		reply, err := gs.SendMessage(ctx, "hi", func(string) {}, nil)
+		resultCh <- sendResult{reply, err}
+	}()
+
+	select {
+	case <-replaced:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SendMessage's reconnect did not announce a session replacement")
+	}
+
+	var result sendResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("SendMessage did not return after reconnect")
+	}
+	if result.err != nil {
+		t.Fatalf("SendMessage returned error: %v", result.err)
+	}
+	if result.reply != "hello" {
+		t.Fatalf("reply = %q, want hello", result.reply)
+	}
+	if got := gs.getSessionKey(); got != "session-2" {
+		t.Fatalf("session key = %q, want session-2 (fresh session)", got)
 	}
 }
 

--- a/cmd/claw-bridge/main_test.go
+++ b/cmd/claw-bridge/main_test.go
@@ -4346,6 +4346,23 @@ func TestSubagentHeartbeatFields(t *testing.T) {
 	}
 }
 
+func TestAddHeartbeatSessionKeysKeepsSnapshotAndLiveKeysSeparate(t *testing.T) {
+	payload := map[string]interface{}{}
+	addHeartbeatSessionKeys(payload, "stale-snapshot", "live-gateway-session")
+	if got := payload["session_key"]; got != "stale-snapshot" {
+		t.Fatalf("session_key = %v, want usage snapshot", got)
+	}
+	if got := payload["gateway_session_key"]; got != "live-gateway-session" {
+		t.Fatalf("gateway_session_key = %v, want live gateway key", got)
+	}
+
+	payload = map[string]interface{}{}
+	addHeartbeatSessionKeys(payload, "old-snapshot", "")
+	if _, ok := payload["gateway_session_key"]; ok {
+		t.Fatalf("gateway_session_key = %v, want omitted without a live key", payload["gateway_session_key"])
+	}
+}
+
 // A lifecycle error that is not a lock conflict skips the mismatch early
 // return, so it reaches abortSession while a concurrent readLoop rotation may
 // already have replaced the current key. The abort must still target the key

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -109,6 +109,7 @@ func migrate(db *sql.DB) error {
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN trigger_actor_json TEXT NOT NULL DEFAULT '{}'`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN stop_comment_pending INTEGER NOT NULL DEFAULT 0`)
 	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN no_progress_paused INTEGER NOT NULL DEFAULT 0`)
+	_, _ = db.Exec(`ALTER TABLE claws ADD COLUMN pending_session_loss_notice TEXT NOT NULL DEFAULT ''`)
 	// rebrief_pending is armed by [claw-retry] when a sandbox is replaced and
 	// consumed on reconnect to re-brief the fresh session. resetClawForRetry's
 	// UPDATE references it on the retry hot path, so a silently missing column
@@ -510,7 +511,8 @@ func migrate(db *sql.DB) error {
 		stage_entered_at INTEGER,
 		stage_stalled_since INTEGER NOT NULL DEFAULT 0,
 		idle_resume_at INTEGER NOT NULL DEFAULT 0,
-		idle_resume_count INTEGER NOT NULL DEFAULT 0
+		idle_resume_count INTEGER NOT NULL DEFAULT 0,
+		pending_session_loss_notice TEXT NOT NULL DEFAULT ''
 	);
 
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -63,6 +63,8 @@ type Server struct {
 	mu    sync.RWMutex
 	claws map[string]*clawConn // claw_id -> conn
 	users map[string]*userConn // tenant_id -> []conn (broadcast)
+	// sessionLostResumeMu makes the shared throttle check and enqueue atomic.
+	sessionLostResumeMu sync.Mutex
 	// gatewayRestartCounts retains the heartbeat counter across WebSocket reconnects.
 	gatewayRestartCounts map[string]int
 	// gatewayUnhealthyCounts survives WebSocket reconnects so flapping gateways still escalate.
@@ -8617,15 +8619,13 @@ func (s *Server) enqueueRestartResume(clawID string, restartCount int) {
 	s.enqueueSessionLostResume(clawID, restartResumePrefix, fmt.Sprintf("restart:%d", restartCount))
 }
 
-// sessionRotatedResumeThrottle bounds the rotation → resume → rotation loop:
-// if lock conflicts persist across fresh sessions (e.g. another process keeps
-// touching the session files), each rotation would otherwise enqueue another
-// resume prompt indefinitely — rotation turns complete with an empty reply,
-// so the no-progress watchdog never observes them.
-const sessionRotatedResumeThrottle = 10 * time.Minute
+// sessionLostResumeThrottle bounds repeated session-loss recovery prompts.
+// Two real incidents inside this window collapse into one prompt because a
+// duplicate recovery is more harmful than a delayed second recovery.
+const sessionLostResumeThrottle = 10 * time.Minute
 
 // sessionPreservedContinuationThrottle bounds the conflict -> continuation ->
-// conflict loop, the same way sessionRotatedResumeThrottle does for rotation.
+// conflict loop, the same way sessionLostResumeThrottle does for session loss.
 //
 // Known limitation: unlike a rotation, the same session can legitimately need a
 // second continuation inside the window, and this throttle drops it silently —
@@ -8636,6 +8636,23 @@ const sessionRotatedResumeThrottle = 10 * time.Minute
 const sessionPreservedContinuationThrottle = 10 * time.Minute
 
 func (s *Server) enqueueSessionRotatedResume(clawID string) {
+	s.mu.RLock()
+	cc := s.claws[clawID]
+	s.mu.RUnlock()
+	if cc == nil {
+		return
+	}
+	cc.mu.RLock()
+	turnOpenOrRecent := !cc.streamingStartedAt.IsZero() || cc.awaitingResponse ||
+		(!cc.lastTurnFinishedAt.IsZero() && time.Since(cc.lastTurnFinishedAt) < autoResumeRecentTurnWindow)
+	cc.mu.RUnlock()
+	if !turnOpenOrRecent {
+		// A lost transcript for an idle claw does not justify making it act on
+		// its own. The next real message will use the new session. This leaves
+		// a known gap: an idle claw is not told that its transcript was lost.
+		log.Printf("[watchdog] skipping session-rotated resume for %s: claw is idle", shortID(clawID))
+		return
+	}
 	s.enqueueSessionLostResume(clawID, sessionRotatedResumePrefix, fmt.Sprintf("session_rotated:%s", uuid.NewString()))
 }
 
@@ -8686,11 +8703,14 @@ func (s *Server) lastSubstantiveClawProgress(clawID string) (string, time.Time) 
 }
 
 func (s *Server) enqueueSessionLostResume(clawID, prefix, marker string) {
+	s.sessionLostResumeMu.Lock()
+	defer s.sessionLostResumeMu.Unlock()
+
 	var recent int
-	err := s.db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ? AND created_at > ?`,
-		clawID, sessionRotatedResumePrefix+"%", now().Add(-sessionRotatedResumeThrottle)).Scan(&recent)
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND (content LIKE ? OR content LIKE ?) AND created_at > ?`,
+		clawID, restartResumePrefix+"%", sessionRotatedResumePrefix+"%", now().Add(-sessionLostResumeThrottle)).Scan(&recent)
 	if err == nil && recent > 0 {
-		log.Printf("[watchdog] skipping session-rotated resume for %s: already resumed within %s", shortID(clawID), sessionRotatedResumeThrottle)
+		log.Printf("[watchdog] skipping session-loss resume for %s: already resumed within %s", shortID(clawID), sessionLostResumeThrottle)
 		return
 	}
 	var status, issueTitle, linearID, githubID, shortcutID, jiraID string

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -69,10 +69,8 @@ type Server struct {
 	gatewayUnhealthyCounts map[string]int
 	// gatewayEscalatedAt records the last gateway-health escalation dispatch per claw,
 	// preventing retries from piling up while a replacement is pending or in flight. Guarded by s.mu.
-	gatewayEscalatedAt map[string]time.Time
-	// autoResumeRestartCounts records restart counts already handled per claw. Guarded by s.mu.
-	autoResumeRestartCounts map[string]int
-	lastTokenFailureLog     time.Time
+	gatewayEscalatedAt  map[string]time.Time
+	lastTokenFailureLog time.Time
 	// trackedPRCount is the PR count observed by the last poll; it drives the
 	// PR watcher's adaptive interval. Guarded by s.mu.
 	trackedPRCount int
@@ -242,33 +240,34 @@ func (s *Server) gatewayUnhealthyCount(clawID string) int {
 type clawConn struct {
 	mu sync.RWMutex // protects mutable fields below
 
-	id                    string
-	tenantID              string
-	conn                  *websocket.Conn
-	tags                  []string        // cached from DB at registration time for access-control checks
-	contextUsage          int             // 0-100, updated from heartbeats
-	gatewayReady          bool            // true once bridge reports gateway session established
-	gatewayRestartCount   int             // cumulative bridge restarts reported by heartbeats
-	gatewaySessionKey     string          // last live gateway session key reported by heartbeat
-	gatewaySessionKeySeen bool            // distinguishes the first live-key heartbeat from a loss
-	forcedFinishCount     int             // consecutive watchdog-forced streaming turn finishes
-	workflowStartPending  bool            // true while initial volume attach / wake is in flight
-	workflowStartDone     bool            // true once initial volume attach / wake has completed
-	streamingBuf          strings.Builder // accumulates chunks for current in-flight response
-	streamingMsgID        string          // pre-assigned message ID for the current stream
-	streamingSplit        bool            // true once activity has split this turn into multiple persisted segments
-	streamingStartedAt    time.Time       // when the current streaming turn started (zero if not streaming)
-	streamingTimeoutSent  bool            // true once the 12-min timeout message has been injected this turn
-	contextWarningSent    bool            // true once the context-nearly-full warning has been injected this turn
-	awaitingResponse      bool            // true as soon as a prompt is delivered, before the first chunk/activity
-	noProgressPaused      bool            // automatic delivery is paused after repeated turns with unchanged progress
-	bridgeErrorStreak     int             // consecutive turns that came back as a claw-bridge transport error (NEXT-725)
-	lastTurnFinishedAt    time.Time       // when the last streaming turn ended (for post-restart resume window)
-	connectedAt           time.Time       // when this connection registered; immutable after registration
-	idleNotifiedAt        time.Time       // when the agent_idle notification fired for the current idle stretch (zero = armed)
-	turnBoundarySeen      bool            // a turn actually ended on THIS connection, so turn tracking is known live (see agentIdleResumeBlindGrace)
-	subagentsActiveAt     time.Time       // when the last heartbeat that REPORTED active spawned subagent sessions arrived (zero = none known; see applySubagentHeartbeatLocked)
-	subagentActiveCount   int             // subagent sessions with a run in flight per that heartbeat
+	id                      string
+	tenantID                string
+	conn                    *websocket.Conn
+	tags                    []string        // cached from DB at registration time for access-control checks
+	contextUsage            int             // 0-100, updated from heartbeats
+	gatewayReady            bool            // true once bridge reports gateway session established
+	gatewayRestartCount     int             // cumulative bridge restarts reported by heartbeats
+	gatewaySessionKey       string          // last live gateway session key reported by heartbeat
+	gatewaySessionKeySeen   bool            // distinguishes the first live-key heartbeat from a loss
+	announcedSessionLossKey string          // newest loss identity already announced; guarded by mu
+	forcedFinishCount       int             // consecutive watchdog-forced streaming turn finishes
+	workflowStartPending    bool            // true while initial volume attach / wake is in flight
+	workflowStartDone       bool            // true once initial volume attach / wake has completed
+	streamingBuf            strings.Builder // accumulates chunks for current in-flight response
+	streamingMsgID          string          // pre-assigned message ID for the current stream
+	streamingSplit          bool            // true once activity has split this turn into multiple persisted segments
+	streamingStartedAt      time.Time       // when the current streaming turn started (zero if not streaming)
+	streamingTimeoutSent    bool            // true once the 12-min timeout message has been injected this turn
+	contextWarningSent      bool            // true once the context-nearly-full warning has been injected this turn
+	awaitingResponse        bool            // true as soon as a prompt is delivered, before the first chunk/activity
+	noProgressPaused        bool            // automatic delivery is paused after repeated turns with unchanged progress
+	bridgeErrorStreak       int             // consecutive turns that came back as a claw-bridge transport error (NEXT-725)
+	lastTurnFinishedAt      time.Time       // when the last streaming turn ended (for post-restart resume window)
+	connectedAt             time.Time       // when this connection registered; immutable after registration
+	idleNotifiedAt          time.Time       // when the agent_idle notification fired for the current idle stretch (zero = armed)
+	turnBoundarySeen        bool            // a turn actually ended on THIS connection, so turn tracking is known live (see agentIdleResumeBlindGrace)
+	subagentsActiveAt       time.Time       // when the last heartbeat that REPORTED active spawned subagent sessions arrived (zero = none known; see applySubagentHeartbeatLocked)
+	subagentActiveCount     int             // subagent sessions with a run in flight per that heartbeat
 
 	deliveryInFlight bool // serializes DB-backed delivery writes
 
@@ -483,7 +482,6 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 		gatewayRestartCounts:     make(map[string]int),
 		gatewayUnhealthyCounts:   make(map[string]int),
 		gatewayEscalatedAt:       make(map[string]time.Time),
-		autoResumeRestartCounts:  make(map[string]int),
 		dependencyStatus:         newDependencyStatusService(hubCfg),
 		fileAckWaiters:           make(map[string]chan types.FileAck),
 		fileReadWaiters:          make(map[string]chan types.FileReadResp),
@@ -2850,7 +2848,8 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				var shouldWake bool
 				var shouldWarnContext bool
 				var shouldEscalateGateway bool
-				var shouldAutoResume bool
+				var shouldNoteSessionLoss bool
+				var sessionLossKey, sessionLossSource string
 				var prevUsage int
 				var revived bool
 				var current bool
@@ -2884,21 +2883,18 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 						// was relaunched and its counter reset.
 						log.Printf("[heartbeat] %s (%s): agent process restarted (restart_count=%d)", rp.Name, clawID[:8], hb.RestartCount)
 						s.gatewayRestartCounts[clawID] = hb.RestartCount
-						if s.autoResumeRestartCounts == nil {
-							s.autoResumeRestartCounts = make(map[string]int)
-						}
-						turnOpenOrRecent := !activeCC.streamingStartedAt.IsZero() || activeCC.awaitingResponse ||
-							(!activeCC.lastTurnFinishedAt.IsZero() && time.Since(activeCC.lastTurnFinishedAt) < autoResumeRecentTurnWindow)
-						// Existence-aware lookup: a bridge relaunch resets its counter
-						// to 0, which equals the zero value of an absent map entry — a
-						// plain read would skip the resume for that first relaunch.
-						lastResumedCount, resumeRecorded := s.autoResumeRestartCounts[clawID]
-						if turnOpenOrRecent && (!resumeRecorded || lastResumedCount != hb.RestartCount) {
-							s.autoResumeRestartCounts[clawID] = hb.RestartCount
-							shouldAutoResume = true
+						shouldNoteSessionLoss = true
+						sessionLossSource = "restart_count"
+						if hb.GatewaySessionKey != nil {
+							sessionLossKey = *hb.GatewaySessionKey
 						}
 					}
 					if hb.GatewaySessionKey != nil {
+						if activeCC.gatewaySessionKeySeen && *hb.GatewaySessionKey != activeCC.gatewaySessionKey {
+							shouldNoteSessionLoss = true
+							sessionLossKey = *hb.GatewaySessionKey
+							sessionLossSource = "gateway_session_key"
+						}
 						// The first live-key observation is a baseline, just like restart_count:
 						// it may describe a session established before this hub connected.
 						activeCC.gatewaySessionKey = *hb.GatewaySessionKey
@@ -3004,8 +3000,8 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 				s.heartbeatWorkflowVolumeLeases(clawID)
-				if shouldAutoResume {
-					go s.enqueueRestartResume(clawID, hb.RestartCount)
+				if shouldNoteSessionLoss {
+					go s.noteSessionLoss(cc, clawID, sessionLossKey, sessionLossSource)
 				}
 				if shouldEscalateGateway {
 					// Re-read the claw state before escalating: idle/completed claws
@@ -3340,7 +3336,12 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		} else if msg.Type == "session_rotated" {
-			go s.enqueueSessionRotatedResume(clawID)
+			var edge struct {
+				SessionKey string `json:"session_key"`
+			}
+			raw, _ := json.Marshal(msg.Payload)
+			_ = json.Unmarshal(raw, &edge)
+			go s.noteSessionLoss(cc, clawID, edge.SessionKey, "session_rotated")
 		} else if msg.Type == "session_preserved" {
 			// A preserved turn positively proves the transport reached the agent,
 			// even though it has no reply body to reach observeTurnOutcome.
@@ -8623,10 +8624,48 @@ const (
 	restartResumePrefix                = "[hub] Agent process restart detected."
 	sessionRotatedResumePrefix         = "[hub] OpenClaw session reset detected."
 	sessionPreservedContinuationPrefix = "[hub] OpenClaw session preserved after lock conflict."
+	sessionLossPendingNotice           = "[hub] Your previous session was lost, so you have no memory of the earlier conversation. Your workspace on disk is intact. Before continuing, recover the current state from the workspace (including git status); do not start over from scratch.\n\n"
 )
 
-func (s *Server) enqueueRestartResume(clawID string, restartCount int) {
-	s.enqueueSessionLostResume(clawID, restartResumePrefix, fmt.Sprintf("restart:%d", restartCount))
+// noteSessionLoss records one session-loss incident, identified by the key of
+// the session that replaced the lost one. The same incident is detected up to
+// three ways (the bridge edge, the live-key change, the restart-count change);
+// keying on the new session key collapses them into one prompt without
+// collapsing two genuinely separate losses, which a time-based throttle could
+// not distinguish.
+func (s *Server) noteSessionLoss(cc *clawConn, clawID, newKey, source string) {
+	cc.mu.Lock()
+	if newKey != "" && newKey == cc.announcedSessionLossKey {
+		cc.mu.Unlock()
+		log.Printf("[watchdog] skipping duplicate session loss for %s: session=%s source=%s", shortID(clawID), shortID(newKey), source)
+		return
+	}
+	if newKey != "" {
+		cc.announcedSessionLossKey = newKey
+	}
+	turnOpenOrRecent := !cc.streamingStartedAt.IsZero() || cc.awaitingResponse ||
+		(!cc.lastTurnFinishedAt.IsZero() && time.Since(cc.lastTurnFinishedAt) < autoResumeRecentTurnWindow)
+	cc.mu.Unlock()
+	if !turnOpenOrRecent {
+		// A lost transcript for an idle claw does not justify making it act on
+		// its own. The next real message will use the new session. This leaves
+		// a known gap: an idle claw is not told that its transcript was lost.
+		log.Printf("[watchdog] skipping session-loss resume for %s: claw is idle (source=%s)", shortID(clawID), source)
+		return
+	}
+	if source == "session_rotated" {
+		s.enqueueSessionRotatedResume(clawID)
+		return
+	}
+	// A live session key makes the marker stable across all reports of this
+	// incident, while still distinguishing a later loss. Old bridges do not
+	// send a key; preserve their historical no-dedup behavior with a fresh
+	// marker for every report.
+	marker := "restart:" + newKey
+	if newKey == "" {
+		marker = "restart:" + uuid.NewString()
+	}
+	s.enqueueSessionLostResume(clawID, restartResumePrefix, marker)
 }
 
 // sessionRotatedResumeThrottle bounds the rotation → resume → rotation loop:
@@ -8658,17 +8697,6 @@ func (s *Server) enqueueSessionRotatedResume(clawID string) {
 	cc := s.claws[clawID]
 	s.mu.RUnlock()
 	if cc == nil {
-		return
-	}
-	cc.mu.RLock()
-	turnOpenOrRecent := !cc.streamingStartedAt.IsZero() || cc.awaitingResponse ||
-		(!cc.lastTurnFinishedAt.IsZero() && time.Since(cc.lastTurnFinishedAt) < autoResumeRecentTurnWindow)
-	cc.mu.RUnlock()
-	if !turnOpenOrRecent {
-		// A lost transcript for an idle claw does not justify making it act on
-		// its own. The next real message will use the new session. This leaves
-		// a known gap: an idle claw is not told that its transcript was lost.
-		log.Printf("[watchdog] skipping session-rotated resume for %s: claw is idle", shortID(clawID))
 		return
 	}
 	var recent int

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -242,33 +242,31 @@ func (s *Server) gatewayUnhealthyCount(clawID string) int {
 type clawConn struct {
 	mu sync.RWMutex // protects mutable fields below
 
-	id                    string
-	tenantID              string
-	conn                  *websocket.Conn
-	tags                  []string        // cached from DB at registration time for access-control checks
-	contextUsage          int             // 0-100, updated from heartbeats
-	gatewayReady          bool            // true once bridge reports gateway session established
-	gatewayRestartCount   int             // cumulative bridge restarts reported by heartbeats
-	gatewaySessionKey     string          // last non-empty gateway session key reported by heartbeats
-	gatewaySessionKeySeen bool            // distinguishes an absent baseline from an empty key
-	forcedFinishCount     int             // consecutive watchdog-forced streaming turn finishes
-	workflowStartPending  bool            // true while initial volume attach / wake is in flight
-	workflowStartDone     bool            // true once initial volume attach / wake has completed
-	streamingBuf          strings.Builder // accumulates chunks for current in-flight response
-	streamingMsgID        string          // pre-assigned message ID for the current stream
-	streamingSplit        bool            // true once activity has split this turn into multiple persisted segments
-	streamingStartedAt    time.Time       // when the current streaming turn started (zero if not streaming)
-	streamingTimeoutSent  bool            // true once the 12-min timeout message has been injected this turn
-	contextWarningSent    bool            // true once the context-nearly-full warning has been injected this turn
-	awaitingResponse      bool            // true as soon as a prompt is delivered, before the first chunk/activity
-	noProgressPaused      bool            // automatic delivery is paused after repeated turns with unchanged progress
-	bridgeErrorStreak     int             // consecutive turns that came back as a claw-bridge transport error (NEXT-725)
-	lastTurnFinishedAt    time.Time       // when the last streaming turn ended (for post-restart resume window)
-	connectedAt           time.Time       // when this connection registered; immutable after registration
-	idleNotifiedAt        time.Time       // when the agent_idle notification fired for the current idle stretch (zero = armed)
-	turnBoundarySeen      bool            // a turn actually ended on THIS connection, so turn tracking is known live (see agentIdleResumeBlindGrace)
-	subagentsActiveAt     time.Time       // when the last heartbeat that REPORTED active spawned subagent sessions arrived (zero = none known; see applySubagentHeartbeatLocked)
-	subagentActiveCount   int             // subagent sessions with a run in flight per that heartbeat
+	id                   string
+	tenantID             string
+	conn                 *websocket.Conn
+	tags                 []string        // cached from DB at registration time for access-control checks
+	contextUsage         int             // 0-100, updated from heartbeats
+	gatewayReady         bool            // true once bridge reports gateway session established
+	gatewayRestartCount  int             // cumulative bridge restarts reported by heartbeats
+	forcedFinishCount    int             // consecutive watchdog-forced streaming turn finishes
+	workflowStartPending bool            // true while initial volume attach / wake is in flight
+	workflowStartDone    bool            // true once initial volume attach / wake has completed
+	streamingBuf         strings.Builder // accumulates chunks for current in-flight response
+	streamingMsgID       string          // pre-assigned message ID for the current stream
+	streamingSplit       bool            // true once activity has split this turn into multiple persisted segments
+	streamingStartedAt   time.Time       // when the current streaming turn started (zero if not streaming)
+	streamingTimeoutSent bool            // true once the 12-min timeout message has been injected this turn
+	contextWarningSent   bool            // true once the context-nearly-full warning has been injected this turn
+	awaitingResponse     bool            // true as soon as a prompt is delivered, before the first chunk/activity
+	noProgressPaused     bool            // automatic delivery is paused after repeated turns with unchanged progress
+	bridgeErrorStreak    int             // consecutive turns that came back as a claw-bridge transport error (NEXT-725)
+	lastTurnFinishedAt   time.Time       // when the last streaming turn ended (for post-restart resume window)
+	connectedAt          time.Time       // when this connection registered; immutable after registration
+	idleNotifiedAt       time.Time       // when the agent_idle notification fired for the current idle stretch (zero = armed)
+	turnBoundarySeen     bool            // a turn actually ended on THIS connection, so turn tracking is known live (see agentIdleResumeBlindGrace)
+	subagentsActiveAt    time.Time       // when the last heartbeat that REPORTED active spawned subagent sessions arrived (zero = none known; see applySubagentHeartbeatLocked)
+	subagentActiveCount  int             // subagent sessions with a run in flight per that heartbeat
 
 	deliveryInFlight bool // serializes DB-backed delivery writes
 
@@ -2847,7 +2845,6 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				var shouldWarnContext bool
 				var shouldEscalateGateway bool
 				var shouldAutoResume bool
-				var shouldResumeSessionRotation bool
 				var prevUsage int
 				var revived bool
 				var current bool
@@ -2864,20 +2861,6 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					prevUsage = activeCC.contextUsage
 					activeCC.contextUsage = hb.ContextUsage
 					activeCC.applySubagentHeartbeatLocked(hb.SubagentsActive, hb.SubagentActiveCount)
-					if hb.SessionKey != "" {
-						// A bridge can reconnect to a gateway that has discarded its
-						// session without emitting an edge. As with restart_count, the
-						// first value after a hub restart is historical state, so it is a
-						// baseline rather than evidence of a new loss.
-						if !activeCC.gatewaySessionKeySeen {
-							activeCC.gatewaySessionKey = hb.SessionKey
-							activeCC.gatewaySessionKeySeen = true
-						} else if hb.SessionKey != activeCC.gatewaySessionKey {
-							log.Printf("[heartbeat] %s (%s): gateway session changed (%s -> %s)", rp.Name, clawID[:8], shortID(activeCC.gatewaySessionKey), shortID(hb.SessionKey))
-							activeCC.gatewaySessionKey = hb.SessionKey
-							shouldResumeSessionRotation = true
-						}
-					}
 					if s.gatewayRestartCounts == nil {
 						s.gatewayRestartCounts = make(map[string]int)
 					}
@@ -2908,11 +2891,6 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							s.autoResumeRestartCounts[clawID] = hb.RestartCount
 							shouldAutoResume = true
 						}
-					}
-					// A restart change and a session-key change describe the same
-					// heartbeat loss. Let the restart path own it to avoid two resumes.
-					if shouldAutoResume {
-						shouldResumeSessionRotation = false
 					}
 					activeCC.gatewayRestartCount = s.gatewayRestartCounts[clawID]
 					// nil means field absent (old bridge) — treat as ready. The
@@ -3016,9 +2994,6 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				s.heartbeatWorkflowVolumeLeases(clawID)
 				if shouldAutoResume {
 					go s.enqueueRestartResume(clawID, hb.RestartCount)
-				}
-				if shouldResumeSessionRotation {
-					go s.enqueueSessionRotatedResume(clawID)
 				}
 				if shouldEscalateGateway {
 					// Re-read the claw state before escalating: idle/completed claws
@@ -8661,13 +8636,6 @@ const sessionRotatedResumeThrottle = 10 * time.Minute
 const sessionPreservedContinuationThrottle = 10 * time.Minute
 
 func (s *Server) enqueueSessionRotatedResume(clawID string) {
-	var recent int
-	err := s.db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ? AND created_at > ?`,
-		clawID, sessionRotatedResumePrefix+"%", now().Add(-sessionRotatedResumeThrottle)).Scan(&recent)
-	if err == nil && recent > 0 {
-		log.Printf("[watchdog] skipping session-rotated resume for %s: already resumed within %s", shortID(clawID), sessionRotatedResumeThrottle)
-		return
-	}
 	s.enqueueSessionLostResume(clawID, sessionRotatedResumePrefix, fmt.Sprintf("session_rotated:%s", uuid.NewString()))
 }
 
@@ -8718,9 +8686,16 @@ func (s *Server) lastSubstantiveClawProgress(clawID string) (string, time.Time) 
 }
 
 func (s *Server) enqueueSessionLostResume(clawID, prefix, marker string) {
+	var recent int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ? AND created_at > ?`,
+		clawID, sessionRotatedResumePrefix+"%", now().Add(-sessionRotatedResumeThrottle)).Scan(&recent)
+	if err == nil && recent > 0 {
+		log.Printf("[watchdog] skipping session-rotated resume for %s: already resumed within %s", shortID(clawID), sessionRotatedResumeThrottle)
+		return
+	}
 	var status, issueTitle, linearID, githubID, shortcutID, jiraID string
 	var bootstrapOK int
-	err := s.db.QueryRow(`SELECT status, COALESCE(bootstrap_ok,0), COALESCE(issue_title,''), COALESCE(linear_issue_id,''), COALESCE(github_issue_id,''), COALESCE(shortcut_story_id,''), COALESCE(jira_issue_id,'') FROM claws WHERE id=?`, clawID).Scan(&status, &bootstrapOK, &issueTitle, &linearID, &githubID, &shortcutID, &jiraID)
+	err = s.db.QueryRow(`SELECT status, COALESCE(bootstrap_ok,0), COALESCE(issue_title,''), COALESCE(linear_issue_id,''), COALESCE(github_issue_id,''), COALESCE(shortcut_story_id,''), COALESCE(jira_issue_id,'') FROM claws WHERE id=?`, clawID).Scan(&status, &bootstrapOK, &issueTitle, &linearID, &githubID, &shortcutID, &jiraID)
 	if err != nil {
 		return
 	}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -242,31 +242,33 @@ func (s *Server) gatewayUnhealthyCount(clawID string) int {
 type clawConn struct {
 	mu sync.RWMutex // protects mutable fields below
 
-	id                   string
-	tenantID             string
-	conn                 *websocket.Conn
-	tags                 []string        // cached from DB at registration time for access-control checks
-	contextUsage         int             // 0-100, updated from heartbeats
-	gatewayReady         bool            // true once bridge reports gateway session established
-	gatewayRestartCount  int             // cumulative bridge restarts reported by heartbeats
-	forcedFinishCount    int             // consecutive watchdog-forced streaming turn finishes
-	workflowStartPending bool            // true while initial volume attach / wake is in flight
-	workflowStartDone    bool            // true once initial volume attach / wake has completed
-	streamingBuf         strings.Builder // accumulates chunks for current in-flight response
-	streamingMsgID       string          // pre-assigned message ID for the current stream
-	streamingSplit       bool            // true once activity has split this turn into multiple persisted segments
-	streamingStartedAt   time.Time       // when the current streaming turn started (zero if not streaming)
-	streamingTimeoutSent bool            // true once the 12-min timeout message has been injected this turn
-	contextWarningSent   bool            // true once the context-nearly-full warning has been injected this turn
-	awaitingResponse     bool            // true as soon as a prompt is delivered, before the first chunk/activity
-	noProgressPaused     bool            // automatic delivery is paused after repeated turns with unchanged progress
-	bridgeErrorStreak    int             // consecutive turns that came back as a claw-bridge transport error (NEXT-725)
-	lastTurnFinishedAt   time.Time       // when the last streaming turn ended (for post-restart resume window)
-	connectedAt          time.Time       // when this connection registered; immutable after registration
-	idleNotifiedAt       time.Time       // when the agent_idle notification fired for the current idle stretch (zero = armed)
-	turnBoundarySeen     bool            // a turn actually ended on THIS connection, so turn tracking is known live (see agentIdleResumeBlindGrace)
-	subagentsActiveAt    time.Time       // when the last heartbeat that REPORTED active spawned subagent sessions arrived (zero = none known; see applySubagentHeartbeatLocked)
-	subagentActiveCount  int             // subagent sessions with a run in flight per that heartbeat
+	id                    string
+	tenantID              string
+	conn                  *websocket.Conn
+	tags                  []string        // cached from DB at registration time for access-control checks
+	contextUsage          int             // 0-100, updated from heartbeats
+	gatewayReady          bool            // true once bridge reports gateway session established
+	gatewayRestartCount   int             // cumulative bridge restarts reported by heartbeats
+	gatewaySessionKey     string          // last non-empty gateway session key reported by heartbeats
+	gatewaySessionKeySeen bool            // distinguishes an absent baseline from an empty key
+	forcedFinishCount     int             // consecutive watchdog-forced streaming turn finishes
+	workflowStartPending  bool            // true while initial volume attach / wake is in flight
+	workflowStartDone     bool            // true once initial volume attach / wake has completed
+	streamingBuf          strings.Builder // accumulates chunks for current in-flight response
+	streamingMsgID        string          // pre-assigned message ID for the current stream
+	streamingSplit        bool            // true once activity has split this turn into multiple persisted segments
+	streamingStartedAt    time.Time       // when the current streaming turn started (zero if not streaming)
+	streamingTimeoutSent  bool            // true once the 12-min timeout message has been injected this turn
+	contextWarningSent    bool            // true once the context-nearly-full warning has been injected this turn
+	awaitingResponse      bool            // true as soon as a prompt is delivered, before the first chunk/activity
+	noProgressPaused      bool            // automatic delivery is paused after repeated turns with unchanged progress
+	bridgeErrorStreak     int             // consecutive turns that came back as a claw-bridge transport error (NEXT-725)
+	lastTurnFinishedAt    time.Time       // when the last streaming turn ended (for post-restart resume window)
+	connectedAt           time.Time       // when this connection registered; immutable after registration
+	idleNotifiedAt        time.Time       // when the agent_idle notification fired for the current idle stretch (zero = armed)
+	turnBoundarySeen      bool            // a turn actually ended on THIS connection, so turn tracking is known live (see agentIdleResumeBlindGrace)
+	subagentsActiveAt     time.Time       // when the last heartbeat that REPORTED active spawned subagent sessions arrived (zero = none known; see applySubagentHeartbeatLocked)
+	subagentActiveCount   int             // subagent sessions with a run in flight per that heartbeat
 
 	deliveryInFlight bool // serializes DB-backed delivery writes
 
@@ -2845,6 +2847,7 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				var shouldWarnContext bool
 				var shouldEscalateGateway bool
 				var shouldAutoResume bool
+				var shouldResumeSessionRotation bool
 				var prevUsage int
 				var revived bool
 				var current bool
@@ -2861,6 +2864,20 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 					prevUsage = activeCC.contextUsage
 					activeCC.contextUsage = hb.ContextUsage
 					activeCC.applySubagentHeartbeatLocked(hb.SubagentsActive, hb.SubagentActiveCount)
+					if hb.SessionKey != "" {
+						// A bridge can reconnect to a gateway that has discarded its
+						// session without emitting an edge. As with restart_count, the
+						// first value after a hub restart is historical state, so it is a
+						// baseline rather than evidence of a new loss.
+						if !activeCC.gatewaySessionKeySeen {
+							activeCC.gatewaySessionKey = hb.SessionKey
+							activeCC.gatewaySessionKeySeen = true
+						} else if hb.SessionKey != activeCC.gatewaySessionKey {
+							log.Printf("[heartbeat] %s (%s): gateway session changed (%s -> %s)", rp.Name, clawID[:8], shortID(activeCC.gatewaySessionKey), shortID(hb.SessionKey))
+							activeCC.gatewaySessionKey = hb.SessionKey
+							shouldResumeSessionRotation = true
+						}
+					}
 					if s.gatewayRestartCounts == nil {
 						s.gatewayRestartCounts = make(map[string]int)
 					}
@@ -2891,6 +2908,11 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							s.autoResumeRestartCounts[clawID] = hb.RestartCount
 							shouldAutoResume = true
 						}
+					}
+					// A restart change and a session-key change describe the same
+					// heartbeat loss. Let the restart path own it to avoid two resumes.
+					if shouldAutoResume {
+						shouldResumeSessionRotation = false
 					}
 					activeCC.gatewayRestartCount = s.gatewayRestartCounts[clawID]
 					// nil means field absent (old bridge) — treat as ready. The
@@ -2994,6 +3016,9 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 				s.heartbeatWorkflowVolumeLeases(clawID)
 				if shouldAutoResume {
 					go s.enqueueRestartResume(clawID, hb.RestartCount)
+				}
+				if shouldResumeSessionRotation {
+					go s.enqueueSessionRotatedResume(clawID)
 				}
 				if shouldEscalateGateway {
 					// Re-read the claw state before escalating: idle/completed claws

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -242,31 +242,33 @@ func (s *Server) gatewayUnhealthyCount(clawID string) int {
 type clawConn struct {
 	mu sync.RWMutex // protects mutable fields below
 
-	id                   string
-	tenantID             string
-	conn                 *websocket.Conn
-	tags                 []string        // cached from DB at registration time for access-control checks
-	contextUsage         int             // 0-100, updated from heartbeats
-	gatewayReady         bool            // true once bridge reports gateway session established
-	gatewayRestartCount  int             // cumulative bridge restarts reported by heartbeats
-	forcedFinishCount    int             // consecutive watchdog-forced streaming turn finishes
-	workflowStartPending bool            // true while initial volume attach / wake is in flight
-	workflowStartDone    bool            // true once initial volume attach / wake has completed
-	streamingBuf         strings.Builder // accumulates chunks for current in-flight response
-	streamingMsgID       string          // pre-assigned message ID for the current stream
-	streamingSplit       bool            // true once activity has split this turn into multiple persisted segments
-	streamingStartedAt   time.Time       // when the current streaming turn started (zero if not streaming)
-	streamingTimeoutSent bool            // true once the 12-min timeout message has been injected this turn
-	contextWarningSent   bool            // true once the context-nearly-full warning has been injected this turn
-	awaitingResponse     bool            // true as soon as a prompt is delivered, before the first chunk/activity
-	noProgressPaused     bool            // automatic delivery is paused after repeated turns with unchanged progress
-	bridgeErrorStreak    int             // consecutive turns that came back as a claw-bridge transport error (NEXT-725)
-	lastTurnFinishedAt   time.Time       // when the last streaming turn ended (for post-restart resume window)
-	connectedAt          time.Time       // when this connection registered; immutable after registration
-	idleNotifiedAt       time.Time       // when the agent_idle notification fired for the current idle stretch (zero = armed)
-	turnBoundarySeen     bool            // a turn actually ended on THIS connection, so turn tracking is known live (see agentIdleResumeBlindGrace)
-	subagentsActiveAt    time.Time       // when the last heartbeat that REPORTED active spawned subagent sessions arrived (zero = none known; see applySubagentHeartbeatLocked)
-	subagentActiveCount  int             // subagent sessions with a run in flight per that heartbeat
+	id                    string
+	tenantID              string
+	conn                  *websocket.Conn
+	tags                  []string        // cached from DB at registration time for access-control checks
+	contextUsage          int             // 0-100, updated from heartbeats
+	gatewayReady          bool            // true once bridge reports gateway session established
+	gatewayRestartCount   int             // cumulative bridge restarts reported by heartbeats
+	gatewaySessionKey     string          // last live gateway session key reported by heartbeat
+	gatewaySessionKeySeen bool            // distinguishes the first live-key heartbeat from a loss
+	forcedFinishCount     int             // consecutive watchdog-forced streaming turn finishes
+	workflowStartPending  bool            // true while initial volume attach / wake is in flight
+	workflowStartDone     bool            // true once initial volume attach / wake has completed
+	streamingBuf          strings.Builder // accumulates chunks for current in-flight response
+	streamingMsgID        string          // pre-assigned message ID for the current stream
+	streamingSplit        bool            // true once activity has split this turn into multiple persisted segments
+	streamingStartedAt    time.Time       // when the current streaming turn started (zero if not streaming)
+	streamingTimeoutSent  bool            // true once the 12-min timeout message has been injected this turn
+	contextWarningSent    bool            // true once the context-nearly-full warning has been injected this turn
+	awaitingResponse      bool            // true as soon as a prompt is delivered, before the first chunk/activity
+	noProgressPaused      bool            // automatic delivery is paused after repeated turns with unchanged progress
+	bridgeErrorStreak     int             // consecutive turns that came back as a claw-bridge transport error (NEXT-725)
+	lastTurnFinishedAt    time.Time       // when the last streaming turn ended (for post-restart resume window)
+	connectedAt           time.Time       // when this connection registered; immutable after registration
+	idleNotifiedAt        time.Time       // when the agent_idle notification fired for the current idle stretch (zero = armed)
+	turnBoundarySeen      bool            // a turn actually ended on THIS connection, so turn tracking is known live (see agentIdleResumeBlindGrace)
+	subagentsActiveAt     time.Time       // when the last heartbeat that REPORTED active spawned subagent sessions arrived (zero = none known; see applySubagentHeartbeatLocked)
+	subagentActiveCount   int             // subagent sessions with a run in flight per that heartbeat
 
 	deliveryInFlight bool // serializes DB-backed delivery writes
 
@@ -2821,17 +2823,21 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 		if msg.Type == "heartbeat" {
 			payload, _ := json.Marshal(msg.Payload)
 			var hb struct {
-				GatewayHealthy   bool     `json:"gateway_healthy"`
-				GatewayReady     *bool    `json:"gateway_ready,omitempty"`
-				ContextUsage     int      `json:"context_usage"`
-				RestartCount     int      `json:"restart_count"`
-				SessionKey       string   `json:"session_key"`
-				InputTokens      *int     `json:"input_tokens"`
-				OutputTokens     *int     `json:"output_tokens"`
-				TotalTokens      *int     `json:"total_tokens"`
-				EstimatedCostUSD *float64 `json:"estimated_cost_usd"`
-				Model            string   `json:"model"`
-				ModelProvider    string   `json:"model_provider"`
+				GatewayHealthy bool  `json:"gateway_healthy"`
+				GatewayReady   *bool `json:"gateway_ready,omitempty"`
+				ContextUsage   int   `json:"context_usage"`
+				RestartCount   int   `json:"restart_count"`
+				// SessionKey is the usage snapshot from sessions.describe. GatewaySessionKey
+				// is the live session identity used for loss detection; they must remain
+				// distinct because a degraded describe call can leave the snapshot stale.
+				SessionKey        string   `json:"session_key"`
+				GatewaySessionKey *string  `json:"gateway_session_key"`
+				InputTokens       *int     `json:"input_tokens"`
+				OutputTokens      *int     `json:"output_tokens"`
+				TotalTokens       *int     `json:"total_tokens"`
+				EstimatedCostUSD  *float64 `json:"estimated_cost_usd"`
+				Model             string   `json:"model"`
+				ModelProvider     string   `json:"model_provider"`
 				// Pointers on purpose: an old bridge omits both, which must
 				// stay distinguishable from a bridge reporting "no subagents"
 				// (see applySubagentHeartbeatLocked).
@@ -2891,6 +2897,12 @@ func (s *Server) handleClawWS(w http.ResponseWriter, r *http.Request) {
 							s.autoResumeRestartCounts[clawID] = hb.RestartCount
 							shouldAutoResume = true
 						}
+					}
+					if hb.GatewaySessionKey != nil {
+						// The first live-key observation is a baseline, just like restart_count:
+						// it may describe a session established before this hub connected.
+						activeCC.gatewaySessionKey = *hb.GatewaySessionKey
+						activeCC.gatewaySessionKeySeen = true
 					}
 					activeCC.gatewayRestartCount = s.gatewayRestartCounts[clawID]
 					// nil means field absent (old bridge) — treat as ready. The

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -8647,10 +8647,15 @@ func (s *Server) noteSessionLoss(cc *clawConn, clawID, newKey, source string) {
 		(!cc.lastTurnFinishedAt.IsZero() && time.Since(cc.lastTurnFinishedAt) < autoResumeRecentTurnWindow)
 	cc.mu.Unlock()
 	if !turnOpenOrRecent {
-		// A lost transcript for an idle claw does not justify making it act on
-		// its own. The next real message will use the new session. This leaves
-		// a known gap: an idle claw is not told that its transcript was lost.
-		log.Printf("[watchdog] skipping session-loss resume for %s: claw is idle (source=%s)", shortID(clawID), source)
+		// An idle claw must not be awakened into autonomous work, but the next
+		// real prompt needs this context so it does not mistake a lost transcript
+		// for an empty workspace. Keep the first notice: more losses add no useful
+		// instruction and would make the eventual prompt noisy.
+		if res, err := s.db.Exec(`UPDATE claws SET pending_session_loss_notice=? WHERE id=? AND pending_session_loss_notice=''`, sessionLossPendingNotice, clawID); err != nil {
+			log.Printf("[watchdog] persist session-loss notice for %s: %v", shortID(clawID), err)
+		} else if n, _ := res.RowsAffected(); n > 0 {
+			log.Printf("[watchdog] recorded session-loss notice for idle claw %s (source=%s)", shortID(clawID), source)
+		}
 		return
 	}
 	if source == "session_rotated" {
@@ -8901,6 +8906,16 @@ func (s *Server) sendNextQueuedMessage(cc *clawConn) {
 	defer cancel()
 	clawMsg := msg
 	clawMsg.UserLogin = nil
+	var notice string
+	if err := s.db.QueryRow(`SELECT pending_session_loss_notice FROM claws WHERE id=?`, clawID).Scan(&notice); err != nil {
+		log.Printf("[hub] read pending session-loss notice for %s: %v", shortID(clawID), err)
+	} else if notice != "" {
+		msg.Content = notice + msg.Content
+		clawMsg.Content = msg.Content
+	}
+	// The notice is read before delivery and only cleared with the delivered
+	// transition after a successful socket write. A failed write therefore leaves
+	// it durable for the next delivery attempt.
 	err = wsjson.Write(ctx, conn, types.WSMessage{Type: "message", Payload: clawMsg})
 	if err != nil {
 		cc.mu.Lock()
@@ -8909,8 +8924,24 @@ func (s *Server) sendNextQueuedMessage(cc *clawConn) {
 		log.Printf("[hub] failed to deliver pending message to %s: %v", shortID(clawID), err)
 		return
 	}
-	if _, err := s.db.Exec(`UPDATE messages SET delivered_at=? WHERE id=? AND delivered_at IS NULL`, now(), msg.ID); err != nil {
+	tx, err := s.db.Begin()
+	if err != nil {
+		log.Printf("[hub] begin delivered-message transition %s: %v", msg.ID, err)
+		return
+	}
+	defer tx.Rollback()
+	if _, err := tx.Exec(`UPDATE messages SET delivered_at=? WHERE id=? AND delivered_at IS NULL`, now(), msg.ID); err != nil {
 		log.Printf("[hub] mark delivered message %s: %v", msg.ID, err)
+		return
+	}
+	if notice != "" {
+		if _, err := tx.Exec(`UPDATE claws SET pending_session_loss_notice='' WHERE id=? AND pending_session_loss_notice=?`, clawID, notice); err != nil {
+			log.Printf("[hub] clear pending session-loss notice for %s: %v", shortID(clawID), err)
+			return
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		log.Printf("[hub] commit delivered-message transition %s: %v", msg.ID, err)
 		return
 	}
 	cc.mu.Lock()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -63,8 +63,6 @@ type Server struct {
 	mu    sync.RWMutex
 	claws map[string]*clawConn // claw_id -> conn
 	users map[string]*userConn // tenant_id -> []conn (broadcast)
-	// sessionLostResumeMu makes the shared throttle check and enqueue atomic.
-	sessionLostResumeMu sync.Mutex
 	// gatewayRestartCounts retains the heartbeat counter across WebSocket reconnects.
 	gatewayRestartCounts map[string]int
 	// gatewayUnhealthyCounts survives WebSocket reconnects so flapping gateways still escalate.
@@ -8619,13 +8617,21 @@ func (s *Server) enqueueRestartResume(clawID string, restartCount int) {
 	s.enqueueSessionLostResume(clawID, restartResumePrefix, fmt.Sprintf("restart:%d", restartCount))
 }
 
-// sessionLostResumeThrottle bounds repeated session-loss recovery prompts.
-// Two real incidents inside this window collapse into one prompt because a
-// duplicate recovery is more harmful than a delayed second recovery.
-const sessionLostResumeThrottle = 10 * time.Minute
+// sessionRotatedResumeThrottle bounds the rotation → resume → rotation loop:
+// if lock conflicts persist across fresh sessions (e.g. another process keeps
+// touching the session files), each rotation would otherwise enqueue another
+// resume prompt indefinitely — rotation turns complete with an empty reply,
+// so the no-progress watchdog never observes them.
+//
+// It is deliberately scoped to the rotation prefix. A shared throttle across
+// rotation and restart was tried to stop one incident producing two prompts,
+// and reverted: it also swallowed the announcement of a genuinely separate
+// restart, which is the silent session loss this work exists to end. The
+// duplicate is truthful and costs one turn; the collapse costs correctness.
+const sessionRotatedResumeThrottle = 10 * time.Minute
 
 // sessionPreservedContinuationThrottle bounds the conflict -> continuation ->
-// conflict loop, the same way sessionLostResumeThrottle does for session loss.
+// conflict loop, the same way sessionRotatedResumeThrottle does for rotation.
 //
 // Known limitation: unlike a rotation, the same session can legitimately need a
 // second continuation inside the window, and this throttle drops it silently —
@@ -8651,6 +8657,13 @@ func (s *Server) enqueueSessionRotatedResume(clawID string) {
 		// its own. The next real message will use the new session. This leaves
 		// a known gap: an idle claw is not told that its transcript was lost.
 		log.Printf("[watchdog] skipping session-rotated resume for %s: claw is idle", shortID(clawID))
+		return
+	}
+	var recent int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ? AND created_at > ?`,
+		clawID, sessionRotatedResumePrefix+"%", now().Add(-sessionRotatedResumeThrottle)).Scan(&recent)
+	if err == nil && recent > 0 {
+		log.Printf("[watchdog] skipping session-rotated resume for %s: already resumed within %s", shortID(clawID), sessionRotatedResumeThrottle)
 		return
 	}
 	s.enqueueSessionLostResume(clawID, sessionRotatedResumePrefix, fmt.Sprintf("session_rotated:%s", uuid.NewString()))
@@ -8703,19 +8716,9 @@ func (s *Server) lastSubstantiveClawProgress(clawID string) (string, time.Time) 
 }
 
 func (s *Server) enqueueSessionLostResume(clawID, prefix, marker string) {
-	s.sessionLostResumeMu.Lock()
-	defer s.sessionLostResumeMu.Unlock()
-
-	var recent int
-	err := s.db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND (content LIKE ? OR content LIKE ?) AND created_at > ?`,
-		clawID, restartResumePrefix+"%", sessionRotatedResumePrefix+"%", now().Add(-sessionLostResumeThrottle)).Scan(&recent)
-	if err == nil && recent > 0 {
-		log.Printf("[watchdog] skipping session-loss resume for %s: already resumed within %s", shortID(clawID), sessionLostResumeThrottle)
-		return
-	}
 	var status, issueTitle, linearID, githubID, shortcutID, jiraID string
 	var bootstrapOK int
-	err = s.db.QueryRow(`SELECT status, COALESCE(bootstrap_ok,0), COALESCE(issue_title,''), COALESCE(linear_issue_id,''), COALESCE(github_issue_id,''), COALESCE(shortcut_story_id,''), COALESCE(jira_issue_id,'') FROM claws WHERE id=?`, clawID).Scan(&status, &bootstrapOK, &issueTitle, &linearID, &githubID, &shortcutID, &jiraID)
+	err := s.db.QueryRow(`SELECT status, COALESCE(bootstrap_ok,0), COALESCE(issue_title,''), COALESCE(linear_issue_id,''), COALESCE(github_issue_id,''), COALESCE(shortcut_story_id,''), COALESCE(jira_issue_id,'') FROM claws WHERE id=?`, clawID).Scan(&status, &bootstrapOK, &issueTitle, &linearID, &githubID, &shortcutID, &jiraID)
 	if err != nil {
 		return
 	}

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -621,6 +621,102 @@ func TestSessionRotatedWhileIdleDoesNotEnqueueResume(t *testing.T) {
 	}
 }
 
+func TestHeartbeatUsesOnlyGatewaySessionKeyForSessionLoss(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-gateway-session-key"
+	conn := watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1 WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Now()
+	cc.mu.Unlock()
+	beat := func(payload map[string]any) {
+		t.Helper()
+		payload["gateway_healthy"] = true
+		if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: payload}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	count := func() int {
+		var n int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ?`, clawID, restartResumePrefix+"%").Scan(&n)
+		return n
+	}
+
+	beat(map[string]any{"restart_count": 0, "session_key": "snapshot-old", "gateway_session_key": "live-old"})
+	eventuallyWatchdog(t, func() bool {
+		cc.mu.RLock()
+		defer cc.mu.RUnlock()
+		return cc.gatewaySessionKeySeen && cc.gatewaySessionKey == "live-old"
+	}, "live gateway session baseline")
+	// A stale sessions.describe snapshot changes, but no live key is reported.
+	// It must not be interpreted as a lost session.
+	beat(map[string]any{"restart_count": 0, "session_key": "snapshot-stale"})
+	time.Sleep(100 * time.Millisecond)
+	if got := count(); got != 0 {
+		t.Fatalf("resume count after snapshot-only heartbeat = %d, want 0", got)
+	}
+	beat(map[string]any{"restart_count": 0, "session_key": "snapshot-stale", "gateway_session_key": "live-new"})
+	eventuallyWatchdog(t, func() bool { return count() == 1 }, "resume after live gateway key change")
+}
+
+func TestSessionLossDeduplicatesAllDetectionPathsByNewKey(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-session-loss-dedup"
+	_ = watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1 WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Now()
+	cc.mu.Unlock()
+	// These calls represent restart_count, gateway_session_key, and the
+	// session_rotated bridge edge reporting the same replacement session.
+	s.noteSessionLoss(cc, clawID, "replacement-key", "restart_count")
+	s.noteSessionLoss(cc, clawID, "replacement-key", "gateway_session_key")
+	s.noteSessionLoss(cc, clawID, "replacement-key", "session_rotated")
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND (content LIKE ? OR content LIKE ?)`, clawID, restartResumePrefix+"%", sessionRotatedResumePrefix+"%").Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("resume count for one incident reported three ways = %d, want 1", n)
+	}
+}
+
+func TestSessionLossDifferentKeysAndMissingKeysDoNotDeduplicate(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-session-loss-distinct"
+	_ = watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1 WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Now()
+	cc.mu.Unlock()
+	count := func() int {
+		var n int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ?`, clawID, restartResumePrefix+"%").Scan(&n)
+		return n
+	}
+	s.noteSessionLoss(cc, clawID, "replacement-one", "restart_count")
+	s.noteSessionLoss(cc, clawID, "replacement-two", "restart_count")
+	if got := count(); got != 2 {
+		t.Fatalf("resume count for two replacement keys = %d, want 2", got)
+	}
+	// Old bridges omit the key. Preserve the pre-key behavior: each report is
+	// an independent incident rather than being collapsed by an empty key.
+	s.noteSessionLoss(cc, clawID, "", "restart_count")
+	s.noteSessionLoss(cc, clawID, "", "restart_count")
+	if got := count(); got != 4 {
+		t.Fatalf("resume count after two keyless reports = %d, want 4", got)
+	}
+}
+
 func TestSessionPreservedEnqueuesContinuationAndResetsBridgeErrorStreak(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "watchdog-session-preserved"

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -433,8 +433,16 @@ func TestRestartMidTurnEnqueuesExactlyOneResume(t *testing.T) {
 		return n
 	}
 	eventuallyWatchdog(t, func() bool { return count() == 1 }, "one restart resume")
+	// A second genuine restart moments later falls inside the shared
+	// session-loss throttle window (unified across rotation and restart by
+	// enqueueSessionLostResume), so it does not get its own resume — two
+	// real incidents this close together collapse into one prompt rather
+	// than risking a duplicate.
 	beat(2)
-	eventuallyWatchdog(t, func() bool { return count() == 2 }, "second restart resume")
+	time.Sleep(50 * time.Millisecond)
+	if got := count(); got != 1 {
+		t.Fatalf("resume count after second restart inside throttle window = %d, want 1", got)
+	}
 }
 
 // A bridge-process relaunch resets restart_count to 0 — equal to the zero
@@ -577,10 +585,13 @@ func TestSessionRotatedEnqueuesResume(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "watchdog-session-rotated"
 	conn := watchdogClaw(t, s, clawID)
-	_ = watchdogClawConn(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
 	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1, issue_title='Fix session', github_issue_id='owner/repo#42' WHERE id=?`, clawID); err != nil {
 		t.Fatal(err)
 	}
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Now()
+	cc.mu.Unlock()
 	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "session_rotated"}); err != nil {
 		t.Fatalf("write session_rotated: %v", err)
 	}
@@ -590,6 +601,86 @@ func TestSessionRotatedEnqueuesResume(t *testing.T) {
 		return n
 	}
 	eventuallyWatchdog(t, func() bool { return count() == 1 }, "session rotated resume")
+}
+
+// A lost transcript on an otherwise idle claw must not wake it: the next
+// real message will run in the new session regardless, and nothing beyond
+// the idle claw itself needs to know the transcript was lost.
+func TestSessionRotatedWhileIdleDoesNotEnqueueResume(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-idle-session-rotated"
+	conn := watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1 WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Time{}
+	cc.awaitingResponse = false
+	cc.lastTurnFinishedAt = now().Add(-autoResumeRecentTurnWindow - time.Second)
+	cc.mu.Unlock()
+	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "session_rotated"}); err != nil {
+		t.Fatalf("write session_rotated: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ?`, clawID, sessionRotatedResumePrefix+"%").Scan(&n); err != nil || n != 0 {
+		t.Fatalf("resume rows=%d err=%v, want 0", n, err)
+	}
+}
+
+// A rotation resume and a restart resume for the same incident must not both
+// go out: enqueueSessionLostResume throttles across both prefixes.
+func TestSessionLostResumeThrottleCoversRotationAndRestart(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-session-loss-throttle"
+	conn := watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1 WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Now()
+	cc.mu.Unlock()
+	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": true, "restart_count": 0}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "session_rotated"}); err != nil {
+		t.Fatal(err)
+	}
+	count := func() int {
+		var n int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND (content LIKE ? OR content LIKE ?)`, clawID, sessionRotatedResumePrefix+"%", restartResumePrefix+"%").Scan(&n)
+		return n
+	}
+	eventuallyWatchdog(t, func() bool { return count() == 1 }, "rotation resume")
+	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": true, "restart_count": 1}}); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if got := count(); got != 1 {
+		t.Fatalf("session-loss resumes=%d, want 1", got)
+	}
+}
+
+// enqueueRestartResume previously had no throttle of its own; centralizing it
+// through enqueueSessionLostResume must still let a genuinely later restart
+// through once the shared window has expired.
+func TestSessionLostResumeThrottleExpires(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-session-loss-throttle-expiry"
+	_ = watchdogClaw(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1 WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`, uuid.NewString(), clawID, "test-tenant-id", "hub", sessionRotatedResumePrefix+" earlier resume", now().Add(-sessionLostResumeThrottle-time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	s.enqueueRestartResume(clawID, 1)
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND (content LIKE ? OR content LIKE ?)`, clawID, sessionRotatedResumePrefix+"%", restartResumePrefix+"%").Scan(&n); err != nil || n != 2 {
+		t.Fatalf("session-loss resumes=%d err=%v, want 2", n, err)
+	}
 }
 
 func TestSessionPreservedEnqueuesContinuationAndResetsBridgeErrorStreak(t *testing.T) {
@@ -622,10 +713,13 @@ func TestSessionRotatedResumeThrottled(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "watchdog-session-rotated-throttled"
 	conn := watchdogClaw(t, s, clawID)
-	_ = watchdogClawConn(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
 	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1, issue_title='Fix session' WHERE id=?`, clawID); err != nil {
 		t.Fatal(err)
 	}
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Now()
+	cc.mu.Unlock()
 	// A resume prompt already went out moments ago — a second rotation inside
 	// the throttle window must not enqueue another one.
 	if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`,
@@ -646,14 +740,17 @@ func TestSessionRotatedResumeThrottleWindowExpires(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "watchdog-session-rotated-throttle-expired"
 	conn := watchdogClaw(t, s, clawID)
-	_ = watchdogClawConn(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
 	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1, issue_title='Fix session' WHERE id=?`, clawID); err != nil {
 		t.Fatal(err)
 	}
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Now()
+	cc.mu.Unlock()
 	// The previous resume is older than the throttle window, so a new
 	// rotation must enqueue a fresh resume prompt.
 	if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`,
-		uuid.NewString(), clawID, "test-tenant-id", "hub", sessionRotatedResumePrefix+" earlier resume", now().Add(-sessionRotatedResumeThrottle-time.Minute)); err != nil {
+		uuid.NewString(), clawID, "test-tenant-id", "hub", sessionRotatedResumePrefix+" earlier resume", now().Add(-sessionLostResumeThrottle-time.Minute)); err != nil {
 		t.Fatal(err)
 	}
 	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "session_rotated"}); err != nil {

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -433,16 +433,8 @@ func TestRestartMidTurnEnqueuesExactlyOneResume(t *testing.T) {
 		return n
 	}
 	eventuallyWatchdog(t, func() bool { return count() == 1 }, "one restart resume")
-	// A second genuine restart moments later falls inside the shared
-	// session-loss throttle window (unified across rotation and restart by
-	// enqueueSessionLostResume), so it does not get its own resume — two
-	// real incidents this close together collapse into one prompt rather
-	// than risking a duplicate.
 	beat(2)
-	time.Sleep(50 * time.Millisecond)
-	if got := count(); got != 1 {
-		t.Fatalf("resume count after second restart inside throttle window = %d, want 1", got)
-	}
+	eventuallyWatchdog(t, func() bool { return count() == 2 }, "second restart resume")
 }
 
 // A bridge-process relaunch resets restart_count to 0 — equal to the zero
@@ -629,60 +621,6 @@ func TestSessionRotatedWhileIdleDoesNotEnqueueResume(t *testing.T) {
 	}
 }
 
-// A rotation resume and a restart resume for the same incident must not both
-// go out: enqueueSessionLostResume throttles across both prefixes.
-func TestSessionLostResumeThrottleCoversRotationAndRestart(t *testing.T) {
-	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
-	const clawID = "watchdog-session-loss-throttle"
-	conn := watchdogClaw(t, s, clawID)
-	cc := watchdogClawConn(t, s, clawID)
-	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1 WHERE id=?`, clawID); err != nil {
-		t.Fatal(err)
-	}
-	cc.mu.Lock()
-	cc.streamingStartedAt = time.Now()
-	cc.mu.Unlock()
-	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": true, "restart_count": 0}}); err != nil {
-		t.Fatal(err)
-	}
-	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "session_rotated"}); err != nil {
-		t.Fatal(err)
-	}
-	count := func() int {
-		var n int
-		_ = db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND (content LIKE ? OR content LIKE ?)`, clawID, sessionRotatedResumePrefix+"%", restartResumePrefix+"%").Scan(&n)
-		return n
-	}
-	eventuallyWatchdog(t, func() bool { return count() == 1 }, "rotation resume")
-	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": true, "restart_count": 1}}); err != nil {
-		t.Fatal(err)
-	}
-	time.Sleep(100 * time.Millisecond)
-	if got := count(); got != 1 {
-		t.Fatalf("session-loss resumes=%d, want 1", got)
-	}
-}
-
-// enqueueRestartResume previously had no throttle of its own; centralizing it
-// through enqueueSessionLostResume must still let a genuinely later restart
-// through once the shared window has expired.
-func TestSessionLostResumeThrottleExpires(t *testing.T) {
-	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
-	const clawID = "watchdog-session-loss-throttle-expiry"
-	_ = watchdogClaw(t, s, clawID)
-	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1 WHERE id=?`, clawID); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`, uuid.NewString(), clawID, "test-tenant-id", "hub", sessionRotatedResumePrefix+" earlier resume", now().Add(-sessionLostResumeThrottle-time.Second)); err != nil {
-		t.Fatal(err)
-	}
-	s.enqueueRestartResume(clawID, 1)
-	var n int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND (content LIKE ? OR content LIKE ?)`, clawID, sessionRotatedResumePrefix+"%", restartResumePrefix+"%").Scan(&n); err != nil || n != 2 {
-		t.Fatalf("session-loss resumes=%d err=%v, want 2", n, err)
-	}
-}
-
 func TestSessionPreservedEnqueuesContinuationAndResetsBridgeErrorStreak(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "watchdog-session-preserved"
@@ -750,7 +688,7 @@ func TestSessionRotatedResumeThrottleWindowExpires(t *testing.T) {
 	// The previous resume is older than the throttle window, so a new
 	// rotation must enqueue a fresh resume prompt.
 	if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`,
-		uuid.NewString(), clawID, "test-tenant-id", "hub", sessionRotatedResumePrefix+" earlier resume", now().Add(-sessionLostResumeThrottle-time.Minute)); err != nil {
+		uuid.NewString(), clawID, "test-tenant-id", "hub", sessionRotatedResumePrefix+" earlier resume", now().Add(-sessionRotatedResumeThrottle-time.Minute)); err != nil {
 		t.Fatal(err)
 	}
 	if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "session_rotated"}); err != nil {

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -592,59 +592,6 @@ func TestSessionRotatedEnqueuesResume(t *testing.T) {
 	eventuallyWatchdog(t, func() bool { return count() == 1 }, "session rotated resume")
 }
 
-func TestHeartbeatSessionKeyChangeEnqueuesRotatedResume(t *testing.T) {
-	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
-	const clawID = "watchdog-heartbeat-session-key"
-	conn := watchdogClaw(t, s, clawID)
-	_ = watchdogClawConn(t, s, clawID)
-	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1, issue_title='Fix session' WHERE id=?`, clawID); err != nil {
-		t.Fatal(err)
-	}
-	beat := func(key string) {
-		if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": true, "restart_count": 0, "session_key": key}}); err != nil {
-			t.Fatal(err)
-		}
-	}
-	count := func() int {
-		var n int
-		_ = db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ?`, clawID, sessionRotatedResumePrefix+"%").Scan(&n)
-		return n
-	}
-	// The first key is a post-hub-start baseline, and an unchanged key is not
-	// a rotation. Only the later replacement must resume the task.
-	beat("session-old")
-	beat("session-old")
-	time.Sleep(100 * time.Millisecond)
-	if got := count(); got != 0 {
-		t.Fatalf("resume rows after baseline and same key = %d, want 0", got)
-	}
-	beat("session-new")
-	eventuallyWatchdog(t, func() bool { return count() == 1 }, "resume after heartbeat session-key change")
-}
-
-func TestHeartbeatSessionKeyChangeRespectsRotatedResumeThrottle(t *testing.T) {
-	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
-	const clawID = "watchdog-heartbeat-session-key-throttled"
-	conn := watchdogClaw(t, s, clawID)
-	_ = watchdogClawConn(t, s, clawID)
-	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1, issue_title='Fix session' WHERE id=?`, clawID); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`, uuid.NewString(), clawID, "test-tenant-id", "hub", sessionRotatedResumePrefix+" earlier resume", now().Add(-time.Minute)); err != nil {
-		t.Fatal(err)
-	}
-	for _, key := range []string{"session-old", "session-new"} {
-		if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": true, "restart_count": 0, "session_key": key}}); err != nil {
-			t.Fatal(err)
-		}
-	}
-	time.Sleep(100 * time.Millisecond)
-	var n int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ?`, clawID, sessionRotatedResumePrefix+"%").Scan(&n); err != nil || n != 1 {
-		t.Fatalf("resume rows=%d err=%v, want 1 (throttled)", n, err)
-	}
-}
-
 func TestSessionPreservedEnqueuesContinuationAndResetsBridgeErrorStreak(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "watchdog-session-preserved"

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http/httptest"
 	"strings"
@@ -714,6 +715,69 @@ func TestSessionLossDifferentKeysAndMissingKeysDoNotDeduplicate(t *testing.T) {
 	s.noteSessionLoss(cc, clawID, "", "restart_count")
 	if got := count(); got != 4 {
 		t.Fatalf("resume count after two keyless reports = %d, want 4", got)
+	}
+}
+
+func TestIdleSessionLossNoticePrefixesNextMessageAndKeepsFirstNotice(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-idle-session-loss-notice"
+	conn := watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1 WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Time{}
+	cc.awaitingResponse = false
+	cc.lastTurnFinishedAt = now().Add(-autoResumeRecentTurnWindow - time.Second)
+	cc.mu.Unlock()
+	s.noteSessionLoss(cc, clawID, "idle-one", "gateway_session_key")
+	s.noteSessionLoss(cc, clawID, "idle-two", "restart_count")
+	var notice string
+	if err := db.QueryRow(`SELECT pending_session_loss_notice FROM claws WHERE id=?`, clawID).Scan(&notice); err != nil {
+		t.Fatal(err)
+	}
+	if notice != sessionLossPendingNotice {
+		t.Fatalf("pending notice = %q, want first session-loss notice", notice)
+	}
+	var resumes int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ?`, clawID, restartResumePrefix+"%").Scan(&resumes); err != nil || resumes != 0 {
+		t.Fatalf("idle resume rows=%d err=%v, want 0", resumes, err)
+	}
+	if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`, uuid.NewString(), clawID, "test-tenant-id", "user", "continue the task", now()); err != nil {
+		t.Fatal(err)
+	}
+	s.sendNextQueuedMessage(cc)
+	readCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	// The connection may carry unrelated async frames (e.g. a checkpoint_create
+	// request) ahead of the queued message; skip those, matching the pattern
+	// used elsewhere in this file.
+	var delivered types.WSMessage
+	for {
+		if err := wsjson.Read(readCtx, conn, &delivered); err != nil {
+			t.Fatal(err)
+		}
+		if delivered.Type == "message" {
+			break
+		}
+	}
+	payload, err := json.Marshal(delivered.Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var message types.HubMessage
+	if err := json.Unmarshal(payload, &message); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := message.Content, sessionLossPendingNotice+"continue the task"; got != want {
+		t.Fatalf("delivered content = %q, want %q", got, want)
+	}
+	if err := db.QueryRow(`SELECT pending_session_loss_notice FROM claws WHERE id=?`, clawID).Scan(&notice); err != nil {
+		t.Fatal(err)
+	}
+	if notice != "" {
+		t.Fatalf("pending notice after delivery = %q, want empty", notice)
 	}
 }
 

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -592,6 +592,59 @@ func TestSessionRotatedEnqueuesResume(t *testing.T) {
 	eventuallyWatchdog(t, func() bool { return count() == 1 }, "session rotated resume")
 }
 
+func TestHeartbeatSessionKeyChangeEnqueuesRotatedResume(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-heartbeat-session-key"
+	conn := watchdogClaw(t, s, clawID)
+	_ = watchdogClawConn(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1, issue_title='Fix session' WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	beat := func(key string) {
+		if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": true, "restart_count": 0, "session_key": key}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	count := func() int {
+		var n int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ?`, clawID, sessionRotatedResumePrefix+"%").Scan(&n)
+		return n
+	}
+	// The first key is a post-hub-start baseline, and an unchanged key is not
+	// a rotation. Only the later replacement must resume the task.
+	beat("session-old")
+	beat("session-old")
+	time.Sleep(100 * time.Millisecond)
+	if got := count(); got != 0 {
+		t.Fatalf("resume rows after baseline and same key = %d, want 0", got)
+	}
+	beat("session-new")
+	eventuallyWatchdog(t, func() bool { return count() == 1 }, "resume after heartbeat session-key change")
+}
+
+func TestHeartbeatSessionKeyChangeRespectsRotatedResumeThrottle(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-heartbeat-session-key-throttled"
+	conn := watchdogClaw(t, s, clawID)
+	_ = watchdogClawConn(t, s, clawID)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1, issue_title='Fix session' WHERE id=?`, clawID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`, uuid.NewString(), clawID, "test-tenant-id", "hub", sessionRotatedResumePrefix+" earlier resume", now().Add(-time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"session-old", "session-new"} {
+		if err := wsjson.Write(context.Background(), conn, types.WSMessage{Type: "heartbeat", Payload: map[string]any{"gateway_healthy": true, "restart_count": 0, "session_key": key}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	time.Sleep(100 * time.Millisecond)
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM messages WHERE claw_id=? AND role='hub' AND content LIKE ?`, clawID, sessionRotatedResumePrefix+"%").Scan(&n); err != nil || n != 1 {
+		t.Fatalf("resume rows=%d err=%v, want 1 (throttled)", n, err)
+	}
+}
+
 func TestSessionPreservedEnqueuesContinuationAndResetsBridgeErrorStreak(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "watchdog-session-preserved"


### PR DESCRIPTION
Closes #666.

## The gap

`reconnectGateway` (`cmd/claw-bridge/main.go`) re-subscribes to the existing session after a gateway reconnect. When the gateway reports the session as gone, it creates a fresh one and sets `createdFresh = true` — a variable used only to call `gs.setReady()`. It never reached the caller, and no `session_rotated` message was sent to the hub.

The hub only continues a claw through two edges: a `session_rotated`/`session_preserved` message, or the bridge-error streak. This path produced neither, so the agent's next turn started with an empty transcript while the hub believed the conversation was continuous.

Both callers were affected: `readLoop` (a background reconnect, which only logged) and `SendMessage` (the retryable-gateway path, which replays the message into what may be a brand-new empty session).

## Changes

**1. Announce the replacement** (`cmd/claw-bridge/main.go`)

`reconnectGateway` and `reconnectGatewayWithTimeout` now return `replacedSession` alongside `reconnected` — the existing boolean means "reconnected", not "the session was replaced". Both call sites announce through a new `onSessionReplaced` callback, wired per connection by `runHubLoop`, reusing the `session_rotated` type and the durability pattern from `reportSessionRecovery` (try `writeHub`, fall back to `queue.pushControl`).

The callback fires from the call sites, not from inside `reconnectGateway`, which holds `reconnectMu` — a network write to the hub under that lock is a needless risk on a saturated gateway, the condition that produces these reconnects.

**2. A live session key on the heartbeat** (both)

The hub already received `session_key` in every heartbeat, but it is unusable for detecting loss: it comes from `gwSession.Usage()`, and `gs.usage` is only written after a *successful* `sessions.describe`. On a degraded gateway — the scenario a backstop exists for — describe times out and every heartbeat keeps reporting the pre-rotation key. The function's own comment says that key is "attributed to the session we actually described": it is a cost-accounting snapshot.

A separate `gateway_session_key` now carries `gwSession.getSessionKey()`, the authoritative live key. `session_key` is untouched, because `recordTaskRunUsage` depends on its snapshot semantics. Both sides carry a comment saying why the two exist, so nobody merges them.

**3. Incident identity: the new session key** (`pkg/hub/server.go`)

One incident is detected up to three ways — the bridge edge, the live-key change, and the `restart_count` change — under different prefixes with independent throttles, so a single gateway crash produced two "your previous session was lost" prompts and the agent ran recovery twice.

A throttle spanning both prefixes was tried and reverted: it also collapsed two *genuinely separate* incidents into one prompt, leaving the second loss unannounced. A short time window does not separate the cases either, since the signals can arrive milliseconds apart.

The identity that works is the key of the session that replaced the lost one. One incident is one new key; two incidents are two different keys. All three detectors now funnel through `noteSessionLoss`, which dedups on that key. When the key is absent (an older bridge), the previous no-dedup behaviour is preserved rather than silently regressing.

**4. Tell an idle claw without waking it** (`pkg/hub/server.go`, `pkg/hub/db.go`)

The `restart_count` path only resumes when `turnOpenOrRecent` — without that gate, a claw idle between workflow stages was told "resume the task, do not start over" and started acting on its own, burning tokens and potentially committing or commenting with nobody having asked. Applying the same gate to the rotation edge fixed that but left the claw never learning it had lost its transcript.

A new `pending_session_loss_notice` column records the notice instead. `sendNextQueuedMessage` prefixes it to the next message actually delivered and clears it in the same transaction that marks the message delivered, so a failed socket write does not lose it. Only the first notice is kept: further losses add no instruction and would make the eventual prompt noisy.

## Verification

- `go build ./...`, `go vet`, `gofmt` clean. Each of the commits builds on its own.
- `go test ./cmd/claw-bridge/...` passes, including `-race`. New hub tests pass at `-count=20`.
- Mutation-checked, each applied to production code and reverted:
  - neutralizing the **`readLoop`** call site, and the **`SendMessage`** call site, each break their own test — both are pinned independently, since a test covering only one would let the other regress silently;
  - removing the key dedup → `TestSessionLossDeduplicatesAllDetectionPathsByNewKey` fails;
  - making the dedup ignore the key → `TestSessionLossDifferentKeysAndMissingKeysDoNotDeduplicate` fails, which is the pin against re-breaking separate incidents;
  - removing the idle gate → two tests fail;
  - dropping the notice prefix at delivery → `TestIdleSessionLossNoticePrefixesNextMessageAndKeepsFirstNotice` fails.
- `TestSendMessageAnnouncesSessionReplacementOnReconnect` was flaky when first written (3 failures in 25 isolated runs) because it started `readLoop` on the re-subscribe response rather than the connection swap; fixed and now passes `-count=50`.
- Pre-existing failures in `./pkg/hub/...`, unrelated: `TestDoneSignalRejectedWhenPRPersistenceFails`, `TestHandleClawDoneSignal_IssueLessWorkflowWatchesPR`, `TestCompleteIssueLessDoneClawKeepsRunningOnStoreFailure` (they reach the real GitHub API from the host and pass in CI). `TestGitHubPRFactoryLabelsAndExcludeLabelsMatchBackingIssueLabels` is a pre-existing flake under concurrency: it passes in isolation here, and on the same mixed selection main failed 3 of 4 rounds against 0 of 4 on this branch.

## Noted, not addressed

`setReady()` starts `go gs.refreshContextUsage(context.Background())` whenever a fresh session is created, which can interleave a `sessions.describe` with the retried `sessions.send` on the same connection. Pre-existing and out of scope; only the test was made tolerant of the ordering, no production code changed for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)