### PR TITLE
Announce releases on Discord

### DIFF
--- a/.depot/workflows/release-notes.yml
+++ b/.depot/workflows/release-notes.yml
@@ -11,6 +11,12 @@ jobs:
   generate-release-notes:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.ref_name, '-') }}  # skip prereleases
+    outputs:
+      title: ${{ steps.parsed.outputs.title }}
+      summary: ${{ steps.parsed.outputs.summary }}
+      whatsNew: ${{ steps.parsed.outputs.whatsNew }}
+      improvements: ${{ steps.parsed.outputs.improvements }}
+      fixes: ${{ steps.parsed.outputs.fixes }}
     steps:
       - name: Validate release tag
         run: |
@@ -333,3 +339,44 @@ jobs:
             - Summary: ${{ steps.parsed.outputs.summary }}
           commit-message: "docs: release notes for ${{ github.ref_name }}"
           delete-branch: true
+
+  notify-discord:
+    name: Announce on Discord
+    runs-on: ubuntu-latest
+    needs: generate-release-notes
+    permissions:
+      contents: read
+    env:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Wait for the GitHub Release
+        if: env.DISCORD_WEBHOOK != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # The Release workflow fires off the same tag but runs in parallel, and
+          # it has to build binaries for five platforms first. Announcing before
+          # it finishes would link people to a release page with no downloads.
+          for _ in $(seq 1 60); do
+            if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 30
+          done
+          echo "GitHub Release ${GITHUB_REF_NAME} did not appear within 30 minutes" >&2
+          exit 1
+
+      - name: Post changelog to Discord
+        if: env.DISCORD_WEBHOOK != ''
+        env:
+          TAG: ${{ github.ref_name }}
+          DISCORD_MODE: changelog
+          NOTES_TITLE: ${{ needs.generate-release-notes.outputs.title }}
+          NOTES_SUMMARY: ${{ needs.generate-release-notes.outputs.summary }}
+          NOTES_WHATS_NEW: ${{ needs.generate-release-notes.outputs.whatsNew }}
+          NOTES_IMPROVEMENTS: ${{ needs.generate-release-notes.outputs.improvements }}
+          NOTES_FIXES: ${{ needs.generate-release-notes.outputs.fixes }}
+        run: ./hack/discord-release-notify.sh

--- a/.depot/workflows/release.yaml
+++ b/.depot/workflows/release.yaml
@@ -16,6 +16,8 @@ jobs:
     runs-on: depot-ubuntu-24.04
     permissions:
       contents: write
+    outputs:
+      prerelease: ${{ steps.semver.outputs.prerelease }}
 
     steps:
       - name: Validate release tag
@@ -205,3 +207,31 @@ jobs:
           git add "Formula/${FORMULA_FILE}"
           git diff --staged --quiet || git commit -m "${COMMIT_MSG}"
           git push
+
+  notify-discord:
+    name: Announce prerelease on Discord
+    runs-on: depot-ubuntu-24.04
+    needs: release
+    # Stable tags are announced by the release-notes workflow, which has the
+    # curated changelog. Only prereleases are announced from here.
+    if: needs.release.outputs.prerelease == 'true'
+    permissions:
+      contents: read
+    env:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Post pull request list to Discord
+        if: env.DISCORD_WEBHOOK != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          DISCORD_MODE: prs
+        run: |
+          set -euo pipefail
+          # No curated notes exist for a prerelease, so reuse the pull request
+          # list that "generate_release_notes" already wrote into the release.
+          RELEASE_BODY="$(gh release view "$TAG" --json body --jq .body)"
+          export RELEASE_BODY
+          ./hack/discord-release-notify.sh

