### PR TITLE
Report progress and parallelize checkpoint file restore

### DIFF
--- a/pkg/hub/checkpoints.go
+++ b/pkg/hub/checkpoints.go
@@ -15,6 +15,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/config"
@@ -23,6 +25,7 @@ import (
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"github.com/google/uuid"
 	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/sync/errgroup"
 	"nhooyr.io/websocket/wsjson"
 )
 
@@ -32,7 +35,15 @@ const (
 	checkpointRequestTimeout     = 2 * time.Minute
 	checkpointTerminationTimeout = 90 * time.Second
 	maxCheckpointBlobBytes       = 256 << 20
+
+	defaultCheckpointRestoreParallelism = 8
+	checkpointRestoreFileTimeout        = 2 * time.Minute
+	checkpointRestoreProgressInterval   = 10 * time.Second
 )
+
+type checkpointFileWriter func(ctx context.Context, remotePath string, data []byte) error
+
+var checkpointRestoreNow = time.Now
 
 type checkpointSummary struct {
 	ID              string     `json:"id"`
@@ -1008,6 +1019,64 @@ func restoreRemotePath(path, home, workspace string) string {
 	}
 }
 
+func (s *Server) restoreCheckpointFilesTo(ctx context.Context, clawID, checkpointID string, files []types.CheckpointFile, remotePathFor func(path string) string, parallelism int, write checkpointFileWriter) error {
+	totalBytes := int64(0)
+	for _, f := range files {
+		totalBytes += f.Size
+	}
+	total := len(files)
+	log.Printf("[checkpoint] restoring %d files (%d bytes) into claw %s", total, totalBytes, clawID)
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(parallelism)
+	var done atomic.Int64
+	var progressMu sync.Mutex
+	lastProgress := checkpointRestoreNow()
+	reportProgress := func() {
+		progressMu.Lock()
+		defer progressMu.Unlock()
+		now := checkpointRestoreNow()
+		if now.Sub(lastProgress) < checkpointRestoreProgressInterval {
+			return
+		}
+		lastProgress = now
+		completed := done.Load()
+		log.Printf("[checkpoint] claw %s: restored %d/%d files", clawID, completed, total)
+		s.setBootstrapStatus(clawID, fmt.Sprintf("Restoring checkpoint files (%d/%d)", completed, total))
+	}
+
+	for _, f := range files {
+		f := f
+		group.Go(func() error {
+			// errgroup still runs every submitted worker after the first
+			// failure. The SSH writer ignores its context, so without this
+			// check a failed restore would keep uploading the whole manifest
+			// before returning the error.
+			if err := groupCtx.Err(); err != nil {
+				return err
+			}
+			data, err := os.ReadFile(checkpointBlobPath(f.SHA256))
+			if err != nil {
+				return fmt.Errorf("read checkpoint blob %s: %w", f.SHA256, err)
+			}
+			writeCtx, cancel := context.WithTimeout(groupCtx, checkpointRestoreFileTimeout)
+			err = write(writeCtx, remotePathFor(f.Path), data)
+			cancel()
+			if err != nil {
+				return fmt.Errorf("restore %s: %w", f.Path, err)
+			}
+			done.Add(1)
+			reportProgress()
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return err
+	}
+	log.Printf("[checkpoint] claw %s: restore complete (%d files)", clawID, total)
+	return nil
+}
+
 func (s *Server) restoreCheckpointToDaytona(ctx context.Context, clawID, instanceID string, p *daytonaProvider.Provider) error {
 	checkpointID := s.pendingRestoreCheckpoint(clawID)
 	if checkpointID == "" {
@@ -1018,15 +1087,12 @@ func (s *Server) restoreCheckpointToDaytona(ctx context.Context, clawID, instanc
 	if err != nil {
 		return err
 	}
-	for _, f := range files {
-		data, err := os.ReadFile(checkpointBlobPath(f.SHA256))
-		if err != nil {
-			return fmt.Errorf("read checkpoint blob %s: %w", f.SHA256, err)
-		}
-		remote := restoreRemotePath(f.Path, "/home/daytona", "/home/daytona/.openclaw/workspace")
-		if err := p.WriteFile(ctx, instanceID, remote, data); err != nil {
-			return fmt.Errorf("restore %s: %w", f.Path, err)
-		}
+	if err := s.restoreCheckpointFilesTo(ctx, clawID, checkpointID, files, func(path string) string {
+		return restoreRemotePath(path, "/home/daytona", "/home/daytona/.openclaw/workspace")
+	}, defaultCheckpointRestoreParallelism, func(ctx context.Context, remote string, data []byte) error {
+		return p.WriteFile(ctx, instanceID, remote, data)
+	}); err != nil {
+		return err
 	}
 	s.markRestoreApplied(clawID, checkpointID)
 	return nil
@@ -1042,15 +1108,12 @@ func (s *Server) restoreCheckpointToExedev(ctx context.Context, clawID, vmName s
 	if err != nil {
 		return err
 	}
-	for _, f := range files {
-		data, err := os.ReadFile(checkpointBlobPath(f.SHA256))
-		if err != nil {
-			return fmt.Errorf("read checkpoint blob %s: %w", f.SHA256, err)
-		}
-		remote := restoreRemotePath(f.Path, ".", ".openclaw/workspace")
-		if err := p.WriteFile(ctx, vmName, remote, data); err != nil {
-			return fmt.Errorf("restore %s: %w", f.Path, err)
-		}
+	if err := s.restoreCheckpointFilesTo(ctx, clawID, checkpointID, files, func(path string) string {
+		return restoreRemotePath(path, ".", ".openclaw/workspace")
+	}, 1, func(ctx context.Context, remote string, data []byte) error {
+		return p.WriteFile(ctx, vmName, remote, data)
+	}); err != nil {
+		return err
 	}
 	s.markRestoreApplied(clawID, checkpointID)
 	return nil
@@ -1077,15 +1140,12 @@ func (s *Server) restoreCheckpointToSSH(clawID, user, host string) error {
 		return fmt.Errorf("ssh dial: %w", err)
 	}
 	defer client.Close()
-	for _, f := range files {
-		data, err := os.ReadFile(checkpointBlobPath(f.SHA256))
-		if err != nil {
-			return fmt.Errorf("read checkpoint blob %s: %w", f.SHA256, err)
-		}
-		remote := restoreRemotePath(f.Path, ".", ".openclaw/workspace")
-		if err := sshWriteBytes(client, remote, data); err != nil {
-			return fmt.Errorf("restore %s: %w", f.Path, err)
-		}
+	if err := s.restoreCheckpointFilesTo(context.Background(), clawID, checkpointID, files, func(path string) string {
+		return restoreRemotePath(path, ".", ".openclaw/workspace")
+	}, 1, func(_ context.Context, remote string, data []byte) error {
+		return sshWriteBytes(client, remote, data)
+	}); err != nil {
+		return err
 	}
 	s.markRestoreApplied(clawID, checkpointID)
 	return nil

--- a/pkg/hub/checkpoints.go
+++ b/pkg/hub/checkpoints.go
@@ -1049,9 +1049,8 @@ func (s *Server) restoreCheckpointFilesTo(ctx context.Context, clawID, checkpoin
 		f := f
 		group.Go(func() error {
 			// errgroup still runs every submitted worker after the first
-			// failure. The SSH writer ignores its context, so without this
-			// check a failed restore would keep uploading the whole manifest
-			// before returning the error.
+			// failure, so do not begin any more uploads once the group is
+			// cancelled.
 			if err := groupCtx.Err(); err != nil {
 				return err
 			}
@@ -1142,8 +1141,8 @@ func (s *Server) restoreCheckpointToSSH(clawID, user, host string) error {
 	defer client.Close()
 	if err := s.restoreCheckpointFilesTo(context.Background(), clawID, checkpointID, files, func(path string) string {
 		return restoreRemotePath(path, ".", ".openclaw/workspace")
-	}, 1, func(_ context.Context, remote string, data []byte) error {
-		return sshWriteBytes(client, remote, data)
+	}, 1, func(ctx context.Context, remote string, data []byte) error {
+		return sshWriteBytes(ctx, client, remote, data)
 	}); err != nil {
 		return err
 	}
@@ -1151,19 +1150,69 @@ func (s *Server) restoreCheckpointToSSH(clawID, user, host string) error {
 	return nil
 }
 
-func sshWriteBytes(client *gossh.Client, remote string, data []byte) error {
-	sess, err := client.NewSession()
-	if err != nil {
-		return err
-	}
-	defer sess.Close()
-	sess.Stdin = bytes.NewReader(data)
+func sshWriteBytes(ctx context.Context, client *gossh.Client, remote string, data []byte) error {
 	cmd := fmt.Sprintf("mkdir -p %s && cat > %s", checkpointShellQuote(filepath.Dir(remote)), checkpointShellQuote(remote))
-	out, err := sess.CombinedOutput(cmd)
-	if err != nil {
-		return fmt.Errorf("%w: %s", err, string(out))
+	return sshWriteSessionWithNewSession(ctx, cmd, func() (checkpointSSHSession, error) {
+		sess, err := client.NewSession()
+		if err != nil {
+			return nil, err
+		}
+		sess.Stdin = bytes.NewReader(data)
+		return sess, nil
+	}, client.Close)
+}
+
+type checkpointSSHSession interface {
+	CombinedOutput(string) ([]byte, error)
+	Close() error
+}
+
+func sshWriteSessionWithNewSession(ctx context.Context, cmd string, newSession func() (checkpointSSHSession, error), closeClient func() error) error {
+	type result struct {
+		err  error
+		sess checkpointSSHSession
 	}
-	return nil
+	completed := make(chan result, 1)
+	go func() {
+		sess, err := newSession()
+		completed <- result{sess: sess, err: err}
+	}()
+	select {
+	case result := <-completed:
+		if result.err != nil {
+			return result.err
+		}
+		return sshWriteSession(ctx, result.sess, cmd, closeClient)
+	case <-ctx.Done():
+		go func() { _ = closeClient() }()
+		return ctx.Err()
+	}
+}
+
+func sshWriteSession(ctx context.Context, sess checkpointSSHSession, cmd string, closeClient func() error) error {
+	type result struct {
+		out []byte
+		err error
+	}
+	completed := make(chan result, 1)
+	go func() {
+		out, err := sess.CombinedOutput(cmd)
+		completed <- result{out: out, err: err}
+	}()
+	select {
+	case result := <-completed:
+		_ = sess.Close()
+		if result.err != nil {
+			return fmt.Errorf("%w: %s", result.err, string(result.out))
+		}
+		return nil
+	case <-ctx.Done():
+		go func() {
+			_ = closeClient()
+			_ = sess.Close()
+		}()
+		return ctx.Err()
+	}
 }
 
 func checkpointShellQuote(s string) string {

--- a/pkg/hub/checkpoints_test.go
+++ b/pkg/hub/checkpoints_test.go
@@ -226,8 +226,8 @@ func TestRestoreCheckpointFilesToReturnsWriteError(t *testing.T) {
 		t.Fatalf("restore error = %v, want wrapped path", err)
 	}
 	// The remaining files must not be uploaded after the first failure: the
-	// SSH writer ignores its context, so only the cancellation check inside
-	// the worker stops the rest of the manifest from being sent.
+	// worker's cancellation check must stop the rest of the manifest from
+	// being sent once the group is cancelled.
 	for _, remote := range written {
 		if strings.HasSuffix(remote, "file-c") {
 			t.Fatalf("kept restoring after failure: wrote %q", remote)
@@ -256,6 +256,65 @@ func TestRestoreCheckpointFilesToReportsProgress(t *testing.T) {
 	}
 	if !strings.Contains(status, "Restoring checkpoint files (") {
 		t.Fatalf("bootstrap status = %q, want restore progress", status)
+	}
+}
+
+type blockingCheckpointSSHSession struct {
+	closeStarted chan struct{}
+	neverClose   chan struct{}
+	once         sync.Once
+}
+
+func (s *blockingCheckpointSSHSession) CombinedOutput(string) ([]byte, error) {
+	<-s.neverClose
+	return nil, nil
+}
+
+func (s *blockingCheckpointSSHSession) Close() error {
+	s.once.Do(func() { close(s.closeStarted) })
+	<-s.neverClose
+	return nil
+}
+
+func TestSSHWriteSessionHonorsContextDeadline(t *testing.T) {
+	sess := &blockingCheckpointSSHSession{closeStarted: make(chan struct{}), neverClose: make(chan struct{})}
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	err := sshWriteSession(ctx, sess, "cat > file", func() error { return nil })
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("write error = %v, want deadline exceeded", err)
+	}
+	select {
+	case <-sess.closeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("session close was not started after context expiry")
+	}
+}
+
+func TestSSHWriteSessionWithNewSessionHonorsContextDeadline(t *testing.T) {
+	newSessionStarted := make(chan struct{})
+	clientClosed := make(chan struct{})
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	err := sshWriteSessionWithNewSession(ctx, "cat > file", func() (checkpointSSHSession, error) {
+		close(newSessionStarted)
+		select {}
+	}, func() error {
+		close(clientClosed)
+		return nil
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("write error = %v, want deadline exceeded", err)
+	}
+	select {
+	case <-newSessionStarted:
+	case <-time.After(time.Second):
+		t.Fatal("new session was not started")
+	}
+	select {
+	case <-clientClosed:
+	case <-time.After(time.Second):
+		t.Fatal("client was not closed after context expiry")
 	}
 }
 

--- a/pkg/hub/checkpoints_test.go
+++ b/pkg/hub/checkpoints_test.go
@@ -3,14 +3,38 @@ package hub
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 	"nhooyr.io/websocket"
 )
+
+func checkpointRestoreTestFiles(t *testing.T, contents []string) []types.CheckpointFile {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	files := make([]types.CheckpointFile, 0, len(contents))
+	for i, content := range contents {
+		sha := strings.Repeat(string(rune('a'+i)), 64)
+		path := checkpointBlobPath(sha)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("make blob directory: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write blob: %v", err)
+		}
+		files = append(files, types.CheckpointFile{Path: "workspace/file-" + string(rune('a'+i)), SHA256: sha, Size: int64(len(content))})
+	}
+	return files
+}
 
 func newCheckpointCompletionTestServer(t *testing.T) *Server {
 	t.Helper()
@@ -124,6 +148,114 @@ func TestDispatchCheckpointWriteFailureRemovesWaiter(t *testing.T) {
 	defer cc.mu.RUnlock()
 	if cc.checkpointInProgress {
 		t.Fatal("expected failed dispatch to clear checkpoint in progress")
+	}
+}
+
+func TestRestoreCheckpointFilesToWritesFiles(t *testing.T) {
+	s := newCheckpointCompletionTestServer(t)
+	files := checkpointRestoreTestFiles(t, []string{"one", "two"})
+	written := make(map[string]string)
+	var mu sync.Mutex
+	err := s.restoreCheckpointFilesTo(context.Background(), "claw", "checkpoint", files, func(path string) string {
+		return "/remote/" + path
+	}, 1, func(_ context.Context, remote string, data []byte) error {
+		mu.Lock()
+		written[remote] = string(data)
+		mu.Unlock()
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if got, want := written["/remote/workspace/file-a"], "one"; got != want {
+		t.Fatalf("first file = %q, want %q", got, want)
+	}
+	if got, want := written["/remote/workspace/file-b"], "two"; got != want {
+		t.Fatalf("second file = %q, want %q", got, want)
+	}
+	if len(written) != len(files) {
+		t.Fatalf("wrote %d files, want %d", len(written), len(files))
+	}
+}
+
+func TestRestoreCheckpointFilesToBoundsParallelism(t *testing.T) {
+	s := newCheckpointCompletionTestServer(t)
+	files := checkpointRestoreTestFiles(t, make([]string, 32))
+	for i := range files {
+		path := checkpointBlobPath(files[i].SHA256)
+		if err := os.WriteFile(path, []byte("data"), 0o644); err != nil {
+			t.Fatalf("rewrite blob: %v", err)
+		}
+	}
+	var inFlight, maxInFlight atomic.Int64
+	err := s.restoreCheckpointFilesTo(context.Background(), "claw", "checkpoint", files, func(path string) string { return path }, 8, func(_ context.Context, _ string, _ []byte) error {
+		current := inFlight.Add(1)
+		for {
+			max := maxInFlight.Load()
+			if current <= max || maxInFlight.CompareAndSwap(max, current) {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+		inFlight.Add(-1)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if got := maxInFlight.Load(); got > 8 {
+		t.Fatalf("maximum concurrency = %d, want at most 8", got)
+	}
+	if got := maxInFlight.Load(); got < 2 {
+		t.Fatalf("maximum concurrency = %d, want parallel writes", got)
+	}
+}
+
+func TestRestoreCheckpointFilesToReturnsWriteError(t *testing.T) {
+	s := newCheckpointCompletionTestServer(t)
+	files := checkpointRestoreTestFiles(t, []string{"good", "bad", "never"})
+	var written []string
+	err := s.restoreCheckpointFilesTo(context.Background(), "claw", "checkpoint", files, func(path string) string { return path }, 1, func(_ context.Context, remote string, _ []byte) error {
+		if strings.HasSuffix(remote, "file-b") {
+			return errors.New("upload failed")
+		}
+		written = append(written, remote)
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "restore workspace/file-b") {
+		t.Fatalf("restore error = %v, want wrapped path", err)
+	}
+	// The remaining files must not be uploaded after the first failure: the
+	// SSH writer ignores its context, so only the cancellation check inside
+	// the worker stops the rest of the manifest from being sent.
+	for _, remote := range written {
+		if strings.HasSuffix(remote, "file-c") {
+			t.Fatalf("kept restoring after failure: wrote %q", remote)
+		}
+	}
+}
+
+func TestRestoreCheckpointFilesToReportsProgress(t *testing.T) {
+	s := newCheckpointCompletionTestServer(t)
+	files := checkpointRestoreTestFiles(t, []string{"one", "two"})
+	originalNow := checkpointRestoreNow
+	base := time.Now()
+	var calls atomic.Int64
+	checkpointRestoreNow = func() time.Time {
+		return base.Add(time.Duration(calls.Add(1)) * 11 * time.Second)
+	}
+	t.Cleanup(func() { checkpointRestoreNow = originalNow })
+	if err := s.restoreCheckpointFilesTo(context.Background(), "claw", "checkpoint", files, func(path string) string { return path }, 1, func(_ context.Context, _ string, _ []byte) error {
+		return nil
+	}); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	var status string
+	if err := s.db.QueryRow(`SELECT bootstrap_status FROM claws WHERE id='claw'`).Scan(&status); err != nil {
+		t.Fatalf("read bootstrap status: %v", err)
+	}
+	if !strings.Contains(status, "Restoring checkpoint files (") {
+		t.Fatalf("bootstrap status = %q, want restore progress", status)
 	}
 }
 

--- a/web/components/bootstrap-progress.tsx
+++ b/web/components/bootstrap-progress.tsx
@@ -16,6 +16,7 @@ type StepKey = typeof STEPS[number]["key"]
 
 function activeStep(status?: string): StepKey {
   const value = (status || "").toLowerCase()
+  if (value.includes("restoring checkpoint")) return "workspace"
   if (value.includes("connecting to hub") || value.includes("starting elasticclaw connector")) return "connect"
   if (value.includes("repo") || value.includes("workspace") || value.includes("sync")) return "workspace"
   if (value.includes("configuring openclaw") || value.includes("gateway")) return "openclaw"
@@ -33,6 +34,7 @@ function friendlyDetail(status?: string): string {
     case "openclaw":
       return "Starting OpenClaw"
     case "workspace":
+      if (value.toLowerCase().includes("restoring checkpoint")) return value
       if (value.toLowerCase().includes("sync")) return "Syncing repositories"
       if (value.toLowerCase().includes("access")) return "Preparing repository access"
       return "Preparing workspace"


### PR DESCRIPTION
## Problem

Real incident on 2026-09-01, claw NEXT-646 (`346ca98a`).

After a `[claw-retry]` replaced the sandbox, bootstrap sat at `bootstrap_status="Restoring checkpoint files"` from 14:13:18 to 14:35:54 — **22 minutes with zero log lines and a frozen `last_seen`**. It was not hung: `restoreCheckpointToDaytona` was uploading 3278 files / 29 MB serially, three Daytona API round-trips per file. But it is indistinguishable from a hang, and an operator nearly killed a healthy claw over it.

Worse, the operator watching the hub UI saw **"Creating sandbox"** for those 22 minutes: `"Restoring checkpoint files"` matched none of the filters in `bootstrap-progress.tsx` and fell through to the default step.

Two aggravating factors:

- Every other bootstrap step logs and uses `ExecWithTimeout`. Only the restore was silent and unbounded — a single wedged upload would hang bootstrap forever with no diagnostic.
- The reaper stops claws in `starting` after `provisioning_max_age` (default 30 min, no override in the faster `hub.yaml`). The restore finished at 24.5 minutes. A mid-restore reap is **immediately terminal with no retry**: the reaper's reason `"provisioning timed out"` matches no rule in `classifyAgentFailure`, so it buckets as `agentFailureUnknown` and `retryableAgentFailure` rejects it. (An actual restore error, `"Daytona bootstrap failed: ..."`, *is* retryable — the reap is the bad path.)

## Change

Extract the upload loop into `restoreCheckpointFilesTo`, shared by the Daytona, Exedev and SSH restore paths.

- **Bounded parallelism** (8) for Daytona via `errgroup.SetLimit`; the bottleneck is round-trip latency, not bandwidth. Exedev and SSH stay serial (parallelism 1) but reuse the helper. Expect **up to ~8x** — 8 is the ideal-scaling ceiling, ~6-8x is the realistic range.
- **Progress reporting**: file counts logged and written to `bootstrap_status` at most every 10s (`Restoring checkpoint files (1840/3278)`), plus the UI change that actually renders it instead of showing "Creating sandbox".
- **Per-file timeout** of 2 minutes, derived from the group context, on all three paths — including SSH, where honoring the context required running session setup and `CombinedOutput` off the calling goroutine and tearing the connection down detached, since `NewSession` and `Session.Close` both block on the same wedged transport.
- Blobs are read **inside** the workers — the 29 MB manifest is never materialized in memory at once.
- Workers check the group context before starting, so a failed restore stops submitting further uploads instead of finishing the manifest.

Error semantics are unchanged: the same `restore %s: %w` / `read checkpoint blob %s: %w` wrappings, and `markRestoreApplied` still runs only after every file succeeds.

`pkg/hub/reaper.go` is deliberately untouched. Making the restore several times faster and genuinely visible is the fix; the 30-minute reaper stays as the backstop. Adding `"provisioning timed out"` to the `agentFailureProvisioning` signals so reaped claws become retryable is a worthwhile follow-up, but out of scope here.

## Validation

Reviewed by an adversarial loop (3 rounds, 22 raw findings) where every finding had to be proven with production data, a `file:line` citation, or arithmetic from measured premises, and then survive an independent skeptic. Notable **rejections** — things that look alarming but were disproven:

- *Concurrent `CreateFolder` on shared parent directories could fail the restore.* Refuted: the Daytona daemon implements that endpoint as `os.MkdirAll`, which is explicitly race-safe (re-`Lstat`s after `EEXIST`).
- *The 2-minute per-file timeout could fail the incident's largest blob (2.19 MB).* Refuted: the ~10 KB/s figure was a non-representative socket sample — 28.9 MB in 1356 s of measured wall clock gives ~21 KB/s, and the premises fit a latency-dominated model (~138 ms per round-trip) with no bandwidth cap. The workload is latency-bound, which is also why parallelism helps at all.
- *8x concurrency multiplies unretried API calls into a likelier failure.* Refuted: `bootstrapDaytona` is already wrapped in a 3-attempt retry, and the per-attempt request count is unchanged — the change makes a lost attempt ~8x cheaper.

## Tests

`pkg/hub/checkpoints_test.go` covers the happy path, the parallelism bound (atomic in-flight max — fails if `SetLimit` is dropped), error wrapping plus no-uploads-after-failure, throttled progress via an injectable clock, and two SSH tests that block `NewSession`/`Close` forever and assert the write still returns `DeadlineExceeded`.

```
gofmt -l pkg/hub/                                                      clean for changed files
go build ./...                                                         clean
go vet ./pkg/hub/                                                      clean
go test ./pkg/hub/ -race -run 'Checkpoint|RestoreCheckpoint|SSHWrite'   ok (9.0s)
npm run typecheck   (web/)                                             clean
npm run lint        (web/)                                             clean (5 pre-existing warnings, none in changed file)
```

The full `pkg/hub` suite has 3 failures on this branch (`TestDoneSignalRejectedWhenPRPersistenceFails`, `TestHandleClawDoneSignal_IssueLessWorkflowWatchesPR`, `TestCompleteIssueLessDoneClawKeepsRunningOnStoreFailure`) — verified pre-existing by reverting the changed files to `HEAD` and reproducing the identical failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