--- a/hack/discord-release-notify.sh
+++ b/hack/discord-release-notify.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Announce a release on Discord via an incoming channel webhook.
+#
+# Two shapes, selected by DISCORD_MODE:
+#
+#   changelog — stable releases. Uses the curated notes the release-notes
+#               workflow already produced with Groq (What's New / Improvements /
+#               Fixes), so the announcement reads like the docs site entry.
+#
+#   prs       — prereleases. No curated notes exist for an RC, so we fall back to
+#               the pull-request list GitHub generates in the release body.
+#
+# Callers are expected to run this only after the GitHub Release exists, so the
+# link in the embed points at published assets rather than a bare tag.
+#
+# DISCORD_WEBHOOK comes from the DISCORD_RELEASE_WEBHOOK repository secret. Both
+# release workflows skip the announcement when that secret is unset, so forks and
+# a not-yet-configured repo release normally.
+set -euo pipefail
+
+command -v jq >/dev/null || { echo "missing jq"; exit 1; }
+command -v curl >/dev/null || { echo "missing curl"; exit 1; }
+
+require() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "discord-release-notify: missing required env ${name}" >&2
+    exit 1
+  fi
+}
+
+require DISCORD_WEBHOOK
+require TAG
+require DISCORD_MODE
+
+REPO="${GITHUB_REPOSITORY:-elasticclaw/elasticclaw}"
+RELEASE_URL="https://github.com/${REPO}/releases/tag/${TAG}"
+
+# Discord rejects the whole payload when any limit is exceeded: 4096 chars per
+# description, 1024 per field value, 25 fields, 6000 across the embed. Truncate
+# instead of letting a big release silently fail to post.
+clamp() {
+  local max="$1" text
+  text="$(cat)"
+  if (( ${#text} <= max )); then
+    printf '%s' "$text"
+  else
+    printf '%s\n…' "${text:0:max-2}"
+  fi
+}
+
+# JSON array of strings -> markdown bullet list. Anything else yields "".
+bullets() {
+  printf '%s' "${1:-}" | jq -r 'if type == "array" then map("- " + .) | join("\n") else "" end' 2>/dev/null || true
+}
+
+# Emits a field object, or nothing when the section is empty (Discord rejects
+# fields with an empty value).
+field() {
+  local name="$1" value="$2"
+  [[ -n "$value" ]] || return 0
+  jq -n --arg name "$name" --arg value "$(printf '%s' "$value" | clamp 1024)" \
+    '{name: $name, value: $value, inline: false}'
+}
+
+case "$DISCORD_MODE" in
+  changelog)
+    TITLE="${TAG}"
+    [[ -n "${NOTES_TITLE:-}" ]] && TITLE="${TAG} — ${NOTES_TITLE}"
+    DESCRIPTION="$(printf '%s' "${NOTES_SUMMARY:-}" | clamp 4096)"
+    COLOR=2278750  # green
+    FIELDS="$(
+      {
+        field "What's New" "$(bullets "${NOTES_WHATS_NEW:-}")"
+        field "Improvements" "$(bullets "${NOTES_IMPROVEMENTS:-}")"
+        field "Fixes" "$(bullets "${NOTES_FIXES:-}")"
+      } | jq -s '.'
+    )"
+    ;;
+  prs)
+    require RELEASE_BODY
+    TITLE="${TAG} (prerelease)"
+    # GitHub writes "* <pr title> by @<user> in <url>" under "What's Changed".
+    # Rewrite each into "- <title> ([#123](<url>))" so the embed stays compact
+    # and still links every PR.
+    DESCRIPTION="$(
+      printf '%s\n' "$RELEASE_BODY" \
+        | sed -n 's|^\* \(.*\) by @[^ ]* in https://github.com/[^ ]*/pull/\([0-9]*\)$|- \1 ([#\2](https://github.com/'"${REPO}"'/pull/\2))|p' \
+        | clamp 4096
+    )"
+    [[ -n "$DESCRIPTION" ]] || DESCRIPTION="No pull requests since the previous release."
+    COLOR=16098851  # amber
+    FIELDS='[]'
+    ;;
+  *)
+    echo "discord-release-notify: unknown DISCORD_MODE '${DISCORD_MODE}' (want changelog|prs)" >&2
+    exit 1
+    ;;
+esac
+
+jq -n \
+  --arg title "$TITLE" \
+  --arg url "$RELEASE_URL" \
+  --arg description "$DESCRIPTION" \
+  --argjson color "$COLOR" \
+  --argjson fields "$FIELDS" \
+  '{
+     username: "ElasticClaw",
+     embeds: [{
+       title: $title,
+       url: $url,
+       description: $description,
+       color: $color,
+       fields: $fields,
+       footer: {text: "elasticclaw release"}
+     }]
+   }' > /tmp/discord-payload.json
+
+curl -fsS -X POST \
+  -H 'Content-Type: application/json' \
+  --data @/tmp/discord-payload.json \
+  "$DISCORD_WEBHOOK" >/dev/null
+
+echo "Posted ${TAG} to Discord (mode=${DISCORD_MODE})"


### PR DESCRIPTION
Adds a Discord announcement for every release tag.

## Behaviour

| Tag | Announced by | Content |
| --- | --- | --- |
| Stable (`2026.9.1`) | `release-notes.yml` | The curated Groq changelog — title, summary, What's New / Improvements / Fixes |
| Prerelease (`2026.9.1-rc1`) | `release.yaml` | The pull request list GitHub generates in the release body, one linked line per PR |

No role pings.

## Ordering

Both jobs announce only after the GitHub Release exists, so the embed never links to a release page without binaries:

- Prerelease: `needs: release`, so the assets are already published.
- Stable: `release-notes.yml` is a separate workflow that fires off the same tag in parallel with `release.yaml`, so the job polls `gh release view` (up to 30 min) before posting.

## Setup

Add a `DISCORD_RELEASE_WEBHOOK` repository secret (Discord → Server Settings → Integrations → Webhooks → copy the channel webhook URL). Both jobs skip cleanly while the secret is unset, so nothing breaks before it is configured.

## Verification

- `shellcheck` clean on `hack/discord-release-notify.sh` and on the new workflow `run` blocks.
- Both modes exercised locally against a stubbed `curl`; payloads validated with `jq`.

<details>
<summary>Stable payload</summary>

```json
{
  "username": "ElasticClaw",
  "embeds": [
    {
      "title": "2026.9.1 — Bridge Work, Less Guesswork",
      "url": "https://github.com/elasticclaw/elasticclaw/releases/tag/2026.9.1",
      "description": "Bootstraps that stick and a quieter reaper.",
      "color": 2278750,
      "fields": [
        { "name": "What's New", "value": "- Workflow v2 bootstrap promotion guard\n- Queued messages stay out of workflow v2", "inline": false },
        { "name": "Improvements", "value": "- Refreshed workflow v2 execution ownership", "inline": false }
      ],
      "footer": { "text": "elasticclaw release" }
    }
  ]
}
```
</details>

<details>
<summary>Prerelease payload</summary>

```json
{
  "username": "ElasticClaw",
  "embeds": [
    {
      "title": "2026.9.1-rc1 (prerelease)",
      "url": "https://github.com/elasticclaw/elasticclaw/releases/tag/2026.9.1-rc1",
      "description": "- Guard workflow v2 bootstrap promotion ([#613](https://github.com/elasticclaw/elasticclaw/pull/613))\n- Keep queued messages out of workflow v2 ([#611](https://github.com/elasticclaw/elasticclaw/pull/611))",
      "color": 16098851,
      "fields": [],
      "footer": { "text": "elasticclaw release" }
    }
  ]
}
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)