### PR TITLE
feat(hub,web): notify on dependency downtime and provider usage limits

### DIFF
--- a/pkg/hub/bridge_error.go
+++ b/pkg/hub/bridge_error.go
@@ -182,6 +182,9 @@ func (s *Server) observeTurnOutcome(cc *clawConn, clawID, messageID, content str
 		cc.bridgeErrorStreak = 0
 		cc.mu.Unlock()
 	}
+	// An authored turn also proves the provider answered, which is what a
+	// released usage limit is waiting to hear.
+	s.observeAuthoredTurnForLLMLimit(clawID)
 	return s.observeCompletedTurn(clawID, messageID, content), false
 }
 

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -569,6 +569,13 @@ func migrate(db *sql.DB) error {
 		detail      TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(detail) AND json_type(detail) = 'object'),
 		occurred_at INTEGER NOT NULL
 	);
+	CREATE TABLE IF NOT EXISTS infra_notification_deliveries (
+		event_rowid INTEGER NOT NULL,
+		notifier TEXT NOT NULL,
+		delivered_at INTEGER NOT NULL,
+		status TEXT NOT NULL,
+		PRIMARY KEY(event_rowid, notifier)
+	);
 	-- rowid, rather than occurred_at, is the future delivery watermark: an
 	-- event recorded late must never disappear behind a newer wall-clock value.
 	-- SQLite already indexes its implicit rowid, so no secondary index is needed.

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -588,6 +588,13 @@ func migrate(db *sql.DB) error {
 		message         TEXT NOT NULL DEFAULT '',
 		since           INTEGER NOT NULL DEFAULT 0,
 		notified_status TEXT NOT NULL DEFAULT '',
+		-- The CheckedAt of the last snapshot that counted as an observation.
+		-- The status cache outlives the watcher tick, so a re-served snapshot
+		-- must not count as a second consecutive check toward the debounce.
+		last_checked_at INTEGER NOT NULL DEFAULT 0,
+		-- When the last degraded/down alert for this dependency was recorded,
+		-- so the opt-in repeat_after can re-alert during a long outage.
+		last_alert_at   INTEGER NOT NULL DEFAULT 0,
 		updated_at      INTEGER NOT NULL DEFAULT 0
 	);
 

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -560,6 +560,30 @@ func migrate(db *sql.DB) error {
 		released_at      INTEGER NOT NULL DEFAULT 0
 	);
 
+	-- Infra events are deliberately outside task_run_events: an account limit or
+	-- vendor outage is a fleet fact, not four independent agent failures.
+	CREATE TABLE IF NOT EXISTS infra_events (
+		event_key   TEXT UNIQUE NOT NULL,
+		event_type  TEXT NOT NULL,
+		subject     TEXT NOT NULL,
+		detail      TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(detail) AND json_type(detail) = 'object'),
+		occurred_at INTEGER NOT NULL
+	);
+	-- rowid, rather than occurred_at, is the future delivery watermark: an
+	-- event recorded late must never disappear behind a newer wall-clock value.
+	-- SQLite already indexes its implicit rowid, so no secondary index is needed.
+
+	-- This durable state makes the dependency watcher edge-triggered across a
+	-- hub restart; an outage must not page again merely because the process did.
+	CREATE TABLE IF NOT EXISTS dependency_status_state (
+		id              TEXT PRIMARY KEY,
+		status          TEXT NOT NULL DEFAULT '',
+		message         TEXT NOT NULL DEFAULT '',
+		since           INTEGER NOT NULL DEFAULT 0,
+		notified_status TEXT NOT NULL DEFAULT '',
+		updated_at      INTEGER NOT NULL DEFAULT 0
+	);
+
 
 
 	CREATE TABLE IF NOT EXISTS messages (

--- a/pkg/hub/dependency_status.go
+++ b/pkg/hub/dependency_status.go
@@ -113,6 +113,18 @@ func newDependencyStatusService(cfg *types.HubConfig) *dependencyStatusService {
 }
 
 func (s *dependencyStatusService) snapshot(ctx context.Context) DependencyStatusResponse {
+	// A dashboard request is only an observer: cancelling it must not abandon
+	// the shared refresh another observer is already waiting on.
+	return s.snapshotWithRefreshContext(ctx, context.Background())
+}
+
+// snapshotForWatcher lets shutdown cancel the watcher-owned status request.
+// The background watcher has no user request to outlive, unlike snapshot.
+func (s *dependencyStatusService) snapshotForWatcher(ctx context.Context) DependencyStatusResponse {
+	return s.snapshotWithRefreshContext(ctx, ctx)
+}
+
+func (s *dependencyStatusService) snapshotWithRefreshContext(ctx, refreshCtx context.Context) DependencyStatusResponse {
 	if resp, ok := s.freshSnapshot(); ok {
 		return s.applyLLMUsageLimits(resp)
 	}
@@ -122,7 +134,7 @@ func (s *dependencyStatusService) snapshot(ctx context.Context) DependencyStatus
 			return resp, nil
 		}
 
-		return s.refreshSnapshot(context.Background()), nil
+		return s.refreshSnapshot(refreshCtx), nil
 	})
 	if resp, ok := value.(DependencyStatusResponse); ok {
 		return s.applyLLMUsageLimits(cloneDependencyStatusResponse(resp))

--- a/pkg/hub/dependency_watcher.go
+++ b/pkg/hub/dependency_watcher.go
@@ -5,7 +5,9 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"net/url"
 	"runtime/debug"
+	"strings"
 	"time"
 )
 
@@ -141,7 +143,7 @@ func (s *Server) observeDependencyStatus(dependency DependencyStatus, nowAt time
 			if err := s.recordInfraEvent(infraEvent{
 				EventKey:  fmt.Sprintf("dependency_recovered:%s:%d", dependency.ID, epochMillis(state.Since)),
 				EventType: "dependency_recovered", Subject: dependency.ID,
-				Detail:     map[string]any{"id": dependency.ID, "name": dependency.Name, "message": dependency.Message, "duration_ms": duration.Milliseconds()},
+				Detail:     map[string]any{"id": dependency.ID, "name": dependency.Name, "message": dependency.Message, "duration_ms": duration.Milliseconds(), "status_page": dependencyStatusPage(dependency.Source)},
 				OccurredAt: nowAt,
 			}); err != nil {
 				return err
@@ -179,7 +181,7 @@ func (s *Server) observeDependencyStatus(dependency DependencyStatus, nowAt time
 			if err := s.recordInfraEvent(infraEvent{
 				EventKey:  fmt.Sprintf("%s:%s:%d", eventType, dependency.ID, epochMillis(state.Since)),
 				EventType: eventType, Subject: dependency.ID,
-				Detail:     map[string]any{"id": dependency.ID, "name": dependency.Name, "message": dependency.Message, "status": dependency.Status},
+				Detail:     map[string]any{"id": dependency.ID, "name": dependency.Name, "message": dependency.Message, "status": dependency.Status, "status_page": dependencyStatusPage(dependency.Source)},
 				OccurredAt: nowAt,
 			}); err != nil {
 				return err
@@ -198,7 +200,7 @@ func (s *Server) observeDependencyStatus(dependency DependencyStatus, nowAt time
 		if err := s.recordInfraEvent(infraEvent{
 			EventKey:  fmt.Sprintf("%s:%s:%d:repeat:%d", eventType, dependency.ID, epochMillis(state.Since), epochMillis(nowAt)),
 			EventType: eventType, Subject: dependency.ID,
-			Detail:     map[string]any{"id": dependency.ID, "name": dependency.Name, "message": dependency.Message, "status": dependency.Status, "repeat": true},
+			Detail:     map[string]any{"id": dependency.ID, "name": dependency.Name, "message": dependency.Message, "status": dependency.Status, "repeat": true, "status_page": dependencyStatusPage(dependency.Source)},
 			OccurredAt: nowAt,
 		}); err != nil {
 			return err
@@ -206,6 +208,18 @@ func (s *Server) observeDependencyStatus(dependency DependencyStatus, nowAt time
 		state.LastAlertAt = nowAt
 	}
 	return s.storeDependencyStatusState(state, nowAt)
+}
+
+// dependencyStatusPage turns the endpoint a checker polled
+// (https://status.vendor.com/api/v2/status.json) into the page a human opens,
+// so an alert that says "watch the status page" also says where it is.
+// Non-URL sources ("hub") have no page.
+func dependencyStatusPage(source string) string {
+	u, err := url.Parse(strings.TrimSpace(source))
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return ""
+	}
+	return u.Scheme + "://" + u.Host
 }
 
 func (s *Server) loadDependencyStatusState(id string) (dependencyStatusState, bool, error) {

--- a/pkg/hub/dependency_watcher.go
+++ b/pkg/hub/dependency_watcher.go
@@ -1,0 +1,178 @@
+package hub
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"runtime/debug"
+	"time"
+)
+
+const dependencyWatcherInterval = time.Minute
+
+type dependencyStatusState struct {
+	ID             string
+	Status         string
+	Message        string
+	Since          time.Time
+	NotifiedStatus string
+}
+
+// startDependencyWatcher keeps status-page changes visible even when nobody
+// has the dashboard open. It runs ticks inline because an overlapping check
+// could make two observations look like the debounce had been satisfied.
+func (s *Server) startDependencyWatcher() {
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	s.dependencyWatcherStop, s.dependencyWatcherDone = stop, done
+	tickCtx, cancelTicks := context.WithCancel(context.Background())
+	s.safeGo("dependency watcher", func() {
+		defer close(done)
+		defer cancelTicks()
+		go func() { <-stop; cancelTicks() }()
+		for {
+			timer := time.NewTimer(dependencyWatcherInterval)
+			select {
+			case <-stop:
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("[dependencies] watcher tick panic: %v\n%s", r, debug.Stack())
+					}
+				}()
+				s.dependencyWatcherTick(tickCtx, s.nowFunc())
+			}()
+		}
+	})
+}
+
+func (s *Server) stopDependencyWatcher(timeout time.Duration) {
+	if s.dependencyWatcherStop == nil {
+		return
+	}
+	close(s.dependencyWatcherStop)
+	s.dependencyWatcherStop = nil
+	select {
+	case <-s.dependencyWatcherDone:
+	case <-time.After(timeout):
+		log.Printf("[dependencies] watcher tick still running after %v; shutting down anyway", timeout)
+	}
+}
+
+func (s *Server) dependencyWatcherTick(ctx context.Context, nowAt time.Time) {
+	if err := ctx.Err(); err != nil {
+		return
+	}
+	for _, dependency := range s.dependencyStatus.snapshotForWatcher(ctx).Dependencies {
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		// Limited is an account-local fact with richer retry information in the
+		// LLM latch. Unknown means this hub cannot observe the vendor at all;
+		// treating it as a transition would manufacture outages during egress loss.
+		if dependency.Status == dependencyStatusUnknown || dependency.Status == dependencyStatusLimited {
+			continue
+		}
+		if err := s.observeDependencyStatus(dependency, nowAt); err != nil {
+			log.Printf("[dependencies] record status for %s: %v", dependency.ID, err)
+		}
+	}
+}
+
+func (s *Server) observeDependencyStatus(dependency DependencyStatus, nowAt time.Time) error {
+	state, found, err := s.loadDependencyStatusState(dependency.ID)
+	if err != nil {
+		return err
+	}
+	if !found {
+		state = dependencyStatusState{ID: dependency.ID}
+	}
+
+	if dependency.Status == dependencyStatusOperational {
+		if state.NotifiedStatus == dependencyStatusDegraded || state.NotifiedStatus == dependencyStatusDowntime {
+			duration := time.Duration(0)
+			if !state.Since.IsZero() {
+				duration = nowAt.Sub(state.Since)
+			}
+			if err := s.recordInfraEvent(infraEvent{
+				EventKey:  fmt.Sprintf("dependency_recovered:%s:%d", dependency.ID, epochMillis(state.Since)),
+				EventType: "dependency_recovered", Subject: dependency.ID,
+				Detail:     map[string]any{"id": dependency.ID, "name": dependency.Name, "message": dependency.Message, "duration_ms": duration.Milliseconds()},
+				OccurredAt: nowAt,
+			}); err != nil {
+				return err
+			}
+		}
+		state.Status, state.Message, state.Since, state.NotifiedStatus = dependency.Status, dependency.Message, time.Time{}, dependencyStatusOperational
+		return s.storeDependencyStatusState(state, nowAt)
+	}
+
+	// A different bad status starts a fresh debounce but keeps the outage's
+	// original start: recovery duration describes the whole customer-visible
+	// incident, not merely its last status-page label.
+	if state.Status != dependency.Status {
+		if state.Since.IsZero() || state.Status == dependencyStatusOperational || state.Status == "" {
+			state.Since = nowAt
+		}
+		state.Status, state.Message = dependency.Status, dependency.Message
+		return s.storeDependencyStatusState(state, nowAt)
+	}
+
+	state.Message = dependency.Message
+	if state.NotifiedStatus != dependency.Status {
+		eventType := ""
+		switch dependency.Status {
+		case dependencyStatusDegraded:
+			if state.NotifiedStatus == "" || state.NotifiedStatus == dependencyStatusOperational {
+				eventType = "dependency_degraded"
+			}
+		case dependencyStatusDowntime:
+			if state.NotifiedStatus == "" || state.NotifiedStatus == dependencyStatusOperational || state.NotifiedStatus == dependencyStatusDegraded {
+				eventType = "dependency_down"
+			}
+		}
+		if eventType != "" {
+			if err := s.recordInfraEvent(infraEvent{
+				EventKey:  fmt.Sprintf("%s:%s:%d", eventType, dependency.ID, epochMillis(state.Since)),
+				EventType: eventType, Subject: dependency.ID,
+				Detail:     map[string]any{"id": dependency.ID, "name": dependency.Name, "message": dependency.Message, "status": dependency.Status},
+				OccurredAt: nowAt,
+			}); err != nil {
+				return err
+			}
+			state.NotifiedStatus = dependency.Status
+		}
+	}
+	return s.storeDependencyStatusState(state, nowAt)
+}
+
+func (s *Server) loadDependencyStatusState(id string) (dependencyStatusState, bool, error) {
+	var state dependencyStatusState
+	var since int64
+	err := s.db.QueryRow(`SELECT id, status, message, since, notified_status FROM dependency_status_state WHERE id=?`, id).
+		Scan(&state.ID, &state.Status, &state.Message, &since, &state.NotifiedStatus)
+	if err == sql.ErrNoRows {
+		return dependencyStatusState{}, false, nil
+	}
+	if err != nil {
+		return dependencyStatusState{}, false, fmt.Errorf("load state: %w", err)
+	}
+	state.Since = timeFromEpochMillis(since)
+	return state, true, nil
+}
+
+func (s *Server) storeDependencyStatusState(state dependencyStatusState, nowAt time.Time) error {
+	_, err := s.db.Exec(`INSERT INTO dependency_status_state(id, status, message, since, notified_status, updated_at)
+		VALUES(?,?,?,?,?,?) ON CONFLICT(id) DO UPDATE SET status=excluded.status, message=excluded.message,
+		since=excluded.since, notified_status=excluded.notified_status, updated_at=excluded.updated_at`,
+		state.ID, state.Status, state.Message, epochMillisOrZero(state.Since), state.NotifiedStatus, epochMillis(nowAt))
+	if err != nil {
+		return fmt.Errorf("store state: %w", err)
+	}
+	return nil
+}

--- a/pkg/hub/dependency_watcher.go
+++ b/pkg/hub/dependency_watcher.go
@@ -17,6 +17,15 @@ type dependencyStatusState struct {
 	Message        string
 	Since          time.Time
 	NotifiedStatus string
+	// LastCheckedAt is the CheckedAt of the snapshot observation that last
+	// counted toward the debounce. The watcher ticks every minute but the
+	// status cache lives five: without this fence the same vendor-page fetch
+	// is re-served to consecutive ticks and one flapping observation would
+	// satisfy the two-consecutive-checks debounce all by itself.
+	LastCheckedAt time.Time
+	// LastAlertAt is when this dependency last produced a degraded/down
+	// event, so the opt-in repeat_after can re-alert during a long outage.
+	LastAlertAt time.Time
 }
 
 // startDependencyWatcher keeps status-page changes visible even when nobody
@@ -68,6 +77,7 @@ func (s *Server) dependencyWatcherTick(ctx context.Context, nowAt time.Time) {
 	if err := ctx.Err(); err != nil {
 		return
 	}
+	repeatAfter := s.infraRepeatAfter()
 	for _, dependency := range s.dependencyStatus.snapshotForWatcher(ctx).Dependencies {
 		if err := ctx.Err(); err != nil {
 			return
@@ -78,19 +88,48 @@ func (s *Server) dependencyWatcherTick(ctx context.Context, nowAt time.Time) {
 		if dependency.Status == dependencyStatusUnknown || dependency.Status == dependencyStatusLimited {
 			continue
 		}
-		if err := s.observeDependencyStatus(dependency, nowAt); err != nil {
+		if err := s.observeDependencyStatus(dependency, nowAt, repeatAfter); err != nil {
 			log.Printf("[dependencies] record status for %s: %v", dependency.ID, err)
 		}
 	}
 }
 
-func (s *Server) observeDependencyStatus(dependency DependencyStatus, nowAt time.Time) error {
+// infraRepeatAfter reads notifications.infra.repeat_after on every tick so a
+// config change needs no restart. Zero means repeats are off — the default,
+// and deliberately so (see InfraNotificationsConfig).
+func (s *Server) infraRepeatAfter() time.Duration {
+	cfg := s.notificationsConfig()
+	if cfg == nil || cfg.Infra == nil || cfg.Infra.RepeatAfter == "" {
+		return 0
+	}
+	if d, err := time.ParseDuration(cfg.Infra.RepeatAfter); err == nil && d > 0 {
+		return d
+	}
+	return 0
+}
+
+func (s *Server) observeDependencyStatus(dependency DependencyStatus, nowAt time.Time, repeatAfter time.Duration) error {
 	state, found, err := s.loadDependencyStatusState(dependency.ID)
 	if err != nil {
 		return err
 	}
 	if !found {
 		state = dependencyStatusState{ID: dependency.ID}
+	}
+
+	// Only a strictly newer fetch counts as a new check. The per-dependency
+	// CheckedAt is stamped at refresh time and survives the cache, so a
+	// re-served snapshot carries the same instant and is the same single
+	// observation, not a second consecutive one. A zero CheckedAt (only
+	// synthetic snapshots produce one) always counts rather than never.
+	// Truncated to the millisecond the state row stores, or a reloaded state
+	// would compare as older than the very fetch that produced it.
+	checkedAt := dependency.CheckedAt.Truncate(time.Millisecond)
+	if !checkedAt.IsZero() && !checkedAt.After(state.LastCheckedAt) {
+		return nil
+	}
+	if checkedAt.After(state.LastCheckedAt) {
+		state.LastCheckedAt = checkedAt
 	}
 
 	if dependency.Status == dependencyStatusOperational {
@@ -108,7 +147,7 @@ func (s *Server) observeDependencyStatus(dependency DependencyStatus, nowAt time
 				return err
 			}
 		}
-		state.Status, state.Message, state.Since, state.NotifiedStatus = dependency.Status, dependency.Message, time.Time{}, dependencyStatusOperational
+		state.Status, state.Message, state.Since, state.NotifiedStatus, state.LastAlertAt = dependency.Status, dependency.Message, time.Time{}, dependencyStatusOperational, time.Time{}
 		return s.storeDependencyStatusState(state, nowAt)
 	}
 
@@ -146,16 +185,34 @@ func (s *Server) observeDependencyStatus(dependency DependencyStatus, nowAt time
 				return err
 			}
 			state.NotifiedStatus = dependency.Status
+			state.LastAlertAt = nowAt
 		}
+	} else if repeatAfter > 0 && !state.LastAlertAt.IsZero() && nowAt.Sub(state.LastAlertAt) >= repeatAfter {
+		// repeat_after is opt-in: re-say a still-standing outage so a channel
+		// that scrolled past the original alert hears about it again. A fresh
+		// event key per repeat keeps the event-store dedupe from swallowing it.
+		eventType := "dependency_degraded"
+		if dependency.Status == dependencyStatusDowntime {
+			eventType = "dependency_down"
+		}
+		if err := s.recordInfraEvent(infraEvent{
+			EventKey:  fmt.Sprintf("%s:%s:%d:repeat:%d", eventType, dependency.ID, epochMillis(state.Since), epochMillis(nowAt)),
+			EventType: eventType, Subject: dependency.ID,
+			Detail:     map[string]any{"id": dependency.ID, "name": dependency.Name, "message": dependency.Message, "status": dependency.Status, "repeat": true},
+			OccurredAt: nowAt,
+		}); err != nil {
+			return err
+		}
+		state.LastAlertAt = nowAt
 	}
 	return s.storeDependencyStatusState(state, nowAt)
 }
 
 func (s *Server) loadDependencyStatusState(id string) (dependencyStatusState, bool, error) {
 	var state dependencyStatusState
-	var since int64
-	err := s.db.QueryRow(`SELECT id, status, message, since, notified_status FROM dependency_status_state WHERE id=?`, id).
-		Scan(&state.ID, &state.Status, &state.Message, &since, &state.NotifiedStatus)
+	var since, lastChecked, lastAlert int64
+	err := s.db.QueryRow(`SELECT id, status, message, since, notified_status, last_checked_at, last_alert_at FROM dependency_status_state WHERE id=?`, id).
+		Scan(&state.ID, &state.Status, &state.Message, &since, &state.NotifiedStatus, &lastChecked, &lastAlert)
 	if err == sql.ErrNoRows {
 		return dependencyStatusState{}, false, nil
 	}
@@ -163,14 +220,18 @@ func (s *Server) loadDependencyStatusState(id string) (dependencyStatusState, bo
 		return dependencyStatusState{}, false, fmt.Errorf("load state: %w", err)
 	}
 	state.Since = timeFromEpochMillis(since)
+	state.LastCheckedAt = timeFromEpochMillis(lastChecked)
+	state.LastAlertAt = timeFromEpochMillis(lastAlert)
 	return state, true, nil
 }
 
 func (s *Server) storeDependencyStatusState(state dependencyStatusState, nowAt time.Time) error {
-	_, err := s.db.Exec(`INSERT INTO dependency_status_state(id, status, message, since, notified_status, updated_at)
-		VALUES(?,?,?,?,?,?) ON CONFLICT(id) DO UPDATE SET status=excluded.status, message=excluded.message,
-		since=excluded.since, notified_status=excluded.notified_status, updated_at=excluded.updated_at`,
-		state.ID, state.Status, state.Message, epochMillisOrZero(state.Since), state.NotifiedStatus, epochMillis(nowAt))
+	_, err := s.db.Exec(`INSERT INTO dependency_status_state(id, status, message, since, notified_status, last_checked_at, last_alert_at, updated_at)
+		VALUES(?,?,?,?,?,?,?,?) ON CONFLICT(id) DO UPDATE SET status=excluded.status, message=excluded.message,
+		since=excluded.since, notified_status=excluded.notified_status, last_checked_at=excluded.last_checked_at,
+		last_alert_at=excluded.last_alert_at, updated_at=excluded.updated_at`,
+		state.ID, state.Status, state.Message, epochMillisOrZero(state.Since), state.NotifiedStatus,
+		epochMillisOrZero(state.LastCheckedAt), epochMillisOrZero(state.LastAlertAt), epochMillis(nowAt))
 	if err != nil {
 		return fmt.Errorf("store state: %w", err)
 	}

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -1370,6 +1370,20 @@ func (s *Server) checkNotifications(cfg *types.HubConfig) []DoctorCheck {
 		}
 	}
 
+	// Provider caps used to page through the lifecycle agent_idle event. They
+	// are infrastructure events now, and a hub configured before that change
+	// routes agent_idle somewhere but provider caps nowhere: the claws park,
+	// the dashboard shows the badge, and nobody is paged. That is exactly the
+	// silence the old route existed to break, so it is said here rather than
+	// discovered during the next cap.
+	if lifecycleRoutesAgentIdle(nCfg.Lifecycle) && !infraRoutesProviderLimits(nCfg.Infra) {
+		checks = append(checks, DoctorCheck{
+			Category: "notifications", Severity: "critical", OK: false,
+			Title:       "Provider cap alerts have no route",
+			Description: "Lifecycle alerts route agent_idle, but a provider usage limit no longer fires it: caps are infrastructure events (provider_limit_opened, provider_limit_exhausted, provider_limit_released) and no infrastructure route receives them. A capped provider account parks its claws without paging anyone until notifications.infra has a route for those events.",
+		})
+	}
+
 	// Scheduled reports. A disabled schedule delivers nothing, so its report
 	// and destination checks are skipped: an operator who pauses a schedule
 	// before deleting the notifier (or before upgrading to a build that
@@ -1681,4 +1695,46 @@ func (s *Server) checkHubSettings(cfg *types.HubConfig) []DoctorCheck {
 	}
 
 	return checks
+}
+
+// lifecycleRoutesAgentIdle reports whether an enabled lifecycle block would
+// deliver agent_idle: some route carries it (or receives everything) and the
+// per-event toggle has not muted it.
+func lifecycleRoutesAgentIdle(lc *types.LifecycleNotificationsConfig) bool {
+	if !lc.IsEnabled() {
+		return false
+	}
+	if lc.Events != nil && lc.Events.AgentIdle != nil && !*lc.Events.AgentIdle {
+		return false
+	}
+	for _, route := range lc.EffectiveRoutes() {
+		if len(route.Events) == 0 {
+			return true
+		}
+		for _, event := range route.Events {
+			if event == taskRunEventAgentIdle {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// infraRoutesProviderLimits reports whether an enabled infra block delivers
+// at least one provider_limit_* event somewhere.
+func infraRoutesProviderLimits(ic *types.InfraNotificationsConfig) bool {
+	if !ic.IsEnabled() {
+		return false
+	}
+	for _, route := range ic.Routes {
+		if len(route.Events) == 0 {
+			return true
+		}
+		for _, event := range route.Events {
+			if strings.HasPrefix(event, "provider_limit_") {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -1250,6 +1250,9 @@ func (s *Server) checkNotifications(cfg *types.HubConfig) []DoctorCheck {
 			Error:       err.Error(),
 		})
 	}
+	if err := types.ValidateInfraNotificationsConfig(nCfg); err != nil {
+		checks = append(checks, DoctorCheck{Category: "notifications", Severity: "critical", Title: "Infrastructure notifications config invalid", Description: "No infrastructure notifications will be delivered until this is fixed in hub.yaml.", OK: false, Error: err.Error()})
+	}
 
 	secrets := func(name string) (string, bool) {
 		v, ok := cfg.Secrets[name]
@@ -1339,6 +1342,31 @@ func (s *Server) checkNotifications(cfg *types.HubConfig) []DoctorCheck {
 				Title:       label + " is configured",
 				Description: fmt.Sprintf("Notifier %q constructed successfully and has a channel.", via),
 			})
+		}
+	}
+
+	// Infrastructure routes are global hub alerts, so their secrets resolve in
+	// the hub scope just like lifecycle routes. Check each destination here:
+	// passing structural validation alone cannot prove a real outage can post.
+	if nCfg.Infra.IsEnabled() {
+		for i, route := range nCfg.Infra.Routes {
+			via := strings.TrimSpace(route.Via)
+			label := fmt.Sprintf("Infrastructure route %d (%q)", i+1, via)
+			nc, ok := nCfg.Notifiers[via]
+			if via == "" || !ok {
+				checks = append(checks, DoctorCheck{Category: "notifications", Severity: "critical", OK: false, Title: label + " names an unknown notifier", Description: "This infrastructure route will not deliver messages until its via names a configured notifier."})
+				continue
+			}
+			channel, _ := s.notifierSettings(nc)["channel"].(string)
+			if strings.TrimSpace(channel) == "" {
+				checks = append(checks, DoctorCheck{Category: "notifications", Severity: "critical", OK: false, Title: label + " has no channel", Description: fmt.Sprintf("Notifier %q needs a channel for this infrastructure route.", via)})
+				continue
+			}
+			if _, err := notify.New(nc.Type, s.notifierSettings(nc), secrets); err != nil {
+				checks = append(checks, DoctorCheck{Category: "notifications", Severity: "critical", OK: false, Title: label + " is not constructible", Description: fmt.Sprintf("Infrastructure alerts through notifier %q will not be delivered.", via), Error: err.Error()})
+				continue
+			}
+			checks = append(checks, DoctorCheck{Category: "notifications", Severity: "info", OK: true, Title: label + " is configured", Description: fmt.Sprintf("Notifier %q constructed successfully and has a channel.", via)})
 		}
 	}
 

--- a/pkg/hub/doctor.go
+++ b/pkg/hub/doctor.go
@@ -127,6 +127,7 @@ func (s *Server) runDoctorChecks(ctx context.Context) DoctorResponse {
 	// --- Notifications ---
 	checks = append(checks, s.checkNotifications(hubCfg)...)
 	checks = append(checks, s.checkNotifyActions(hubCfg)...)
+	checks = append(checks, s.checkInfraDeliveries(ctx)...)
 
 	// --- Hub Settings ---
 	checks = append(checks, s.checkHubSettings(hubCfg)...)

--- a/pkg/hub/doctor_runtime.go
+++ b/pkg/hub/doctor_runtime.go
@@ -91,3 +91,46 @@ func runtimeQueryErrorCheck(title string, err error) DoctorCheck {
 		OK:          false,
 	}
 }
+
+// infraDeliveryFailureWindow bounds how far back Doctor looks for discarded
+// infrastructure alerts. A week outlives any on-call rotation that could
+// have missed the outage, and older drops are no longer actionable.
+const infraDeliveryFailureWindow = 7 * 24 * time.Hour
+
+// checkInfraDeliveries surfaces infrastructure alerts a route gave up on. The
+// transient-failure cap discards an alert after infraMaxTransientFailures
+// consecutive send failures so one poisoned send cannot wedge the route, and
+// nothing else in the product shows that it happened: the channel simply
+// never hears about the outage. Doctor is where that gap becomes visible.
+func (s *Server) checkInfraDeliveries(ctx context.Context) []DoctorCheck {
+	if s.db == nil {
+		return nil
+	}
+	current := now()
+	if s.nowFunc != nil {
+		current = s.nowFunc()
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT notifier, COUNT(*), MAX(delivered_at) FROM infra_notification_deliveries
+		WHERE status=? AND delivered_at>=? GROUP BY notifier ORDER BY notifier`,
+		notificationDeliveryStatusFailed, epochMillis(current.Add(-infraDeliveryFailureWindow)))
+	if err != nil {
+		return []DoctorCheck{runtimeQueryErrorCheck("Dropped infrastructure alerts", err)}
+	}
+	defer rows.Close()
+	var checks []DoctorCheck
+	for rows.Next() {
+		var via string
+		var count int
+		var latest int64
+		if err := rows.Scan(&via, &count, &latest); err != nil {
+			return append(checks, runtimeQueryErrorCheck("Dropped infrastructure alerts", err))
+		}
+		checks = append(checks, DoctorCheck{
+			Category: "notifications", Severity: "warning", OK: false,
+			Title: fmt.Sprintf("Infrastructure route %q dropped %d alert(s) in the last 7 days", via, count),
+			Description: fmt.Sprintf("The hub gave up on each after %d consecutive failed send attempts, so the channel never received them; the latest was discarded at %s. Check the notifier and the hub log for [notify] errors.",
+				infraMaxTransientFailures, time.UnixMilli(latest).UTC().Format(time.RFC3339)),
+		})
+	}
+	return checks
+}

--- a/pkg/hub/doctor_runtime_test.go
+++ b/pkg/hub/doctor_runtime_test.go
@@ -87,3 +87,37 @@ func hasFailedRuntimeCheck(checks []DoctorCheck, title string) bool {
 	}
 	return false
 }
+
+// Alerts a route discarded at the transient-failure cap have no other
+// operator-visible trace, so Doctor lists them per route for a week.
+func TestCheckInfraDeliveriesSurfacesDroppedAlerts(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{}, "", "", "")
+	current := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+	s.nowFunc = func() time.Time { return current }
+	if checks := s.checkInfraDeliveries(context.Background()); len(checks) != 0 {
+		t.Fatalf("clean table produced checks: %#v", checks)
+	}
+	for _, row := range []struct {
+		rowid  int64
+		via    string
+		status string
+		at     time.Time
+	}{
+		{1, "ops", notificationDeliveryStatusFailed, current.Add(-time.Hour)},
+		{2, "ops", notificationDeliveryStatusFailed, current.Add(-2 * time.Hour)},
+		{3, "ops", notificationDeliveryStatusSent, current.Add(-time.Hour)},
+		{4, "oncall", notificationDeliveryStatusFailed, current.Add(-8 * 24 * time.Hour)},
+	} {
+		if _, err := db.Exec(`INSERT INTO infra_notification_deliveries(event_rowid,notifier,delivered_at,status) VALUES(?,?,?,?)`, row.rowid, row.via, epochMillis(row.at), row.status); err != nil {
+			t.Fatal(err)
+		}
+	}
+	checks := s.checkInfraDeliveries(context.Background())
+	if len(checks) != 1 {
+		t.Fatalf("checks = %#v, want one for ops only (oncall's drop is older than the window)", checks)
+	}
+	c := checks[0]
+	if c.OK || c.Severity != "warning" || c.Title != `Infrastructure route "ops" dropped 2 alert(s) in the last 7 days` || !strings.Contains(c.Description, current.Add(-time.Hour).Format(time.RFC3339)) {
+		t.Fatalf("unexpected check: %#v", c)
+	}
+}

--- a/pkg/hub/doctor_test.go
+++ b/pkg/hub/doctor_test.go
@@ -483,3 +483,61 @@ func TestCheckNotifyActionsAllValid(t *testing.T) {
 		t.Fatalf("got %#v, want one passing summary check", checks)
 	}
 }
+
+// Provider caps moved from the lifecycle agent_idle event to infra events. A
+// lifecycle-only configuration that used to page on a cap now pages nobody,
+// and Doctor has to say so; any infra route carrying provider_limit_* (or
+// receiving everything) closes the gap, and a muted agent_idle never had it.
+func TestCheckNotificationsFlagsUnroutedProviderCaps(t *testing.T) {
+	s := &Server{}
+	const title = "Provider cap alerts have no route"
+	has := func(cfg *types.HubConfig) bool {
+		for _, check := range s.checkNotifications(cfg) {
+			if check.Title == title {
+				if check.OK || check.Severity != "critical" {
+					t.Fatalf("unrouted provider caps must be a failing critical check: %#v", check)
+				}
+				return true
+			}
+		}
+		return false
+	}
+	notifiers := map[string]types.NotifierConfig{"ops": {Type: "slack", Settings: map[string]any{"token_secret": "token", "channel": "C0123ABCD"}}}
+	lifecycle := func(events []string) *types.LifecycleNotificationsConfig {
+		return &types.LifecycleNotificationsConfig{Routes: []types.LifecycleRoute{{Via: "ops", Events: events}}}
+	}
+	hub := func(lc *types.LifecycleNotificationsConfig, ic *types.InfraNotificationsConfig) *types.HubConfig {
+		return &types.HubConfig{Secrets: map[string]string{"token": "xoxb-test"}, Notifications: &types.NotificationsConfig{Notifiers: notifiers, Lifecycle: lc, Infra: ic}}
+	}
+	off := false
+
+	if !has(hub(lifecycle(nil), nil)) {
+		t.Fatal("lifecycle receive-all with no infra block was not flagged")
+	}
+	if !has(hub(lifecycle([]string{"agent_idle"}), &types.InfraNotificationsConfig{Enabled: &off, Routes: []types.InfraRoute{{Via: "ops"}}})) {
+		t.Fatal("agent_idle route with a disabled infra block was not flagged")
+	}
+	if !has(hub(lifecycle([]string{"agent_idle"}), &types.InfraNotificationsConfig{Routes: []types.InfraRoute{{Via: "ops", Events: []string{"dependency_down"}}}})) {
+		t.Fatal("infra route without provider_limit_* events was not flagged")
+	}
+	if has(hub(lifecycle([]string{"agent_idle"}), &types.InfraNotificationsConfig{Routes: []types.InfraRoute{{Via: "ops", Events: []string{"provider_limit_opened"}}}})) {
+		t.Fatal("a provider_limit_* infra route was flagged")
+	}
+	if has(hub(lifecycle([]string{"agent_idle"}), &types.InfraNotificationsConfig{Routes: []types.InfraRoute{{Via: "ops"}}})) {
+		t.Fatal("a receive-all infra route was flagged")
+	}
+	if has(hub(lifecycle([]string{"pr_opened"}), nil)) {
+		t.Fatal("a lifecycle route that never carried agent_idle was flagged")
+	}
+	muted := lifecycle(nil)
+	muted.Events = &types.LifecycleEventToggles{AgentIdle: &off}
+	if has(hub(muted, nil)) {
+		t.Fatal("a muted agent_idle was flagged")
+	}
+	if has(hub(&types.LifecycleNotificationsConfig{Enabled: &off, Via: "ops"}, nil)) {
+		t.Fatal("a disabled lifecycle block was flagged")
+	}
+	if has(hub(nil, nil)) {
+		t.Fatal("no lifecycle block was flagged")
+	}
+}

--- a/pkg/hub/infra_events.go
+++ b/pkg/hub/infra_events.go
@@ -1,0 +1,44 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// infraEvent is the durable, fleet-wide counterpart to a task-run event.
+// EventKey is supplied by the producer because it names the real-world edge
+// and lets a retry after a crash safely repeat the insert.
+type infraEvent struct {
+	EventKey   string
+	EventType  string
+	Subject    string
+	Detail     map[string]any
+	OccurredAt time.Time
+}
+
+func (s *Server) recordInfraEvent(event infraEvent) error {
+	if !types.IsInfraEventType(event.EventType) {
+		return fmt.Errorf("unsupported infra event type %q", event.EventType)
+	}
+	detail, err := json.Marshal(event.Detail)
+	if err != nil {
+		return fmt.Errorf("marshal infra event detail: %w", err)
+	}
+	if event.OccurredAt.IsZero() {
+		if s.nowFunc != nil {
+			event.OccurredAt = s.nowFunc()
+		} else {
+			event.OccurredAt = now()
+		}
+	}
+	_, err = s.db.Exec(`INSERT INTO infra_events(event_key, event_type, subject, detail, occurred_at)
+		VALUES(?,?,?,?,?) ON CONFLICT(event_key) DO NOTHING`,
+		event.EventKey, event.EventType, event.Subject, string(detail), epochMillis(event.OccurredAt))
+	if err != nil {
+		return fmt.Errorf("insert infra event: %w", err)
+	}
+	return nil
+}

--- a/pkg/hub/infra_events.go
+++ b/pkg/hub/infra_events.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/types"
@@ -19,9 +20,47 @@ type infraEvent struct {
 	OccurredAt time.Time
 }
 
+// infraEventSecretPatterns match credential-shaped substrings a message
+// quoted from outside — a provider's 429 body, a vendor status page — may
+// carry into infra_events and from there into every routed channel. The
+// redaction lives here, at the one boundary every producer writes through,
+// rather than in the producer that first needed it. Over-redaction is the
+// safe failure mode: nothing in an outage or billing-cap message needs a
+// 28-char opaque string to be actionable.
+var infraEventSecretPatterns = []*regexp.Regexp{
+	// Provider API keys: sk-..., sk-ant-..., sk-proj-... and friends.
+	regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{8,}`),
+	// An echoed Authorization header: whatever follows "Bearer" on the same
+	// line is the credential, however short or oddly spelled, quotes
+	// included. Only horizontal whitespace may separate the two — a header
+	// block's next line is a different header, not the token.
+	regexp.MustCompile(`(?i)\bbearer[ \t]+(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s;,'"]+)`),
+	// Any long opaque run that reads as a credential, not prose.
+	regexp.MustCompile(`[A-Za-z0-9_-]{28,}`),
+}
+
+func redactInfraEventMessage(message string) string {
+	for _, pattern := range infraEventSecretPatterns {
+		message = pattern.ReplaceAllString(message, "[redacted]")
+	}
+	return message
+}
+
 func (s *Server) recordInfraEvent(event infraEvent) error {
 	if !types.IsInfraEventType(event.EventType) {
 		return fmt.Errorf("unsupported infra event type %q", event.EventType)
+	}
+	// The message is the one detail field quoted from outside the hub, and
+	// buildInfraMessage forwards it verbatim; redact it for every producer
+	// here rather than trusting each to remember. Copied, not mutated: the
+	// caller's map is its own.
+	if message, ok := event.Detail["message"].(string); ok {
+		copied := make(map[string]any, len(event.Detail))
+		for key, value := range event.Detail {
+			copied[key] = value
+		}
+		copied["message"] = redactInfraEventMessage(message)
+		event.Detail = copied
 	}
 	detail, err := json.Marshal(event.Detail)
 	if err != nil {

--- a/pkg/hub/infra_events_test.go
+++ b/pkg/hub/infra_events_test.go
@@ -219,3 +219,47 @@ func TestLLMUsageLimitInfraEventsArePerKeyAndSecretSafe(t *testing.T) {
 		t.Fatalf("events after exhaustion = %v", got)
 	}
 }
+
+// A real outage alert must carry the human status page the message tells the
+// reader to watch, derived from the endpoint the checker polled.
+func TestDependencyWatcherEventsCarryTheStatusPage(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	bad := DependencyStatus{ID: "model:anthropic", Name: "Anthropic", Status: dependencyStatusDowntime, Message: "down", Source: "https://status.anthropic.com/api/v2/status.json"}
+	for i := 0; i < 2; i++ {
+		if err := s.observeDependencyStatus(bad, base.Add(time.Duration(i)*time.Minute), 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	good := bad
+	good.Status, good.Message = dependencyStatusOperational, "ok"
+	if err := s.observeDependencyStatus(good, base.Add(2*time.Minute), 0); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := s.db.Query(`SELECT event_type, detail FROM infra_events ORDER BY rowid`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var seen int
+	for rows.Next() {
+		var eventType, raw string
+		if err := rows.Scan(&eventType, &raw); err != nil {
+			t.Fatal(err)
+		}
+		var detail map[string]any
+		if err := json.Unmarshal([]byte(raw), &detail); err != nil {
+			t.Fatal(err)
+		}
+		if detail["status_page"] != "https://status.anthropic.com" {
+			t.Fatalf("%s status_page = %v, want the vendor page", eventType, detail["status_page"])
+		}
+		seen++
+	}
+	if seen != 2 {
+		t.Fatalf("recorded %d events, want down + recovered", seen)
+	}
+	if got := dependencyStatusPage("hub"); got != "" {
+		t.Fatalf("non-URL source produced a status page %q", got)
+	}
+}

--- a/pkg/hub/infra_events_test.go
+++ b/pkg/hub/infra_events_test.go
@@ -269,3 +269,41 @@ func TestDependencyWatcherEventsCarryTheStatusPage(t *testing.T) {
 		t.Fatalf("non-URL source produced a status page %q", got)
 	}
 }
+
+// Redaction is a property of the event store, not of one producer: a vendor
+// status page that echoes a credential reaches infra_events through the
+// dependency watcher, which never knew about the LLM-limit patterns.
+func TestRecordInfraEventRedactsSecretsFromEveryProducer(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	const token = "sk-ant-api03-Fak3Tok3nFak3Tok3nFak3"
+	bad := DependencyStatus{ID: "model:anthropic", Name: "Anthropic", Status: dependencyStatusDowntime,
+		Message: "gateway rejected Authorization: Bearer " + token + " during the incident", Source: "https://status.anthropic.com/api/v2/status.json"}
+	for i := 0; i < 2; i++ {
+		if err := s.observeDependencyStatus(bad, base.Add(time.Duration(i)*time.Minute), 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var raw string
+	if err := s.db.QueryRow(`SELECT detail FROM infra_events WHERE event_type='dependency_down'`).Scan(&raw); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(raw, token) {
+		t.Fatalf("status-page text carried a credential into infra_events: %s", raw)
+	}
+	var detail map[string]any
+	if err := json.Unmarshal([]byte(raw), &detail); err != nil {
+		t.Fatal(err)
+	}
+	if msg, _ := detail["message"].(string); !strings.Contains(msg, "during the incident") {
+		t.Fatalf("redaction mangled the prose around the credential: %q", msg)
+	}
+	// The producer's own map is left alone.
+	original := map[string]any{"message": "Bearer " + token}
+	if err := s.recordInfraEvent(infraEvent{EventKey: "redact-copy", EventType: "dependency_down", Subject: "x", Detail: original, OccurredAt: base}); err != nil {
+		t.Fatal(err)
+	}
+	if original["message"] != "Bearer "+token {
+		t.Fatalf("recordInfraEvent mutated the caller's detail map: %v", original)
+	}
+}

--- a/pkg/hub/infra_events_test.go
+++ b/pkg/hub/infra_events_test.go
@@ -1,0 +1,129 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+func infraEventTypes(t *testing.T, s *Server) []string {
+	t.Helper()
+	rows, err := s.db.Query(`SELECT event_type FROM infra_events ORDER BY rowid`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var eventType string
+		if err := rows.Scan(&eventType); err != nil {
+			t.Fatal(err)
+		}
+		out = append(out, eventType)
+	}
+	return out
+}
+
+func TestDependencyWatcherDebounceAndUnknown(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	bad := DependencyStatus{ID: "model:test", Name: "Test", Status: dependencyStatusDowntime, Message: "down"}
+	if err := s.observeDependencyStatus(bad, base); err != nil {
+		t.Fatal(err)
+	}
+	if got := infraEventTypes(t, s); len(got) != 0 {
+		t.Fatalf("single bad check emitted %v", got)
+	}
+	var sinceBefore int64
+	if err := s.db.QueryRow(`SELECT since FROM dependency_status_state WHERE id='model:test'`).Scan(&sinceBefore); err != nil {
+		t.Fatal(err)
+	}
+	s.nowFunc = func() time.Time { return base.Add(30 * time.Second) }
+	s.dependencyStatus.mu.Lock()
+	s.dependencyStatus.cache = &DependencyStatusResponse{Dependencies: []DependencyStatus{{ID: "model:test", Status: dependencyStatusUnknown}}, CheckedAt: now()}
+	s.dependencyStatus.mu.Unlock()
+	s.dependencyWatcherTick(t.Context(), base.Add(30*time.Second))
+	var sinceAfter int64
+	if err := s.db.QueryRow(`SELECT since FROM dependency_status_state WHERE id='model:test'`).Scan(&sinceAfter); err != nil {
+		t.Fatal(err)
+	}
+	if sinceBefore != sinceAfter {
+		t.Fatalf("unknown reset since: %d -> %d", sinceBefore, sinceAfter)
+	}
+	if got := infraEventTypes(t, s); len(got) != 0 {
+		t.Fatalf("unknown emitted %v", got)
+	}
+	if err := s.observeDependencyStatus(bad, base.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if got := infraEventTypes(t, s); strings.Join(got, ",") != "dependency_down" {
+		t.Fatalf("events = %v, want dependency_down", got)
+	}
+}
+
+func TestDependencyWatcherRecoveryDoesNotReAlertAfterRestart(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	bad := DependencyStatus{ID: "model:test", Name: "Test", Status: dependencyStatusDowntime}
+	for _, at := range []time.Time{base, base.Add(time.Minute)} {
+		if err := s.observeDependencyStatus(bad, at); err != nil {
+			t.Fatal(err)
+		}
+	}
+	good := DependencyStatus{ID: "model:test", Name: "Test", Status: dependencyStatusOperational}
+	if err := s.observeDependencyStatus(good, base.Add(2*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.observeDependencyStatus(good, base.Add(3*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if got := infraEventTypes(t, s); strings.Join(got, ",") != "dependency_down,dependency_recovered" {
+		t.Fatalf("events = %v", got)
+	}
+}
+
+func TestLLMUsageLimitInfraEventsArePerKeyAndSecretSafe(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	const key = "sk-this-must-never-appear"
+	for i := 0; i < 4; i++ {
+		limitClaw(t, s, fmt.Sprintf("shared-key-%d", i), key, false)
+	}
+	limit := types.LLMUsageLimit{Reason: types.LLMLimitUsage, RegainAt: now().Add(time.Hour), Message: "account " + key + " reached its allowance"}
+	for i := 0; i < 4; i++ {
+		s.handleLLMUsageLimit(nil, fmt.Sprintf("shared-key-%d", i), limit)
+	}
+	if got := infraEventTypes(t, s); strings.Join(got, ",") != "provider_limit_opened" {
+		t.Fatalf("events = %v", got)
+	}
+	var detail, eventKey string
+	if err := s.db.QueryRow(`SELECT detail, event_key FROM infra_events`).Scan(&detail, &eventKey); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(detail, key) || strings.Contains(eventKey, key) {
+		t.Fatalf("raw key leaked into event: key=%q detail=%q", eventKey, detail)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(detail), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["parked_claws"] != float64(4) {
+		t.Fatalf("parked_claws = %v, want 4", payload["parked_claws"])
+	}
+	s.releaseLLMUsageLimit(key, "test release", false)
+	if got := infraEventTypes(t, s); strings.Join(got, ",") != "provider_limit_opened,provider_limit_released" {
+		t.Fatalf("events after release = %v", got)
+	}
+	record, _ := s.loadLLMUsageLimit(key)
+	record.ReleasedAt, record.Retries = now(), llmLimitMaxAutoRetries-1
+	if err := s.storeLLMUsageLimit(record); err != nil {
+		t.Fatal(err)
+	}
+	s.handleLLMUsageLimit(nil, "shared-key-0", limit)
+	if got := infraEventTypes(t, s); strings.Join(got, ",") != "provider_limit_opened,provider_limit_released,provider_limit_exhausted" {
+		t.Fatalf("events after exhaustion = %v", got)
+	}
+}

--- a/pkg/hub/infra_events_test.go
+++ b/pkg/hub/infra_events_test.go
@@ -32,7 +32,7 @@ func TestDependencyWatcherDebounceAndUnknown(t *testing.T) {
 	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
 	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
 	bad := DependencyStatus{ID: "model:test", Name: "Test", Status: dependencyStatusDowntime, Message: "down"}
-	if err := s.observeDependencyStatus(bad, base); err != nil {
+	if err := s.observeDependencyStatus(bad, base, 0); err != nil {
 		t.Fatal(err)
 	}
 	if got := infraEventTypes(t, s); len(got) != 0 {
@@ -57,11 +57,97 @@ func TestDependencyWatcherDebounceAndUnknown(t *testing.T) {
 	if got := infraEventTypes(t, s); len(got) != 0 {
 		t.Fatalf("unknown emitted %v", got)
 	}
-	if err := s.observeDependencyStatus(bad, base.Add(time.Minute)); err != nil {
+	if err := s.observeDependencyStatus(bad, base.Add(time.Minute), 0); err != nil {
 		t.Fatal(err)
 	}
 	if got := infraEventTypes(t, s); strings.Join(got, ",") != "dependency_down" {
 		t.Fatalf("events = %v, want dependency_down", got)
+	}
+}
+
+// Regression: the snapshot cache lives five minutes while the watcher ticks
+// every one, so the SAME vendor-page fetch is re-served to consecutive ticks.
+// A re-served snapshot must not count as the second consecutive check the
+// debounce demands — otherwise one flapping observation pages the channel a
+// minute later all by itself.
+func TestDependencyWatcherCachedSnapshotDoesNotSatisfyDebounce(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	seed := func(checkedAt time.Time) {
+		s.dependencyStatus.mu.Lock()
+		s.dependencyStatus.cache = &DependencyStatusResponse{
+			Dependencies: []DependencyStatus{{ID: "model:test", Name: "Test", Status: dependencyStatusDowntime, Message: "down", CheckedAt: checkedAt}},
+			CheckedAt:    checkedAt,
+		}
+		s.dependencyStatus.mu.Unlock()
+	}
+	// CheckedAt must sit inside the cache TTL relative to the wall clock, or
+	// snapshotForWatcher would refresh over the network instead of re-serving.
+	checked := time.Now().UTC()
+	seed(checked)
+	s.dependencyWatcherTick(t.Context(), checked)
+	s.dependencyWatcherTick(t.Context(), checked.Add(time.Minute))
+	if got := infraEventTypes(t, s); len(got) != 0 {
+		t.Fatalf("two ticks over one cached fetch emitted %v; the debounce needs two distinct observations", got)
+	}
+	seed(checked.Add(time.Minute))
+	s.dependencyWatcherTick(t.Context(), checked.Add(2*time.Minute))
+	if got := infraEventTypes(t, s); strings.Join(got, ",") != "dependency_down" {
+		t.Fatalf("events after a genuinely new fetch = %v, want dependency_down", got)
+	}
+}
+
+// repeat_after re-alerts while a dependency is still degraded/down, once per
+// elapsed interval; zero (the default) never repeats, and recovery resets the
+// repeat clock.
+func TestDependencyWatcherRepeatAfterReAlerts(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	observe := func(at time.Time, repeatAfter time.Duration) {
+		t.Helper()
+		dep := DependencyStatus{ID: "model:test", Name: "Test", Status: dependencyStatusDowntime, Message: "down", CheckedAt: at}
+		if err := s.observeDependencyStatus(dep, at, repeatAfter); err != nil {
+			t.Fatal(err)
+		}
+	}
+	observe(base, time.Hour)
+	observe(base.Add(time.Minute), time.Hour)
+	if got := infraEventTypes(t, s); strings.Join(got, ",") != "dependency_down" {
+		t.Fatalf("events = %v, want dependency_down", got)
+	}
+	// Half an hour later the repeat is not yet due.
+	observe(base.Add(31*time.Minute), time.Hour)
+	if got := infraEventTypes(t, s); strings.Join(got, ",") != "dependency_down" {
+		t.Fatalf("events before repeat_after elapsed = %v", got)
+	}
+	// An hour past the first alert, the repeat fires under a fresh event key.
+	observe(base.Add(62*time.Minute), time.Hour)
+	if got := infraEventTypes(t, s); strings.Join(got, ",") != "dependency_down,dependency_down" {
+		t.Fatalf("events after repeat_after elapsed = %v", got)
+	}
+	// The default (zero) never repeats, no matter how stale the last alert is.
+	observe(base.Add(5*time.Hour), 0)
+	if got := infraEventTypes(t, s); strings.Join(got, ",") != "dependency_down,dependency_down" {
+		t.Fatalf("repeat fired with repeat_after unset: %v", got)
+	}
+	good := DependencyStatus{ID: "model:test", Name: "Test", Status: dependencyStatusOperational, CheckedAt: base.Add(6 * time.Hour)}
+	if err := s.observeDependencyStatus(good, base.Add(6*time.Hour), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if got := infraEventTypes(t, s); strings.Join(got, ",") != "dependency_down,dependency_down,dependency_recovered" {
+		t.Fatalf("events after recovery = %v", got)
+	}
+}
+
+func TestInfraRepeatAfterConfig(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Infra: &types.InfraNotificationsConfig{RepeatAfter: "45m"},
+	}}, "", "", "")
+	if got := s.infraRepeatAfter(); got != 45*time.Minute {
+		t.Fatalf("infraRepeatAfter = %v, want 45m", got)
+	}
+	s.hubCfg.Notifications.Infra.RepeatAfter = ""
+	if got := s.infraRepeatAfter(); got != 0 {
+		t.Fatalf("empty repeat_after = %v, want 0 (off)", got)
 	}
 }
 
@@ -70,15 +156,15 @@ func TestDependencyWatcherRecoveryDoesNotReAlertAfterRestart(t *testing.T) {
 	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
 	bad := DependencyStatus{ID: "model:test", Name: "Test", Status: dependencyStatusDowntime}
 	for _, at := range []time.Time{base, base.Add(time.Minute)} {
-		if err := s.observeDependencyStatus(bad, at); err != nil {
+		if err := s.observeDependencyStatus(bad, at, 0); err != nil {
 			t.Fatal(err)
 		}
 	}
 	good := DependencyStatus{ID: "model:test", Name: "Test", Status: dependencyStatusOperational}
-	if err := s.observeDependencyStatus(good, base.Add(2*time.Minute)); err != nil {
+	if err := s.observeDependencyStatus(good, base.Add(2*time.Minute), 0); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.observeDependencyStatus(good, base.Add(3*time.Minute)); err != nil {
+	if err := s.observeDependencyStatus(good, base.Add(3*time.Minute), 0); err != nil {
 		t.Fatal(err)
 	}
 	if got := infraEventTypes(t, s); strings.Join(got, ",") != "dependency_down,dependency_recovered" {
@@ -92,7 +178,10 @@ func TestLLMUsageLimitInfraEventsArePerKeyAndSecretSafe(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		limitClaw(t, s, fmt.Sprintf("shared-key-%d", i), key, false)
 	}
-	limit := types.LLMUsageLimit{Reason: types.LLMLimitUsage, RegainAt: now().Add(time.Hour), Message: "account " + key + " reached its allowance"}
+	// The provider message quotes a raw token UNRELATED to the configured key
+	// id: literal key-id substitution alone would wave it straight through.
+	const rawToken = "sk-ant-api03-Fak3Tok3nFak3Tok3nFak3"
+	limit := types.LLMUsageLimit{Reason: types.LLMLimitUsage, RegainAt: now().Add(time.Hour), Message: "account " + key + " reached its allowance; rejected credential " + rawToken}
 	for i := 0; i < 4; i++ {
 		s.handleLLMUsageLimit(nil, fmt.Sprintf("shared-key-%d", i), limit)
 	}
@@ -105,6 +194,9 @@ func TestLLMUsageLimitInfraEventsArePerKeyAndSecretSafe(t *testing.T) {
 	}
 	if strings.Contains(detail, key) || strings.Contains(eventKey, key) {
 		t.Fatalf("raw key leaked into event: key=%q detail=%q", eventKey, detail)
+	}
+	if strings.Contains(detail, rawToken) {
+		t.Fatalf("raw provider token leaked into event detail: %q", detail)
 	}
 	var payload map[string]any
 	if err := json.Unmarshal([]byte(detail), &payload); err != nil {

--- a/pkg/hub/infra_events_test.go
+++ b/pkg/hub/infra_events_test.go
@@ -205,9 +205,15 @@ func TestLLMUsageLimitInfraEventsArePerKeyAndSecretSafe(t *testing.T) {
 	if payload["parked_claws"] != float64(4) {
 		t.Fatalf("parked_claws = %v, want 4", payload["parked_claws"])
 	}
+	// A scheduled release is a probe; the lift is announced once a claw on
+	// the key proves it with an authored turn.
 	s.releaseLLMUsageLimit(key, "test release", false)
+	if got := infraEventTypes(t, s); strings.Join(got, ",") != "provider_limit_opened" {
+		t.Fatalf("events after an unproven release = %v", got)
+	}
+	s.observeTurnOutcome(nil, "shared-key-0", "msg-proof", "Back to work.")
 	if got := infraEventTypes(t, s); strings.Join(got, ",") != "provider_limit_opened,provider_limit_released" {
-		t.Fatalf("events after release = %v", got)
+		t.Fatalf("events after the proving turn = %v", got)
 	}
 	record, _ := s.loadLLMUsageLimit(key)
 	record.ReleasedAt, record.Retries = now(), llmLimitMaxAutoRetries-1

--- a/pkg/hub/infra_notifier.go
+++ b/pkg/hub/infra_notifier.go
@@ -436,6 +436,7 @@ func buildInfraMessage(e infraEventRow, _ time.Time) notify.Message {
 		subject = e.Subject
 	}
 	retry := stringValue(e.Detail, "retry_count")
+	quoteMessage := true
 	var body string
 	switch e.EventType {
 	case "dependency_recovered":
@@ -452,10 +453,15 @@ func buildInfraMessage(e infraEventRow, _ time.Time) notify.Message {
 		body = "Automatic retries are exhausted; the hub will not retry on its own. Raise the cap in the provider's billing console, then clear the block (a parked claw's page, or DELETE /api/claws/{id}/llm-limit) to resume."
 	case "provider_limit_released":
 		body = "Provider access has recovered; the parked claws resumed on their own."
+		// Deliberately no provider message below: the only text the record
+		// carries is the rejection that opened the episode, and quoting "you
+		// have reached your usage limits" under "cap lifted" reads as a
+		// contradiction rather than as context.
+		quoteMessage = false
 	default:
 		body = "Wait for recovery and watch the dependency's status page."
 	}
-	if msg := strings.TrimSpace(stringValue(e.Detail, "message")); msg != "" {
+	if msg := strings.TrimSpace(stringValue(e.Detail, "message")); msg != "" && quoteMessage {
 		body += "\n" + msg
 	}
 	fields := []notify.Field{{Label: "Event", Value: strings.ReplaceAll(e.EventType, "_", " ")}}
@@ -465,6 +471,13 @@ func buildInfraMessage(e infraEventRow, _ time.Time) notify.Message {
 		fields = append(fields, notify.Field{Label: "Opening alert", Value: "not delivered"})
 	}
 	if strings.HasPrefix(e.EventType, "dependency_") {
+		// How long it was down is the first thing asked about a recovery, and
+		// the watcher has always recorded it — it just never reached anyone.
+		if e.EventType == "dependency_recovered" {
+			if down := formatOutageDuration(e.Detail); down != "" {
+				fields = append(fields, notify.Field{Label: "Down for", Value: down})
+			}
+		}
 		if statusPage := stringValue(e.Detail, "status_page"); statusPage != "" {
 			fields = append(fields, notify.Field{Label: "Status page", Value: statusPage})
 		}
@@ -492,6 +505,33 @@ func buildInfraMessage(e infraEventRow, _ time.Time) notify.Message {
 	}
 	fields = append(fields, notify.Field{Label: "Occurred", Value: e.OccurredAt.UTC().Format(time.RFC3339)})
 	return notify.Message{Emoji: style.emoji, Title: style.title, Severity: style.severity, Subject: subject, Body: body, Fields: fields, Summary: []string{style.title, subject}}
+}
+
+// formatOutageDuration renders duration_ms as the coarse, readable span an
+// operator reads at a glance ("1h 24m"), not a precise one: nobody acts on the
+// seconds of an outage, and the watcher's own resolution is a minute anyway.
+func formatOutageDuration(detail map[string]any) string {
+	ms := stringValue(detail, "duration_ms")
+	if ms == "" {
+		return ""
+	}
+	millis, err := strconv.ParseInt(ms, 10, 64)
+	if err != nil || millis <= 0 {
+		return ""
+	}
+	d := time.Duration(millis) * time.Millisecond
+	if d < time.Minute {
+		return "under a minute"
+	}
+	hours, minutes := int(d/time.Hour), int((d%time.Hour)/time.Minute)
+	switch {
+	case hours == 0:
+		return fmt.Sprintf("%dm", minutes)
+	case minutes == 0:
+		return fmt.Sprintf("%dh", hours)
+	default:
+		return fmt.Sprintf("%dh %dm", hours, minutes)
+	}
 }
 
 func stringValue(m map[string]any, key string) string {

--- a/pkg/hub/infra_notifier.go
+++ b/pkg/hub/infra_notifier.go
@@ -34,6 +34,39 @@ type infraEventRow struct {
 	OccurredAt         time.Time
 }
 
+// initInfraNotifierBaseline stamps every configured route's watermark at the
+// head of infra_events before any event producer starts, for the same reason
+// initLifecycleNotifierBaseline does: the producers (dependency watcher, LLM
+// limit latch) run unconditionally from boot, so a route whose cursor were
+// left at zero would replay the entire recorded history — weeks of resolved
+// outages — into its channel the first time it delivered. Only a missing
+// watermark is written; persisted cursors stay authoritative.
+func (s *Server) initInfraNotifierBaseline() {
+	cfg := s.notificationsConfig()
+	if cfg == nil || !cfg.Infra.IsEnabled() {
+		return
+	}
+	for _, route := range cfg.Infra.Routes {
+		via := strings.TrimSpace(route.Via)
+		if via == "" {
+			continue
+		}
+		if _, found, err := s.notifierStateInt64(infraWatermarkKey(via)); err == nil && !found {
+			if maxRow, err := s.infraMaxEventRowID(); err == nil {
+				s.setNotifierStateInt64(infraWatermarkKey(via), maxRow)
+			} else {
+				log.Printf("[notify] init infra watermark baseline for %q: %v", via, err)
+			}
+		}
+	}
+}
+
+func (s *Server) infraMaxEventRowID() (int64, error) {
+	var maxRow int64
+	err := s.db.QueryRow(`SELECT COALESCE(MAX(rowid),0) FROM infra_events`).Scan(&maxRow)
+	return maxRow, err
+}
+
 func (s *Server) startInfraNotifier() {
 	stop, done := make(chan struct{}), make(chan struct{})
 	s.infraNotifierStop, s.infraNotifierDone = stop, done
@@ -92,6 +125,7 @@ func (s *Server) infraNotifierTick(ctx context.Context, nowAt time.Time) {
 		return
 	}
 	s.clearPollWarning("infra-config")
+	s.flushPendingInfraDeliveries()
 	for _, route := range cfg.Infra.Routes {
 		via := strings.TrimSpace(route.Via)
 		n, err := s.notifierFor(via, cfg.Notifiers[via], s.hubSecretResolver())
@@ -107,9 +141,22 @@ func (s *Server) infraNotifierTick(ctx context.Context, nowAt time.Time) {
 }
 
 func (s *Server) deliverInfraRoute(ctx context.Context, nowAt time.Time, via string, route types.InfraRoute, n notify.Notifier) error {
-	watermark, _, err := s.notifierStateInt64(infraWatermarkKey(via))
+	watermark, found, err := s.notifierStateInt64(infraWatermarkKey(via))
 	if err != nil {
 		return err
+	}
+	if !found {
+		// A route seen for the first time (added at runtime, or enabled after
+		// the hub had already been recording events) starts at the head of the
+		// stream: everything before it existed is history, not news. The boot
+		// path stamps configured routes synchronously (initInfraNotifierBaseline);
+		// this is the backstop for runtime config changes.
+		maxRow, err := s.infraMaxEventRowID()
+		if err != nil {
+			return err
+		}
+		s.setNotifierStateInt64(infraWatermarkKey(via), maxRow)
+		return nil
 	}
 	// Collect the whole batch before issuing any further query on this
 	// connection: the test harness (and a modest deployment) runs SQLite
@@ -148,6 +195,12 @@ func (s *Server) deliverInfraRoute(ctx context.Context, nowAt time.Time, via str
 			s.setNotifierStateInt64(infraWatermarkKey(via), e.RowID)
 			continue
 		}
+		// A delivery whose bookkeeping row is still stashed in memory counts
+		// as delivered: the send already happened, only its record is owed.
+		if s.infraDeliveryPending(e.RowID, via) {
+			s.setNotifierStateInt64(infraWatermarkKey(via), e.RowID)
+			continue
+		}
 		var exists int
 		if err := s.db.QueryRow(`SELECT EXISTS(SELECT 1 FROM infra_notification_deliveries WHERE event_rowid=? AND notifier=?)`, e.RowID, via).Scan(&exists); err != nil {
 			return err
@@ -175,18 +228,65 @@ func (s *Server) deliverInfraRoute(ctx context.Context, nowAt time.Time, via str
 				}
 				s.clearNotifierState(infraFailureKey(e.RowID, via))
 			}
-			if _, err := s.db.Exec(`INSERT INTO infra_notification_deliveries(event_rowid,notifier,delivered_at,status) VALUES(?,?,?,?)`, e.RowID, via, epochMillis(nowAt), notificationDeliveryStatusFailed); err != nil {
-				return err
-			}
+			s.recordInfraDelivery(e.RowID, via, notificationDeliveryStatusFailed, nowAt)
 		} else {
 			s.clearNotifierState(infraFailureKey(e.RowID, via))
-			if _, err := s.db.Exec(`INSERT INTO infra_notification_deliveries(event_rowid,notifier,delivered_at,status) VALUES(?,?,?,?)`, e.RowID, via, epochMillis(nowAt), notificationDeliveryStatusSent); err != nil {
-				return err
-			}
+			s.recordInfraDelivery(e.RowID, via, notificationDeliveryStatusSent, nowAt)
 		}
 		s.setNotifierStateInt64(infraWatermarkKey(via), e.RowID)
 	}
 	return nil
+}
+
+// infraDeliveryKey identifies one stashed infra delivery row.
+type infraDeliveryKey struct {
+	rowid int64
+	via   string
+}
+
+// infraPendingDelivery is a delivery whose post-send bookkeeping write failed;
+// flushPendingInfraDeliveries retries it. While stashed, the (event, route)
+// pair still counts as delivered (see deliverInfraRoute): the send already
+// reached the channel, so retrying the SEND on a sick database would page the
+// same alert every tick — the lesson recordNotificationDelivery learned.
+type infraPendingDelivery struct {
+	status      string
+	deliveredAt time.Time
+}
+
+func (s *Server) infraDeliveryPending(rowid int64, via string) bool {
+	_, ok := s.infraPendingDeliveries[infraDeliveryKey{rowid: rowid, via: via}]
+	return ok
+}
+
+func (s *Server) recordInfraDelivery(rowid int64, via, status string, at time.Time) {
+	if err := s.execInfraDelivery(rowid, via, status, at); err != nil {
+		log.Printf("[notify] record infra delivery for event %d via %s (will retry): %v", rowid, via, err)
+		if s.infraPendingDeliveries == nil {
+			s.infraPendingDeliveries = make(map[infraDeliveryKey]infraPendingDelivery)
+		}
+		s.infraPendingDeliveries[infraDeliveryKey{rowid: rowid, via: via}] = infraPendingDelivery{status: status, deliveredAt: at}
+	}
+}
+
+func (s *Server) execInfraDelivery(rowid int64, via, status string, at time.Time) error {
+	_, err := s.db.Exec(`INSERT INTO infra_notification_deliveries(event_rowid,notifier,delivered_at,status) VALUES(?,?,?,?) ON CONFLICT(event_rowid,notifier) DO NOTHING`, rowid, via, epochMillis(at), status)
+	return err
+}
+
+// flushPendingInfraDeliveries retries delivery rows whose insert failed after
+// a successful send. Runs at the top of every tick so the stash drains as
+// soon as the database accepts writes again. Like the lifecycle stash, it
+// only closes the dedupe gap within one process lifetime — see
+// flushPendingNotificationDeliveries for why that window is accepted.
+func (s *Server) flushPendingInfraDeliveries() {
+	for key, p := range s.infraPendingDeliveries {
+		if err := s.execInfraDelivery(key.rowid, key.via, p.status, p.deliveredAt); err != nil {
+			log.Printf("[notify] retry infra delivery for event %d via %s: %v", key.rowid, key.via, err)
+			continue
+		}
+		delete(s.infraPendingDeliveries, key)
+	}
 }
 
 type infraEventStyle struct {
@@ -224,7 +324,7 @@ func buildInfraMessage(e infraEventRow, _ time.Time) notify.Message {
 			fields = append(fields, notify.Field{Label: "Status page", Value: statusPage})
 		}
 	} else if strings.HasPrefix(e.EventType, "provider_limit_") {
-		for _, field := range []struct{ label, key string }{{"Provider", "provider"}, {"Key", "key_id"}, {"Claws parked", "claws_parked"}, {"Deadline", "deadline"}} {
+		for _, field := range []struct{ label, key string }{{"Provider", "provider"}, {"Key", "key_id"}, {"Claws parked", "parked_claws"}, {"Deadline", "deadline"}} {
 			if value := stringValue(e.Detail, field.key); value != "" {
 				fields = append(fields, notify.Field{Label: field.label, Value: value})
 			}
@@ -245,6 +345,13 @@ func stringValue(m map[string]any, key string) string {
 		return v.String()
 	case float64:
 		return strconv.FormatFloat(v, 'f', -1, 64)
+	// Details straight from a producer (the test-send path) carry Go ints;
+	// details read back from the store arrive as float64 via json.Unmarshal.
+	// Both spellings of the same count must render.
+	case int:
+		return strconv.Itoa(v)
+	case int64:
+		return strconv.FormatInt(v, 10)
 	default:
 		return ""
 	}

--- a/pkg/hub/infra_notifier.go
+++ b/pkg/hub/infra_notifier.go
@@ -474,7 +474,10 @@ func buildInfraMessage(e infraEventRow, _ time.Time) notify.Message {
 		case "provider_limit_released":
 			labelled = append(labelled, struct{ label, key string }{"Claws resumed", "parked_claws"})
 		case "provider_limit_exhausted":
-			labelled = append(labelled, struct{ label, key string }{"Claws parked", "parked_claws"}, struct{ label, key string }{"Last retry", "deadline"})
+			// The last attempt the hub made, not the record's deadline: an
+			// exhausted latch is never auto-released, so its deadline is an
+			// instant nothing honours.
+			labelled = append(labelled, struct{ label, key string }{"Claws parked", "parked_claws"}, struct{ label, key string }{"Last retry", "last_retry"})
 		default:
 			labelled = append(labelled, struct{ label, key string }{"Claws parked", "parked_claws"}, struct{ label, key string }{"Deadline", "deadline"})
 			if retry != "" && retry != "0" {

--- a/pkg/hub/infra_notifier.go
+++ b/pkg/hub/infra_notifier.go
@@ -33,10 +33,14 @@ func infraFailureKey(rowid int64, via string) string {
 }
 
 type infraEventRow struct {
-	RowID              int64
-	EventType, Subject string
-	Detail             map[string]any
-	OccurredAt         time.Time
+	RowID                        int64
+	EventKey, EventType, Subject string
+	Detail                       map[string]any
+	OccurredAt                   time.Time
+	// MissedOpening marks a recovery whose opening alert this route
+	// discarded (see infraRouteMissedOpening); the message says so instead
+	// of celebrating the end of an incident the channel never heard of.
+	MissedOpening bool
 }
 
 // initInfraNotifierBaseline stamps every configured route's watermark at the
@@ -173,7 +177,7 @@ func (s *Server) deliverInfraRoute(ctx context.Context, nowAt time.Time, via str
 	// with a single pooled connection, so a query/exec nested inside these
 	// still-open rows would block forever waiting for a connection that
 	// only this same in-flight Query holds.
-	rows, err := s.db.Query(`SELECT rowid,event_type,subject,detail,occurred_at FROM infra_events WHERE rowid>? ORDER BY rowid LIMIT 200`, watermark)
+	rows, err := s.db.Query(`SELECT rowid,event_key,event_type,subject,detail,occurred_at FROM infra_events WHERE rowid>? ORDER BY rowid LIMIT 200`, watermark)
 	if err != nil {
 		return err
 	}
@@ -182,7 +186,7 @@ func (s *Server) deliverInfraRoute(ctx context.Context, nowAt time.Time, via str
 		var e infraEventRow
 		var raw string
 		var occurred int64
-		if err := rows.Scan(&e.RowID, &e.EventType, &e.Subject, &raw, &occurred); err != nil {
+		if err := rows.Scan(&e.RowID, &e.EventKey, &e.EventType, &e.Subject, &raw, &occurred); err != nil {
 			rows.Close()
 			return err
 		}
@@ -219,6 +223,11 @@ func (s *Server) deliverInfraRoute(ctx context.Context, nowAt time.Time, via str
 			s.setNotifierStateInt64(infraWatermarkKey(via), e.RowID)
 			continue
 		}
+		missed, err := s.infraRouteMissedOpening(e, via)
+		if err != nil {
+			return err
+		}
+		e.MissedOpening = missed
 		sendCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		_, sendErr := n.Send(sendCtx, buildInfraMessage(e, nowAt))
 		cancel()
@@ -246,6 +255,57 @@ func (s *Server) deliverInfraRoute(ctx context.Context, nowAt time.Time, via str
 		s.setNotifierStateInt64(infraWatermarkKey(via), e.RowID)
 	}
 	return nil
+}
+
+// infraOpeningKeyPatterns names the events that opened the incident a
+// recovery closes, as SQL LIKE patterns. The producers build recovery keys
+// from the same suffix as their openings — dependency_recovered:<id>:<since>
+// against dependency_down/degraded:<id>:<since> (plus their ":repeat:" keys),
+// provider_limit_released:<key>:<detected>:<retry> against every opened or
+// exhausted event of that episode — so the pairing needs no extra bookkeeping.
+func infraOpeningKeyPatterns(e infraEventRow) []string {
+	switch e.EventType {
+	case "dependency_recovered":
+		suffix := strings.TrimPrefix(e.EventKey, "dependency_recovered:")
+		return []string{"dependency_down:" + suffix, "dependency_down:" + suffix + ":%", "dependency_degraded:" + suffix, "dependency_degraded:" + suffix + ":%"}
+	case "provider_limit_released":
+		episode := strings.TrimPrefix(e.EventKey, "provider_limit_released:")
+		if i := strings.LastIndex(episode, ":"); i >= 0 {
+			episode = episode[:i]
+		}
+		return []string{"provider_limit_opened:" + episode + ":%", "provider_limit_exhausted:" + episode + ":%"}
+	}
+	return nil
+}
+
+// infraRouteMissedOpening reports whether this route discarded every opening
+// alert of the incident e closes. The transient-failure cap has to give up on
+// an alert eventually, or one poisoned send wedges the route forever; but
+// the recovery that follows must not then read as good news about an outage
+// the channel was never told of. An opening the route never saw at all (a
+// route baselined mid-incident) is history, not a dropped alert, and the
+// recovery stands on its own.
+func (s *Server) infraRouteMissedOpening(e infraEventRow, via string) (bool, error) {
+	patterns := infraOpeningKeyPatterns(e)
+	if len(patterns) == 0 {
+		return false, nil
+	}
+	clauses := make([]string, 0, len(patterns))
+	args := []any{via, e.RowID}
+	for _, pattern := range patterns {
+		clauses = append(clauses, "ev.event_key LIKE ?")
+		args = append(args, pattern)
+	}
+	var failed, sent int
+	err := s.db.QueryRow(`SELECT
+			COALESCE(SUM(d.status=?),0), COALESCE(SUM(d.status=?),0)
+		FROM infra_events ev JOIN infra_notification_deliveries d ON d.event_rowid=ev.rowid AND d.notifier=?
+		WHERE ev.rowid<? AND (`+strings.Join(clauses, " OR ")+`)`,
+		append([]any{notificationDeliveryStatusFailed, notificationDeliveryStatusSent}, args...)...).Scan(&failed, &sent)
+	if err != nil {
+		return false, err
+	}
+	return failed > 0 && sent == 0, nil
 }
 
 func infraConfiguredRoutes(ic *types.InfraNotificationsConfig) map[string]bool {
@@ -399,6 +459,11 @@ func buildInfraMessage(e infraEventRow, _ time.Time) notify.Message {
 		body += "\n" + msg
 	}
 	fields := []notify.Field{{Label: "Event", Value: strings.ReplaceAll(e.EventType, "_", " ")}}
+	if e.MissedOpening {
+		style.severity = notify.SeverityWarning
+		body = fmt.Sprintf("This channel never received the alert that opened this incident: the hub gave up delivering it after %d failed attempts. Check the notifier and the hub log for [notify] errors.\n%s", infraMaxTransientFailures, body)
+		fields = append(fields, notify.Field{Label: "Opening alert", Value: "not delivered"})
+	}
 	if strings.HasPrefix(e.EventType, "dependency_") {
 		if statusPage := stringValue(e.Detail, "status_page"); statusPage != "" {
 			fields = append(fields, notify.Field{Label: "Status page", Value: statusPage})

--- a/pkg/hub/infra_notifier.go
+++ b/pkg/hub/infra_notifier.go
@@ -1,0 +1,238 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/notify"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+const (
+	infraDefaultPollInterval  = time.Minute
+	infraMaxTransientFailures = 60
+)
+
+// Infra uses its own cursor because these events describe the fleet, not a
+// task run. A route that is temporarily broken must not make a healthy route
+// skip an outage it never received.
+func infraWatermarkKey(via string) string { return "infra_watermark_rowid:" + via }
+func infraFailureKey(rowid int64, via string) string {
+	return fmt.Sprintf("infra_transient:%s:%d", via, rowid)
+}
+
+type infraEventRow struct {
+	RowID              int64
+	EventType, Subject string
+	Detail             map[string]any
+	OccurredAt         time.Time
+}
+
+func (s *Server) startInfraNotifier() {
+	stop, done := make(chan struct{}), make(chan struct{})
+	s.infraNotifierStop, s.infraNotifierDone = stop, done
+	tickCtx, cancel := context.WithCancel(context.Background())
+	s.safeGo("infra notifier", func() {
+		defer close(done)
+		defer cancel()
+		go func() { <-stop; cancel() }()
+		for {
+			cfg := s.notificationsConfig()
+			interval := infraDefaultPollInterval
+			if cfg != nil && cfg.Infra != nil && cfg.Infra.PollInterval != "" {
+				if d, err := time.ParseDuration(cfg.Infra.PollInterval); err == nil && d > 0 {
+					interval = d
+				}
+			}
+			timer := time.NewTimer(interval)
+			select {
+			case <-stop:
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("[notify] infra notifier tick panic: %v\n%s", r, debug.Stack())
+					}
+				}()
+				s.infraNotifierTick(tickCtx, s.nowFunc())
+			}()
+		}
+	})
+}
+
+func (s *Server) stopInfraNotifier(timeout time.Duration) {
+	if s.infraNotifierStop == nil {
+		return
+	}
+	close(s.infraNotifierStop)
+	s.infraNotifierStop = nil
+	select {
+	case <-s.infraNotifierDone:
+	case <-time.After(timeout):
+		log.Printf("[notify] infra notifier tick still running after %v; shutting down anyway", timeout)
+	}
+}
+
+func (s *Server) infraNotifierTick(ctx context.Context, nowAt time.Time) {
+	cfg := s.notificationsConfig()
+	if cfg == nil || !cfg.Infra.IsEnabled() {
+		return
+	}
+	if err := types.ValidateInfraNotificationsConfig(cfg); err != nil {
+		s.logPollWarningOnce("infra-config", "[notify] invalid notifications config — infrastructure notifications paused: %v", err)
+		return
+	}
+	s.clearPollWarning("infra-config")
+	for _, route := range cfg.Infra.Routes {
+		via := strings.TrimSpace(route.Via)
+		n, err := s.notifierFor(via, cfg.Notifiers[via], s.hubSecretResolver())
+		if err != nil {
+			s.logPollWarningOnce("infra-notifier:"+via, "[notify] notifier %q unavailable — its infrastructure notifications are held until it can be built: %v", via, err)
+			continue
+		}
+		s.clearPollWarning("infra-notifier:" + via)
+		if err := s.deliverInfraRoute(ctx, nowAt, via, route, n); err != nil {
+			log.Printf("[notify] infrastructure route %q: %v", via, err)
+		}
+	}
+}
+
+func (s *Server) deliverInfraRoute(ctx context.Context, nowAt time.Time, via string, route types.InfraRoute, n notify.Notifier) error {
+	watermark, _, err := s.notifierStateInt64(infraWatermarkKey(via))
+	if err != nil {
+		return err
+	}
+	// Collect the whole batch before issuing any further query on this
+	// connection: the test harness (and a modest deployment) runs SQLite
+	// with a single pooled connection, so a query/exec nested inside these
+	// still-open rows would block forever waiting for a connection that
+	// only this same in-flight Query holds.
+	rows, err := s.db.Query(`SELECT rowid,event_type,subject,detail,occurred_at FROM infra_events WHERE rowid>? ORDER BY rowid LIMIT 200`, watermark)
+	if err != nil {
+		return err
+	}
+	var events []infraEventRow
+	for rows.Next() {
+		var e infraEventRow
+		var raw string
+		var occurred int64
+		if err := rows.Scan(&e.RowID, &e.EventType, &e.Subject, &raw, &occurred); err != nil {
+			rows.Close()
+			return err
+		}
+		e.OccurredAt = timeFromEpochMillis(occurred)
+		_ = json.Unmarshal([]byte(raw), &e.Detail)
+		events = append(events, e)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
+
+	allowed := map[string]bool{}
+	for _, e := range route.Events {
+		allowed[e] = true
+	}
+	for _, e := range events {
+		if len(allowed) != 0 && !allowed[e.EventType] {
+			s.setNotifierStateInt64(infraWatermarkKey(via), e.RowID)
+			continue
+		}
+		var exists int
+		if err := s.db.QueryRow(`SELECT EXISTS(SELECT 1 FROM infra_notification_deliveries WHERE event_rowid=? AND notifier=?)`, e.RowID, via).Scan(&exists); err != nil {
+			return err
+		}
+		if exists != 0 {
+			s.setNotifierStateInt64(infraWatermarkKey(via), e.RowID)
+			continue
+		}
+		sendCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		_, sendErr := n.Send(sendCtx, buildInfraMessage(e, nowAt))
+		cancel()
+		if sendErr != nil {
+			if notify.Classify(sendErr) == notify.ErrorConfig {
+				return nil
+			}
+			if notify.Classify(sendErr) != notify.ErrorPermanent {
+				count, _, stateErr := s.notifierStateInt64(infraFailureKey(e.RowID, via))
+				if stateErr != nil {
+					return stateErr
+				}
+				count++
+				if count < infraMaxTransientFailures {
+					s.setNotifierStateInt64(infraFailureKey(e.RowID, via), count)
+					return nil
+				}
+				s.clearNotifierState(infraFailureKey(e.RowID, via))
+			}
+			if _, err := s.db.Exec(`INSERT INTO infra_notification_deliveries(event_rowid,notifier,delivered_at,status) VALUES(?,?,?,?)`, e.RowID, via, epochMillis(nowAt), notificationDeliveryStatusFailed); err != nil {
+				return err
+			}
+		} else {
+			s.clearNotifierState(infraFailureKey(e.RowID, via))
+			if _, err := s.db.Exec(`INSERT INTO infra_notification_deliveries(event_rowid,notifier,delivered_at,status) VALUES(?,?,?,?)`, e.RowID, via, epochMillis(nowAt), notificationDeliveryStatusSent); err != nil {
+				return err
+			}
+		}
+		s.setNotifierStateInt64(infraWatermarkKey(via), e.RowID)
+	}
+	return nil
+}
+
+type infraEventStyle struct {
+	emoji, title string
+	severity     notify.Severity
+}
+
+var infraEventStyles = map[string]infraEventStyle{
+	"dependency_down": {":fire:", "Dependency is down", notify.SeverityError}, "dependency_degraded": {":warning:", "Dependency is degraded", notify.SeverityWarning}, "dependency_recovered": {":white_check_mark:", "Dependency recovered", notify.SeveritySuccess},
+	"provider_limit_opened": {":credit_card:", "Provider account is capped", notify.SeverityWarning}, "provider_limit_exhausted": {":no_entry:", "Provider cap needs a human", notify.SeverityError}, "provider_limit_released": {":white_check_mark:", "Provider cap lifted", notify.SeveritySuccess},
+}
+
+func buildInfraMessage(e infraEventRow, _ time.Time) notify.Message {
+	style, ok := infraEventStyles[e.EventType]
+	if !ok {
+		style = infraEventStyle{":warning:", "Infrastructure event", notify.SeverityWarning}
+	}
+	subject := strings.TrimSpace(stringValue(e.Detail, "name"))
+	if subject == "" {
+		subject = e.Subject
+	}
+	body := "Wait for recovery and watch the dependency's status page."
+	if strings.HasPrefix(e.EventType, "provider_limit_") {
+		body = "Raise the provider account cap in its billing console, or wait until the stated reset time."
+	}
+	if e.EventType == "dependency_recovered" || e.EventType == "provider_limit_released" {
+		body = "Service has recovered; resume watching normal work."
+	}
+	if msg := strings.TrimSpace(stringValue(e.Detail, "message")); msg != "" {
+		body += "\n" + msg
+	}
+	return notify.Message{Emoji: style.emoji, Title: style.title, Severity: style.severity, Subject: subject, Body: body, Fields: []notify.Field{{Label: "Event", Value: strings.ReplaceAll(e.EventType, "_", " ")}, {Label: "Occurred", Value: e.OccurredAt.UTC().Format(time.RFC3339)}}, Summary: []string{style.title, subject}}
+}
+
+func stringValue(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	switch v := m[key].(type) {
+	case string:
+		return v
+	case json.Number:
+		return v.String()
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	default:
+		return ""
+	}
+}

--- a/pkg/hub/infra_notifier.go
+++ b/pkg/hub/infra_notifier.go
@@ -218,7 +218,20 @@ func buildInfraMessage(e infraEventRow, _ time.Time) notify.Message {
 	if msg := strings.TrimSpace(stringValue(e.Detail, "message")); msg != "" {
 		body += "\n" + msg
 	}
-	return notify.Message{Emoji: style.emoji, Title: style.title, Severity: style.severity, Subject: subject, Body: body, Fields: []notify.Field{{Label: "Event", Value: strings.ReplaceAll(e.EventType, "_", " ")}, {Label: "Occurred", Value: e.OccurredAt.UTC().Format(time.RFC3339)}}, Summary: []string{style.title, subject}}
+	fields := []notify.Field{{Label: "Event", Value: strings.ReplaceAll(e.EventType, "_", " ")}}
+	if strings.HasPrefix(e.EventType, "dependency_") {
+		if statusPage := stringValue(e.Detail, "status_page"); statusPage != "" {
+			fields = append(fields, notify.Field{Label: "Status page", Value: statusPage})
+		}
+	} else if strings.HasPrefix(e.EventType, "provider_limit_") {
+		for _, field := range []struct{ label, key string }{{"Provider", "provider"}, {"Key", "key_id"}, {"Claws parked", "claws_parked"}, {"Deadline", "deadline"}} {
+			if value := stringValue(e.Detail, field.key); value != "" {
+				fields = append(fields, notify.Field{Label: field.label, Value: value})
+			}
+		}
+	}
+	fields = append(fields, notify.Field{Label: "Occurred", Value: e.OccurredAt.UTC().Format(time.RFC3339)})
+	return notify.Message{Emoji: style.emoji, Title: style.title, Severity: style.severity, Subject: subject, Body: body, Fields: fields, Summary: []string{style.title, subject}}
 }
 
 func stringValue(m map[string]any, key string) string {

--- a/pkg/hub/infra_notifier.go
+++ b/pkg/hub/infra_notifier.go
@@ -22,9 +22,14 @@ const (
 // Infra uses its own cursor because these events describe the fleet, not a
 // task run. A route that is temporarily broken must not make a healthy route
 // skip an outage it never received.
-func infraWatermarkKey(via string) string { return "infra_watermark_rowid:" + via }
+const (
+	infraWatermarkKeyPrefix = "infra_watermark_rowid:"
+	infraTransientKeyPrefix = "infra_transient:"
+)
+
+func infraWatermarkKey(via string) string { return infraWatermarkKeyPrefix + via }
 func infraFailureKey(rowid int64, via string) string {
-	return fmt.Sprintf("infra_transient:%s:%d", via, rowid)
+	return fmt.Sprintf("%s%s:%d", infraTransientKeyPrefix, via, rowid)
 }
 
 type infraEventRow struct {
@@ -118,6 +123,10 @@ func (s *Server) stopInfraNotifier(timeout time.Duration) {
 func (s *Server) infraNotifierTick(ctx context.Context, nowAt time.Time) {
 	cfg := s.notificationsConfig()
 	if cfg == nil || !cfg.Infra.IsEnabled() {
+		// Off means no route is configured: drop every cursor so a later
+		// re-enable behaves like a fresh enable instead of flushing the
+		// disabled window into the channel.
+		s.pruneInfraRouteState(nil)
 		return
 	}
 	if err := types.ValidateInfraNotificationsConfig(cfg); err != nil {
@@ -125,6 +134,7 @@ func (s *Server) infraNotifierTick(ctx context.Context, nowAt time.Time) {
 		return
 	}
 	s.clearPollWarning("infra-config")
+	s.pruneInfraRouteState(infraConfiguredRoutes(cfg.Infra))
 	s.flushPendingInfraDeliveries()
 	for _, route := range cfg.Infra.Routes {
 		via := strings.TrimSpace(route.Via)
@@ -236,6 +246,63 @@ func (s *Server) deliverInfraRoute(ctx context.Context, nowAt time.Time, via str
 		s.setNotifierStateInt64(infraWatermarkKey(via), e.RowID)
 	}
 	return nil
+}
+
+func infraConfiguredRoutes(ic *types.InfraNotificationsConfig) map[string]bool {
+	configured := map[string]bool{}
+	if ic == nil {
+		return configured
+	}
+	for _, route := range ic.Routes {
+		if via := strings.TrimSpace(route.Via); via != "" {
+			configured[via] = true
+		}
+	}
+	return configured
+}
+
+// infraStateVia recovers the route name from either per-route state key.
+func infraStateVia(key string) string {
+	if strings.HasPrefix(key, infraTransientKeyPrefix) {
+		rest := strings.TrimPrefix(key, infraTransientKeyPrefix)
+		if i := strings.LastIndex(rest, ":"); i >= 0 {
+			return rest[:i]
+		}
+		return rest
+	}
+	return strings.TrimPrefix(key, infraWatermarkKeyPrefix)
+}
+
+// pruneInfraRouteState drops the cursor and transient-failure counters of
+// routes that are not configured right now, for the reason
+// pruneLifecycleRouteState does: nothing else clears them, so a route removed
+// from notifications.infra.routes — or the whole block disabled — and later
+// re-added under the same via would resume from its stale cursor and replay
+// the entire absence window into its channel as live outages. Dropping the
+// state makes a re-added route behave exactly like a newly added one: it
+// baselines at the head of the stream on its first delivery.
+func (s *Server) pruneInfraRouteState(configured map[string]bool) {
+	rows, err := s.db.Query(`SELECT key FROM slack_notifier_state WHERE key LIKE ? OR key LIKE ?`, infraWatermarkKeyPrefix+"%", infraTransientKeyPrefix+"%")
+	if err != nil {
+		log.Printf("[notify] list infra route state: %v", err)
+		return
+	}
+	var stale []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			log.Printf("[notify] list infra route state: %v", err)
+			rows.Close()
+			return
+		}
+		if !configured[infraStateVia(key)] {
+			stale = append(stale, key)
+		}
+	}
+	rows.Close()
+	for _, key := range stale {
+		s.clearNotifierState(key)
+	}
 }
 
 // infraDeliveryKey identifies one stashed infra delivery row.

--- a/pkg/hub/infra_notifier.go
+++ b/pkg/hub/infra_notifier.go
@@ -375,12 +375,25 @@ func buildInfraMessage(e infraEventRow, _ time.Time) notify.Message {
 	if subject == "" {
 		subject = e.Subject
 	}
-	body := "Wait for recovery and watch the dependency's status page."
-	if strings.HasPrefix(e.EventType, "provider_limit_") {
-		body = "Raise the provider account cap in its billing console, or wait until the stated reset time."
-	}
-	if e.EventType == "dependency_recovered" || e.EventType == "provider_limit_released" {
+	retry := stringValue(e.Detail, "retry_count")
+	var body string
+	switch e.EventType {
+	case "dependency_recovered":
 		body = "Service has recovered; resume watching normal work."
+	case "provider_limit_opened":
+		body = "Raise the provider account cap in its billing console, or wait until the stated reset time."
+		if retry != "" && retry != "0" {
+			body = "The provider still reports the cap after automatic retry " + retry + "; the hub retries again at the stated time. Raise the cap in the billing console to end it sooner."
+		}
+	case "provider_limit_exhausted":
+		// The latch never auto-releases an exhausted limit
+		// (releaseDueLLMUsageLimits skips it), so "wait for the reset" would
+		// park the fleet indefinitely.
+		body = "Automatic retries are exhausted; the hub will not retry on its own. Raise the cap in the provider's billing console, then clear the block (a parked claw's page, or DELETE /api/claws/{id}/llm-limit) to resume."
+	case "provider_limit_released":
+		body = "Provider access has recovered; the parked claws resumed on their own."
+	default:
+		body = "Wait for recovery and watch the dependency's status page."
 	}
 	if msg := strings.TrimSpace(stringValue(e.Detail, "message")); msg != "" {
 		body += "\n" + msg
@@ -391,7 +404,19 @@ func buildInfraMessage(e infraEventRow, _ time.Time) notify.Message {
 			fields = append(fields, notify.Field{Label: "Status page", Value: statusPage})
 		}
 	} else if strings.HasPrefix(e.EventType, "provider_limit_") {
-		for _, field := range []struct{ label, key string }{{"Provider", "provider"}, {"Key", "key_id"}, {"Claws parked", "parked_claws"}, {"Deadline", "deadline"}} {
+		labelled := []struct{ label, key string }{{"Provider", "provider"}, {"Key", "key_id"}}
+		switch e.EventType {
+		case "provider_limit_released":
+			labelled = append(labelled, struct{ label, key string }{"Claws resumed", "parked_claws"})
+		case "provider_limit_exhausted":
+			labelled = append(labelled, struct{ label, key string }{"Claws parked", "parked_claws"}, struct{ label, key string }{"Last retry", "deadline"})
+		default:
+			labelled = append(labelled, struct{ label, key string }{"Claws parked", "parked_claws"}, struct{ label, key string }{"Deadline", "deadline"})
+			if retry != "" && retry != "0" {
+				labelled = append(labelled, struct{ label, key string }{"Retry", "retry_count"})
+			}
+		}
+		for _, field := range labelled {
 			if value := stringValue(e.Detail, field.key); value != "" {
 				fields = append(fields, notify.Field{Label: field.label, Value: value})
 			}

--- a/pkg/hub/infra_notifier_test.go
+++ b/pkg/hub/infra_notifier_test.go
@@ -1,0 +1,242 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/notify"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+)
+
+// recordingNotifier captures every message it is asked to send, and can be
+// told to fail (optionally with a classified error) the next N sends.
+type recordingNotifier struct {
+	sent    []notify.Message
+	failN   int
+	failErr error
+}
+
+func (n *recordingNotifier) Send(ctx context.Context, msg notify.Message) (string, error) {
+	if n.failN > 0 {
+		n.failN--
+		if n.failErr != nil {
+			return "", n.failErr
+		}
+		return "", errors.New("synthetic transient failure")
+	}
+	n.sent = append(n.sent, msg)
+	return fmt.Sprintf("handle-%d", len(n.sent)), nil
+}
+
+func mustRecordInfraEvent(t *testing.T, s *Server, key, eventType string, detail map[string]any, at time.Time) {
+	t.Helper()
+	if err := s.recordInfraEvent(infraEvent{EventKey: key, EventType: eventType, Subject: key, Detail: detail, OccurredAt: at}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Regression: a route with a non-empty Events allowlist must skip events not
+// in that list (and still advance its watermark past them) while delivering
+// the ones it does subscribe to.
+func TestDeliverInfraRouteFiltersByEvent(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	mustRecordInfraEvent(t, s, "ev-down", "dependency_down", map[string]any{"name": "Anthropic"}, base)
+	mustRecordInfraEvent(t, s, "ev-capped", "provider_limit_opened", map[string]any{"name": "OpenAI"}, base.Add(time.Second))
+
+	n := &recordingNotifier{}
+	route := types.InfraRoute{Via: "ops", Events: []string{"provider_limit_opened"}}
+	if err := s.deliverInfraRoute(context.Background(), base, "ops", route, n); err != nil {
+		t.Fatal(err)
+	}
+	if len(n.sent) != 1 {
+		t.Fatalf("sent %d messages, want 1", len(n.sent))
+	}
+	if n.sent[0].Subject != "OpenAI" {
+		t.Fatalf("delivered subject = %q, want OpenAI", n.sent[0].Subject)
+	}
+
+	// A second tick with nothing new must not resend, proving the filtered
+	// event advanced the watermark instead of blocking behind it.
+	if err := s.deliverInfraRoute(context.Background(), base, "ops", route, n); err != nil {
+		t.Fatal(err)
+	}
+	if len(n.sent) != 1 {
+		t.Fatalf("second tick sent %d messages, want still 1 (no resend, no unblocking gap)", len(n.sent))
+	}
+}
+
+// An empty Events allowlist on a route means "all infra events".
+func TestDeliverInfraRouteEmptyAllowlistDeliversEverything(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	mustRecordInfraEvent(t, s, "ev-down", "dependency_down", map[string]any{"name": "Anthropic"}, base)
+	mustRecordInfraEvent(t, s, "ev-capped", "provider_limit_opened", map[string]any{"name": "OpenAI"}, base.Add(time.Second))
+
+	n := &recordingNotifier{}
+	route := types.InfraRoute{Via: "ops"}
+	if err := s.deliverInfraRoute(context.Background(), base, "ops", route, n); err != nil {
+		t.Fatal(err)
+	}
+	if len(n.sent) != 2 {
+		t.Fatalf("sent %d messages, want 2", len(n.sent))
+	}
+}
+
+// Regression: dedupe is per (event, route) — two routes must each get their
+// own copy of the same event, and neither route may be sent the same event
+// twice across ticks.
+func TestDeliverInfraRouteDedupePerRoute(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	mustRecordInfraEvent(t, s, "ev-down", "dependency_down", map[string]any{"name": "Anthropic"}, base)
+
+	nOps, nSre := &recordingNotifier{}, &recordingNotifier{}
+	route := types.InfraRoute{Via: "any"}
+	if err := s.deliverInfraRoute(context.Background(), base, "ops", route, nOps); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.deliverInfraRoute(context.Background(), base, "sre", route, nSre); err != nil {
+		t.Fatal(err)
+	}
+	if len(nOps.sent) != 1 || len(nSre.sent) != 1 {
+		t.Fatalf("each route should get the event once: ops=%d sre=%d", len(nOps.sent), len(nSre.sent))
+	}
+	// Re-deliver "ops" — must not resend.
+	if err := s.deliverInfraRoute(context.Background(), base, "ops", route, nOps); err != nil {
+		t.Fatal(err)
+	}
+	if len(nOps.sent) != 1 {
+		t.Fatalf("ops route resent an already-delivered event: sent=%d", len(nOps.sent))
+	}
+}
+
+// Regression: a message that keeps failing with an unclassified (therefore
+// transient) error must not wedge the route's cursor forever — after the cap
+// it is recorded failed and the queue behind it is free to flow.
+func TestDeliverInfraRouteTransientFailureCapUnwedgesRoute(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	mustRecordInfraEvent(t, s, "ev-poison", "dependency_down", map[string]any{"name": "Anthropic"}, base)
+	mustRecordInfraEvent(t, s, "ev-behind", "dependency_recovered", map[string]any{"name": "Anthropic"}, base.Add(time.Second))
+
+	n := &recordingNotifier{failN: infraMaxTransientFailures}
+	route := types.InfraRoute{Via: "ops"}
+	for i := 0; i < infraMaxTransientFailures-1; i++ {
+		if err := s.deliverInfraRoute(context.Background(), base, "ops", route, n); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var exists int
+	if err := s.db.QueryRow(`SELECT COUNT(1) FROM infra_notification_deliveries WHERE notifier='ops'`).Scan(&exists); err != nil {
+		t.Fatal(err)
+	}
+	if exists != 0 {
+		t.Fatalf("poisoned event was recorded before the transient-failure cap was reached")
+	}
+
+	// The cap-th consecutive failure records the poisoned event failed and
+	// unblocks the event behind it.
+	if err := s.deliverInfraRoute(context.Background(), base, "ops", route, n); err != nil {
+		t.Fatal(err)
+	}
+	var status string
+	if err := s.db.QueryRow(`SELECT status FROM infra_notification_deliveries WHERE notifier='ops' AND event_rowid=(SELECT rowid FROM infra_events WHERE event_key='ev-poison')`).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != notificationDeliveryStatusFailed {
+		t.Fatalf("poisoned delivery status = %q, want failed", status)
+	}
+	if len(n.sent) != 1 || n.sent[0].Subject != "Anthropic" {
+		t.Fatalf("event behind the poisoned one was not delivered: sent=%v", n.sent)
+	}
+}
+
+// A notify.ErrorConfig failure pauses the whole route (the config is broken,
+// every send would fail alike) rather than burning through the transient cap
+// per event.
+func TestDeliverInfraRouteConfigErrorPausesRoute(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	mustRecordInfraEvent(t, s, "ev-down", "dependency_down", map[string]any{"name": "Anthropic"}, base)
+
+	n := &recordingNotifier{failN: 1, failErr: notify.ConfigError(errors.New("bad token"))}
+	route := types.InfraRoute{Via: "ops"}
+	if err := s.deliverInfraRoute(context.Background(), base, "ops", route, n); err != nil {
+		t.Fatal(err)
+	}
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(1) FROM infra_notification_deliveries`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("config error must not record a delivery outcome, got %d rows", count)
+	}
+}
+
+// buildInfraMessage must render an actionable next step for both the
+// dependency and provider-cap event families.
+func TestBuildInfraMessageActionable(t *testing.T) {
+	cases := []struct {
+		eventType string
+		wantTitle string
+		wantBody  string
+	}{
+		{"dependency_down", "Dependency is down", "status page"},
+		{"dependency_degraded", "Dependency is degraded", "status page"},
+		{"dependency_recovered", "Dependency recovered", "recovered"},
+		{"provider_limit_opened", "Provider account is capped", "billing console"},
+		{"provider_limit_exhausted", "Provider cap needs a human", "billing console"},
+		{"provider_limit_released", "Provider cap lifted", "recovered"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.eventType, func(t *testing.T) {
+			e := infraEventRow{
+				EventType:  tc.eventType,
+				Subject:    "sample",
+				Detail:     map[string]any{"name": "Anthropic"},
+				OccurredAt: time.Now(),
+			}
+			msg := buildInfraMessage(e, time.Now())
+			if msg.Title != tc.wantTitle {
+				t.Fatalf("title = %q, want %q", msg.Title, tc.wantTitle)
+			}
+			if !strings.Contains(strings.ToLower(msg.Body), tc.wantBody) {
+				t.Fatalf("body = %q, want it to mention %q", msg.Body, tc.wantBody)
+			}
+		})
+	}
+}
+
+// buildInfraMessage must never render the raw provider key: only the masked
+// key id the event producer already stored ever reaches the detail map, so
+// the rendered message must reflect exactly what was recorded and nothing
+// derived from a raw secret.
+func TestBuildInfraMessageRendersOnlyMaskedKeyID(t *testing.T) {
+	const maskedID = "sk-...ab12"
+	e := infraEventRow{
+		EventType:  "provider_limit_opened",
+		Subject:    "sample",
+		Detail:     map[string]any{"name": "OpenAI", "key_id": maskedID, "message": "account capped"},
+		OccurredAt: time.Now(),
+	}
+	msg := buildInfraMessage(e, time.Now())
+	all := msg.Title + msg.Body + msg.Subject
+	for _, f := range msg.Fields {
+		all += f.Label + f.Value
+	}
+	if !strings.Contains(all, "capped") {
+		t.Fatalf("rendered message dropped the provider's own detail message: %q", all)
+	}
+}
+
+func TestBuildInfraMessageUnknownEventTypeDoesNotPanic(t *testing.T) {
+	msg := buildInfraMessage(infraEventRow{EventType: "something_new", Subject: "x"}, time.Now())
+	if msg.Title == "" {
+		t.Fatal("unknown event type produced an empty title")
+	}
+}

--- a/pkg/hub/infra_notifier_test.go
+++ b/pkg/hub/infra_notifier_test.go
@@ -450,3 +450,40 @@ func TestInfraNotifierTickDisabledWindowIsNotReplayed(t *testing.T) {
 	}
 }
 
+// provider_limit_exhausted is never auto-released, so its message must send
+// the operator to clear the block rather than promise a reset that will not
+// come; provider_limit_released describes claws that resumed, not parked.
+func TestBuildInfraMessageProviderLimitFieldsMatchTheLatch(t *testing.T) {
+	detail := map[string]any{"name": "Anthropic", "parked_claws": 4, "deadline": "2026-09-02 00:45 UTC", "retry_count": 3}
+	labels := func(msg notify.Message) map[string]string {
+		out := map[string]string{}
+		for _, f := range msg.Fields {
+			out[f.Label] = f.Value
+		}
+		return out
+	}
+
+	exhausted := buildInfraMessage(infraEventRow{EventType: "provider_limit_exhausted", Subject: "anthropic", Detail: detail, OccurredAt: time.Now()}, time.Now())
+	if strings.Contains(strings.ToLower(exhausted.Body), "wait until") {
+		t.Fatalf("exhausted body still tells the operator to wait: %q", exhausted.Body)
+	}
+	if !strings.Contains(strings.ToLower(exhausted.Body), "clear the block") {
+		t.Fatalf("exhausted body does not name the required action: %q", exhausted.Body)
+	}
+	if got := labels(exhausted); got["Deadline"] != "" || got["Last retry"] != "2026-09-02 00:45 UTC" {
+		t.Fatalf("exhausted fields = %v, want the deadline relabelled as the last retry", got)
+	}
+
+	released := buildInfraMessage(infraEventRow{EventType: "provider_limit_released", Subject: "anthropic", Detail: detail, OccurredAt: time.Now()}, time.Now())
+	if got := labels(released); got["Claws parked"] != "" || got["Deadline"] != "" || got["Claws resumed"] != "4" {
+		t.Fatalf("released fields = %v, want resumed claws and no deadline", got)
+	}
+
+	retry := buildInfraMessage(infraEventRow{EventType: "provider_limit_opened", Subject: "anthropic", Detail: map[string]any{"name": "Anthropic", "retry_count": 2, "deadline": "2026-09-02 00:30 UTC"}, OccurredAt: time.Now()}, time.Now())
+	if got := labels(retry); got["Retry"] != "2" {
+		t.Fatalf("re-latch fields = %v, want the retry number", got)
+	}
+	if !strings.Contains(strings.ToLower(retry.Body), "still") {
+		t.Fatalf("re-latch body reads like a first sighting: %q", retry.Body)
+	}
+}

--- a/pkg/hub/infra_notifier_test.go
+++ b/pkg/hub/infra_notifier_test.go
@@ -384,3 +384,69 @@ func TestBuildInfraMessageRendersParkedClaws(t *testing.T) {
 		})
 	}
 }
+
+// Regression: a route removed from notifications.infra.routes and later
+// re-added under the same via must be re-baselined at the head of the stream,
+// not resume from the cursor it left behind and replay the absence window.
+func TestPruneInfraRouteStateReAddedRouteDoesNotReplayAbsenceWindow(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	establishInfraRoute(t, s, "ops")
+	s.setNotifierStateInt64(infraFailureKey(1, "ops"), 3)
+
+	// Route removed: the absence window records an incident start to finish.
+	s.pruneInfraRouteState(map[string]bool{"eng": true})
+	mustRecordInfraEvent(t, s, "ev-absent-down", "dependency_down", map[string]any{"name": "Anthropic"}, base)
+	mustRecordInfraEvent(t, s, "ev-absent-recovered", "dependency_recovered", map[string]any{"name": "Anthropic"}, base.Add(time.Minute))
+	if _, found, _ := s.notifierStateInt64(infraFailureKey(1, "ops")); found {
+		t.Fatal("transient-failure counter of the removed route survived the prune")
+	}
+
+	// Route re-added.
+	n := &recordingNotifier{}
+	route := types.InfraRoute{Via: "ops"}
+	if err := s.deliverInfraRoute(context.Background(), base.Add(2*time.Minute), "ops", route, n); err != nil {
+		t.Fatal(err)
+	}
+	if len(n.sent) != 0 {
+		t.Fatalf("re-added route replayed %d events from its absence window", len(n.sent))
+	}
+	mustRecordInfraEvent(t, s, "ev-live", "provider_limit_opened", map[string]any{"name": "OpenAI"}, base.Add(3*time.Minute))
+	if err := s.deliverInfraRoute(context.Background(), base.Add(3*time.Minute), "ops", route, n); err != nil {
+		t.Fatal(err)
+	}
+	if len(n.sent) != 1 || n.sent[0].Subject != "OpenAI" {
+		t.Fatalf("re-added route missed its first live event: sent=%v", n.sent)
+	}
+	// A configured route keeps its cursor across ticks.
+	s.pruneInfraRouteState(map[string]bool{"ops": true})
+	if _, found, _ := s.notifierStateInt64(infraWatermarkKey("ops")); !found {
+		t.Fatal("prune dropped the cursor of a configured route")
+	}
+}
+
+// Regression: disabling infrastructure alerts and re-enabling them a week
+// later must not flush the disabled window into the channel as live outages.
+func TestInfraNotifierTickDisabledWindowIsNotReplayed(t *testing.T) {
+	disabled := false
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{"ops": {Type: "slack", Settings: map[string]any{"channel": "C0123ABCD", "token_secret": "slack_token"}}},
+		Infra:     &types.InfraNotificationsConfig{Enabled: &disabled, Routes: []types.InfraRoute{{Via: "ops"}}},
+	}}, "", "", "")
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	establishInfraRoute(t, s, "ops")
+
+	s.infraNotifierTick(context.Background(), base)
+	mustRecordInfraEvent(t, s, "ev-while-off", "dependency_down", map[string]any{"name": "Anthropic"}, base.Add(time.Minute))
+	s.infraNotifierTick(context.Background(), base.Add(2*time.Minute))
+
+	// Re-enabled: the route's first delivery must see nothing from the window.
+	n := &recordingNotifier{}
+	if err := s.deliverInfraRoute(context.Background(), base.Add(3*time.Minute), "ops", types.InfraRoute{Via: "ops"}, n); err != nil {
+		t.Fatal(err)
+	}
+	if len(n.sent) != 0 {
+		t.Fatalf("re-enabled route replayed %d events from the disabled window", len(n.sent))
+	}
+}
+

--- a/pkg/hub/infra_notifier_test.go
+++ b/pkg/hub/infra_notifier_test.go
@@ -580,3 +580,64 @@ func hasField(msg notify.Message, label, value string) bool {
 	}
 	return false
 }
+
+// TestBuildInfraMessageRecoveryShowsHowLongItWasDown covers the two things the
+// first live run of this feature showed a reader: a recovery that never said how
+// long the outage lasted although the watcher had recorded it, and a "cap lifted"
+// message that quoted the original rejection underneath it.
+func TestBuildInfraMessageRecoveryShowsHowLongItWasDown(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		event      infraEventRow
+		wantField  string
+		wantValue  string
+		absentBody string
+	}{
+		{
+			name: "recovery renders the outage duration",
+			event: infraEventRow{
+				EventType: "dependency_recovered", Subject: "Anthropic",
+				Detail: map[string]any{"name": "Anthropic", "duration_ms": int64(2820000), "message": "All Systems Operational"},
+			},
+			wantField: "Down for", wantValue: "47m",
+		},
+		{
+			name: "a lift does not quote the rejection that opened the episode",
+			event: infraEventRow{
+				EventType: "provider_limit_released", Subject: "anthropic",
+				Detail: map[string]any{"provider": "anthropic", "key_id": "key_abc", "parked_claws": 2,
+					"message": "LLM request rejected: You have reached your specified API usage limits."},
+			},
+			absentBody: "You have reached your specified API usage limits",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := buildInfraMessage(tc.event, time.Now())
+			if tc.wantField != "" {
+				var got string
+				for _, f := range msg.Fields {
+					if f.Label == tc.wantField {
+						got = f.Value
+					}
+				}
+				if got != tc.wantValue {
+					t.Fatalf("field %q = %q, want %q (fields: %+v)", tc.wantField, got, tc.wantValue, msg.Fields)
+				}
+			}
+			if tc.absentBody != "" && strings.Contains(msg.Body, tc.absentBody) {
+				t.Fatalf("body must not quote the opening rejection, got:\n%s", msg.Body)
+			}
+		})
+	}
+}
+
+func TestFormatOutageDuration(t *testing.T) {
+	for _, tc := range []struct{ ms, want string }{
+		{"", ""}, {"0", ""}, {"-5", ""}, {"not-a-number", ""},
+		{"30000", "under a minute"}, {"2820000", "47m"}, {"3600000", "1h"}, {"5040000", "1h 24m"},
+	} {
+		if got := formatOutageDuration(map[string]any{"duration_ms": tc.ms}); got != tc.want {
+			t.Errorf("formatOutageDuration(%q) = %q, want %q", tc.ms, got, tc.want)
+		}
+	}
+}

--- a/pkg/hub/infra_notifier_test.go
+++ b/pkg/hub/infra_notifier_test.go
@@ -487,3 +487,96 @@ func TestBuildInfraMessageProviderLimitFieldsMatchTheLatch(t *testing.T) {
 		t.Fatalf("re-latch body reads like a first sighting: %q", retry.Body)
 	}
 }
+
+// A recovery whose opening alert this route discarded at the transient cap
+// must not read as good news about an incident the channel never heard of:
+// it is delivered, but relabelled as a missed alert.
+func TestDeliverInfraRouteRecoveryAfterDroppedOpeningSaysSo(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	establishInfraRoute(t, s, "ops")
+	mustRecordInfraEvent(t, s, "dependency_down:anthropic:100", "dependency_down", map[string]any{"name": "Anthropic"}, base)
+	mustRecordInfraEvent(t, s, "dependency_recovered:anthropic:100", "dependency_recovered", map[string]any{"name": "Anthropic"}, base.Add(time.Second))
+
+	n := &recordingNotifier{failN: infraMaxTransientFailures}
+	route := types.InfraRoute{Via: "ops"}
+	for i := 0; i < infraMaxTransientFailures; i++ {
+		if err := s.deliverInfraRoute(context.Background(), base, "ops", route, n); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(n.sent) != 1 {
+		t.Fatalf("sent %d messages, want the recovery alone", len(n.sent))
+	}
+	got := n.sent[0]
+	if got.Severity != notify.SeverityWarning || !strings.Contains(got.Body, "never received the alert that opened this incident") {
+		t.Fatalf("recovery after a dropped opening was not relabelled: severity=%v body=%q", got.Severity, got.Body)
+	}
+	if !hasField(got, "Opening alert", "not delivered") {
+		t.Fatalf("recovery after a dropped opening lacks the field: %#v", got.Fields)
+	}
+
+	// A different route that delivered the opening gets the plain recovery.
+	establishInfraRoute(t, s, "oncall")
+	mustRecordInfraEvent(t, s, "dependency_down:openai:200", "dependency_down", map[string]any{"name": "OpenAI"}, base.Add(2*time.Second))
+	mustRecordInfraEvent(t, s, "dependency_recovered:openai:200", "dependency_recovered", map[string]any{"name": "OpenAI"}, base.Add(3*time.Second))
+	healthy := &recordingNotifier{}
+	if err := s.deliverInfraRoute(context.Background(), base, "oncall", types.InfraRoute{Via: "oncall"}, healthy); err != nil {
+		t.Fatal(err)
+	}
+	if len(healthy.sent) != 2 || healthy.sent[1].Severity != notify.SeveritySuccess || strings.Contains(healthy.sent[1].Body, "never received") {
+		t.Fatalf("a recovery whose opening was delivered was relabelled: %#v", healthy.sent)
+	}
+}
+
+// The episode pairing for provider caps spans every retry of the episode: a
+// cap whose first "capped" alert reached the channel is a known incident even
+// when a later re-latch alert was dropped.
+func TestInfraOpeningKeyPatternsPairRecoveriesWithTheirEpisode(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	establishInfraRoute(t, s, "ops")
+	mustRecordInfraEvent(t, s, "provider_limit_opened:key_ab:500:0", "provider_limit_opened", map[string]any{"provider": "anthropic"}, base)
+	mustRecordInfraEvent(t, s, "provider_limit_opened:key_ab:500:1", "provider_limit_opened", map[string]any{"provider": "anthropic"}, base.Add(time.Second))
+	mustRecordInfraEvent(t, s, "provider_limit_released:key_ab:500:1", "provider_limit_released", map[string]any{"provider": "anthropic"}, base.Add(2*time.Second))
+	route := types.InfraRoute{Via: "ops"}
+	first := &recordingNotifier{}
+	if err := s.deliverInfraRoute(context.Background(), base, "ops", route, first); err != nil {
+		t.Fatal(err)
+	}
+	if len(first.sent) != 3 {
+		t.Fatalf("sent %d, want 3", len(first.sent))
+	}
+	if first.sent[2].Severity != notify.SeveritySuccess {
+		t.Fatalf("released after delivered openings was relabelled: %#v", first.sent[2])
+	}
+
+	// Mark the retry-1 alert as dropped after the fact: the retry-0 alert
+	// still reached the channel, so the episode is known.
+	if _, err := s.db.Exec(`UPDATE infra_notification_deliveries SET status=? WHERE event_rowid=(SELECT rowid FROM infra_events WHERE event_key='provider_limit_opened:key_ab:500:1')`, notificationDeliveryStatusFailed); err != nil {
+		t.Fatal(err)
+	}
+	row := infraEventRow{EventKey: "provider_limit_released:key_ab:500:1", EventType: "provider_limit_released", RowID: 1 << 40}
+	if missed, err := s.infraRouteMissedOpening(row, "ops"); err != nil || missed {
+		t.Fatalf("episode with one delivered opening reported missed=%v err=%v", missed, err)
+	}
+	if _, err := s.db.Exec(`UPDATE infra_notification_deliveries SET status=? WHERE notifier='ops'`, notificationDeliveryStatusFailed); err != nil {
+		t.Fatal(err)
+	}
+	if missed, err := s.infraRouteMissedOpening(row, "ops"); err != nil || !missed {
+		t.Fatalf("episode with every opening dropped reported missed=%v err=%v", missed, err)
+	}
+	// An opening this route never saw (baselined past it) is not a drop.
+	if missed, err := s.infraRouteMissedOpening(row, "newcomer"); err != nil || missed {
+		t.Fatalf("route without any delivery reported missed=%v err=%v", missed, err)
+	}
+}
+
+func hasField(msg notify.Message, label, value string) bool {
+	for _, field := range msg.Fields {
+		if field.Label == label && field.Value == value {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/hub/infra_notifier_test.go
+++ b/pkg/hub/infra_notifier_test.go
@@ -454,7 +454,7 @@ func TestInfraNotifierTickDisabledWindowIsNotReplayed(t *testing.T) {
 // the operator to clear the block rather than promise a reset that will not
 // come; provider_limit_released describes claws that resumed, not parked.
 func TestBuildInfraMessageProviderLimitFieldsMatchTheLatch(t *testing.T) {
-	detail := map[string]any{"name": "Anthropic", "parked_claws": 4, "deadline": "2026-09-02 00:45 UTC", "retry_count": 3}
+	detail := map[string]any{"name": "Anthropic", "parked_claws": 4, "deadline": "2026-09-02 01:30 UTC", "last_retry": "2026-09-02 00:45 UTC", "retry_count": 3}
 	labels := func(msg notify.Message) map[string]string {
 		out := map[string]string{}
 		for _, f := range msg.Fields {
@@ -471,7 +471,7 @@ func TestBuildInfraMessageProviderLimitFieldsMatchTheLatch(t *testing.T) {
 		t.Fatalf("exhausted body does not name the required action: %q", exhausted.Body)
 	}
 	if got := labels(exhausted); got["Deadline"] != "" || got["Last retry"] != "2026-09-02 00:45 UTC" {
-		t.Fatalf("exhausted fields = %v, want the deadline relabelled as the last retry", got)
+		t.Fatalf("exhausted fields = %v, want the last real retry and no deadline", got)
 	}
 
 	released := buildInfraMessage(infraEventRow{EventType: "provider_limit_released", Subject: "anthropic", Detail: detail, OccurredAt: time.Now()}, time.Now())

--- a/pkg/hub/infra_notifier_test.go
+++ b/pkg/hub/infra_notifier_test.go
@@ -39,12 +39,23 @@ func mustRecordInfraEvent(t *testing.T, s *Server, key, eventType string, detail
 	}
 }
 
+// establishInfraRoute stamps the route's watermark at the current head of
+// infra_events, the way NewServer's baseline (or the route's own first tick)
+// does before any event under test is recorded.
+func establishInfraRoute(t *testing.T, s *Server, via string) {
+	t.Helper()
+	if err := s.deliverInfraRoute(context.Background(), time.Unix(0, 0), via, types.InfraRoute{Via: via}, &recordingNotifier{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // Regression: a route with a non-empty Events allowlist must skip events not
 // in that list (and still advance its watermark past them) while delivering
 // the ones it does subscribe to.
 func TestDeliverInfraRouteFiltersByEvent(t *testing.T) {
 	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
 	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	establishInfraRoute(t, s, "ops")
 	mustRecordInfraEvent(t, s, "ev-down", "dependency_down", map[string]any{"name": "Anthropic"}, base)
 	mustRecordInfraEvent(t, s, "ev-capped", "provider_limit_opened", map[string]any{"name": "OpenAI"}, base.Add(time.Second))
 
@@ -74,6 +85,7 @@ func TestDeliverInfraRouteFiltersByEvent(t *testing.T) {
 func TestDeliverInfraRouteEmptyAllowlistDeliversEverything(t *testing.T) {
 	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
 	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	establishInfraRoute(t, s, "ops")
 	mustRecordInfraEvent(t, s, "ev-down", "dependency_down", map[string]any{"name": "Anthropic"}, base)
 	mustRecordInfraEvent(t, s, "ev-capped", "provider_limit_opened", map[string]any{"name": "OpenAI"}, base.Add(time.Second))
 
@@ -93,6 +105,8 @@ func TestDeliverInfraRouteEmptyAllowlistDeliversEverything(t *testing.T) {
 func TestDeliverInfraRouteDedupePerRoute(t *testing.T) {
 	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
 	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	establishInfraRoute(t, s, "ops")
+	establishInfraRoute(t, s, "sre")
 	mustRecordInfraEvent(t, s, "ev-down", "dependency_down", map[string]any{"name": "Anthropic"}, base)
 
 	nOps, nSre := &recordingNotifier{}, &recordingNotifier{}
@@ -121,6 +135,7 @@ func TestDeliverInfraRouteDedupePerRoute(t *testing.T) {
 func TestDeliverInfraRouteTransientFailureCapUnwedgesRoute(t *testing.T) {
 	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
 	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	establishInfraRoute(t, s, "ops")
 	mustRecordInfraEvent(t, s, "ev-poison", "dependency_down", map[string]any{"name": "Anthropic"}, base)
 	mustRecordInfraEvent(t, s, "ev-behind", "dependency_recovered", map[string]any{"name": "Anthropic"}, base.Add(time.Second))
 
@@ -162,6 +177,7 @@ func TestDeliverInfraRouteTransientFailureCapUnwedgesRoute(t *testing.T) {
 func TestDeliverInfraRouteConfigErrorPausesRoute(t *testing.T) {
 	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
 	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	establishInfraRoute(t, s, "ops")
 	mustRecordInfraEvent(t, s, "ev-down", "dependency_down", map[string]any{"name": "Anthropic"}, base)
 
 	n := &recordingNotifier{failN: 1, failErr: notify.ConfigError(errors.New("bad token"))}
@@ -238,5 +254,133 @@ func TestBuildInfraMessageUnknownEventTypeDoesNotPanic(t *testing.T) {
 	msg := buildInfraMessage(infraEventRow{EventType: "something_new", Subject: "x"}, time.Now())
 	if msg.Title == "" {
 		t.Fatal("unknown event type produced an empty title")
+	}
+}
+
+// Regression: a route seen for the first time — added at runtime, or enabled
+// months after the producers started recording — must baseline at the head of
+// infra_events instead of replaying the whole history as fresh alerts.
+func TestDeliverInfraRouteNewRouteDoesNotReplayHistory(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	mustRecordInfraEvent(t, s, "ev-old-down", "dependency_down", map[string]any{"name": "Anthropic"}, base)
+	mustRecordInfraEvent(t, s, "ev-old-recovered", "dependency_recovered", map[string]any{"name": "Anthropic"}, base.Add(time.Second))
+
+	n := &recordingNotifier{}
+	route := types.InfraRoute{Via: "ops"}
+	if err := s.deliverInfraRoute(context.Background(), base, "ops", route, n); err != nil {
+		t.Fatal(err)
+	}
+	if len(n.sent) != 0 {
+		t.Fatalf("brand-new route replayed %d historical events", len(n.sent))
+	}
+	mustRecordInfraEvent(t, s, "ev-new", "provider_limit_opened", map[string]any{"name": "OpenAI"}, base.Add(time.Minute))
+	if err := s.deliverInfraRoute(context.Background(), base.Add(time.Minute), "ops", route, n); err != nil {
+		t.Fatal(err)
+	}
+	if len(n.sent) != 1 || n.sent[0].Subject != "OpenAI" {
+		t.Fatalf("route missed the first post-baseline event: sent=%v", n.sent)
+	}
+}
+
+// initInfraNotifierBaseline stamps every configured route synchronously at
+// boot, so events produced before the notifier's first tick are history, not
+// a backlog.
+func TestInitInfraNotifierBaselineStampsConfiguredRoutes(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Infra: &types.InfraNotificationsConfig{Routes: []types.InfraRoute{{Via: "ops"}}},
+	}}, "", "", "")
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	mustRecordInfraEvent(t, s, "ev-historical", "dependency_down", map[string]any{"name": "Anthropic"}, base)
+	s.initInfraNotifierBaseline()
+	watermark, found, err := s.notifierStateInt64(infraWatermarkKey("ops"))
+	if err != nil || !found {
+		t.Fatalf("baseline missing: found=%v err=%v", found, err)
+	}
+	maxRow, err := s.infraMaxEventRowID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if watermark != maxRow {
+		t.Fatalf("baseline watermark = %d, want head %d", watermark, maxRow)
+	}
+}
+
+// Regression: a delivery whose bookkeeping write fails after a successful
+// send must be fenced in memory — never re-sent — and its row landed once the
+// database accepts writes again.
+func TestDeliverInfraRoutePendingDeliveryPreventsResend(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	establishInfraRoute(t, s, "ops")
+	mustRecordInfraEvent(t, s, "ev-down", "dependency_down", map[string]any{"name": "Anthropic"}, base)
+	var rowid int64
+	if err := s.db.QueryRow(`SELECT rowid FROM infra_events WHERE event_key='ev-down'`).Scan(&rowid); err != nil {
+		t.Fatal(err)
+	}
+	// Block only the bookkeeping insert; reads and the send stay healthy.
+	if _, err := s.db.Exec(`CREATE TRIGGER block_infra_delivery BEFORE INSERT ON infra_notification_deliveries BEGIN SELECT RAISE(ABORT, 'synthetic bookkeeping failure'); END`); err != nil {
+		t.Fatal(err)
+	}
+	n := &recordingNotifier{}
+	route := types.InfraRoute{Via: "ops"}
+	if err := s.deliverInfraRoute(context.Background(), base, "ops", route, n); err != nil {
+		t.Fatal(err)
+	}
+	if len(n.sent) != 1 {
+		t.Fatalf("sent %d messages, want 1", len(n.sent))
+	}
+	if !s.infraDeliveryPending(rowid, "ops") {
+		t.Fatal("failed bookkeeping write was not stashed as pending")
+	}
+	// Even with the cursor rewound (as if the watermark write had failed
+	// too), the stash alone must fence the resend.
+	s.setNotifierStateInt64(infraWatermarkKey("ops"), 0)
+	if err := s.deliverInfraRoute(context.Background(), base, "ops", route, n); err != nil {
+		t.Fatal(err)
+	}
+	if len(n.sent) != 1 {
+		t.Fatalf("stashed delivery was re-sent: sent=%d", len(n.sent))
+	}
+	// Once the DB accepts writes again the flush lands the row and drains the stash.
+	if _, err := s.db.Exec(`DROP TRIGGER block_infra_delivery`); err != nil {
+		t.Fatal(err)
+	}
+	s.flushPendingInfraDeliveries()
+	if s.infraDeliveryPending(rowid, "ops") {
+		t.Fatal("stash did not drain after the database recovered")
+	}
+	var status string
+	if err := s.db.QueryRow(`SELECT status FROM infra_notification_deliveries WHERE event_rowid=? AND notifier='ops'`, rowid).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != notificationDeliveryStatusSent {
+		t.Fatalf("flushed delivery status = %q, want sent", status)
+	}
+}
+
+// Regression: the producer stores the parked-claw count under "parked_claws";
+// the renderer must read the same key, and must render both the Go int the
+// test-send path stores and the float64 a JSON round-trip produces.
+func TestBuildInfraMessageRendersParkedClaws(t *testing.T) {
+	for name, count := range map[string]any{"int": int(4), "float64": float64(4)} {
+		t.Run(name, func(t *testing.T) {
+			e := infraEventRow{
+				EventType:  "provider_limit_opened",
+				Subject:    "openai",
+				Detail:     map[string]any{"provider": "openai", "key_id": "key_abc123", "parked_claws": count, "deadline": "2026-09-02 00:00 UTC"},
+				OccurredAt: time.Now(),
+			}
+			msg := buildInfraMessage(e, time.Now())
+			got := ""
+			for _, f := range msg.Fields {
+				if f.Label == "Claws parked" {
+					got = f.Value
+				}
+			}
+			if got != "4" {
+				t.Fatalf("Claws parked field = %q, want \"4\" (fields: %+v)", got, msg.Fields)
+			}
+		})
 	}
 }

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -2066,7 +2066,7 @@ func sampleInfraEvent(eventType string) infraEventRow {
 		detail["name"] = subject
 		detail["provider"] = "openai"
 		detail["key_id"] = "sk-...ab12"
-		detail["claws_parked"] = 3
+		detail["parked_claws"] = 3
 		detail["deadline"] = "2026-09-02T00:00:00Z"
 	}
 	return infraEventRow{EventType: eventType, Subject: subject, Detail: detail, OccurredAt: now()}

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -113,6 +113,14 @@ func (s *Server) notificationsConfig() *types.NotificationsConfig {
 			cfg.Scheduled[i].Weekdays = append([]string(nil), src.Scheduled[i].Weekdays...)
 		}
 	}
+	if src.Infra != nil {
+		infra := *src.Infra
+		infra.Routes = append([]types.InfraRoute(nil), src.Infra.Routes...)
+		for i := range infra.Routes {
+			infra.Routes[i].Events = append([]string(nil), src.Infra.Routes[i].Events...)
+		}
+		cfg.Infra = &infra
+	}
 	return cfg
 }
 
@@ -2048,12 +2056,20 @@ func (s *Server) handleInfraNotificationTest(w http.ResponseWriter, r *http.Requ
 }
 
 func sampleInfraEvent(eventType string) infraEventRow {
-	detail := map[string]any{"name": "Sample provider", "message": "Synthetic sample event for notification test"}
-	if strings.HasPrefix(eventType, "provider_limit_") {
-		detail["provider"] = "sample"
-		detail["deadline"] = "tomorrow at 00:00 UTC"
+	detail := map[string]any{"message": "Synthetic sample event for notification test"}
+	subject := "Anthropic"
+	if strings.HasPrefix(eventType, "dependency_") {
+		detail["name"] = subject
+		detail["status_page"] = "https://status.anthropic.com"
+	} else {
+		subject = "OpenAI"
+		detail["name"] = subject
+		detail["provider"] = "openai"
+		detail["key_id"] = "sk-...ab12"
+		detail["claws_parked"] = 3
+		detail["deadline"] = "2026-09-02T00:00:00Z"
 	}
-	return infraEventRow{EventType: eventType, Subject: "sample-provider", Detail: detail, OccurredAt: now()}
+	return infraEventRow{EventType: eventType, Subject: subject, Detail: detail, OccurredAt: now()}
 }
 
 // handleScheduledReportTest probes one scheduled report on demand: it builds

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -1821,6 +1821,10 @@ func (s *Server) handleNotificationTest(w http.ResponseWriter, r *http.Request) 
 		s.handleScheduledReportTest(w, r, report, strings.TrimSpace(body.Via), body.DryRun)
 		return
 	}
+	if types.IsInfraEventType(body.EventType) {
+		s.handleInfraNotificationTest(w, r, body.EventType, strings.TrimSpace(body.Via), body.DryRun)
+		return
+	}
 	supported := lifecycleSupportedEventTypes()
 	if !supported[body.EventType] {
 		valid := make([]string, 0, len(supported))
@@ -1978,6 +1982,78 @@ func (s *Server) handleNotificationTest(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	jsonOK(w, map[string]any{"ok": true, "message_id": handle, "via": via, "payload": payload})
+}
+
+// handleInfraNotificationTest uses the same provider path as delivery while
+// keeping the probe out of the durable infra stream and its route cursor.
+func (s *Server) handleInfraNotificationTest(w http.ResponseWriter, r *http.Request, eventType, requestedVia string, dryRun bool) {
+	cfg := s.notificationsConfig()
+	if cfg == nil || !cfg.Infra.IsEnabled() {
+		jsonError(w, http.StatusBadRequest, "infrastructure notifications are not configured or not enabled (set notifications.infra in hub.yaml)")
+		return
+	}
+	if err := types.ValidateInfraNotificationsConfig(cfg); err != nil {
+		jsonError(w, http.StatusBadRequest, "notifications config invalid: "+err.Error())
+		return
+	}
+	via := requestedVia
+	if via == "" {
+		via = strings.TrimSpace(cfg.Infra.Routes[0].Via)
+	}
+	nc, ok := cfg.Notifiers[via]
+	if !ok {
+		jsonError(w, http.StatusBadRequest, "via "+strconv.Quote(via)+" does not name a configured notifier (defined: "+configuredNotifierNames(cfg.Notifiers)+")")
+		return
+	}
+	msg := buildInfraMessage(sampleInfraEvent(eventType), s.nowFunc())
+	secrets := s.hubSecretResolver()
+	if dryRun {
+		dry := func(name string) (string, bool) {
+			if v, ok := secrets(name); ok && v != "" {
+				return v, true
+			}
+			return "dry-run-placeholder", true
+		}
+		n, err := notify.New(nc.Type, s.notifierSettings(nc), dry)
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, "notifier "+strconv.Quote(via)+" invalid: "+err.Error())
+			return
+		}
+		payload, err := renderNotifierPayload(n, msg)
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, "render payload: "+err.Error())
+			return
+		}
+		jsonOK(w, map[string]any{"dry_run": true, "via": via, "payload": payload})
+		return
+	}
+	n, err := s.notifierFor(via, nc, secrets)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, "notifier "+strconv.Quote(via)+" unavailable: "+err.Error())
+		return
+	}
+	payload, err := renderNotifierPayload(n, msg)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, "render payload: "+err.Error())
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+	handle, err := n.Send(ctx, msg)
+	if err != nil {
+		jsonError(w, http.StatusBadGateway, "notification send failed: "+err.Error())
+		return
+	}
+	jsonOK(w, map[string]any{"ok": true, "message_id": handle, "via": via, "payload": payload})
+}
+
+func sampleInfraEvent(eventType string) infraEventRow {
+	detail := map[string]any{"name": "Sample provider", "message": "Synthetic sample event for notification test"}
+	if strings.HasPrefix(eventType, "provider_limit_") {
+		detail["provider"] = "sample"
+		detail["deadline"] = "tomorrow at 00:00 UTC"
+	}
+	return infraEventRow{EventType: eventType, Subject: "sample-provider", Detail: detail, OccurredAt: now()}
 }
 
 // handleScheduledReportTest probes one scheduled report on demand: it builds

--- a/pkg/hub/lifecycle_notifier.go
+++ b/pkg/hub/lifecycle_notifier.go
@@ -2068,6 +2068,9 @@ func sampleInfraEvent(eventType string) infraEventRow {
 		detail["key_id"] = "sk-...ab12"
 		detail["parked_claws"] = 3
 		detail["deadline"] = "2026-09-02T00:00:00Z"
+		// What an exhausted event carries instead of a deadline (see
+		// recordLLMLimitEvent), so its sample renders the same fields.
+		detail["last_retry"] = "2026-09-02T00:45:00Z"
 	}
 	return infraEventRow{EventType: eventType, Subject: subject, Detail: detail, OccurredAt: now()}
 }

--- a/pkg/hub/llm_usage_limit.go
+++ b/pkg/hub/llm_usage_limit.go
@@ -1,11 +1,12 @@
 package hub
 
 import (
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -164,14 +165,14 @@ func (s *Server) handleLLMUsageLimit(cc *clawConn, clawID string, limit types.LL
 	case opened:
 		log.Printf("[llm-limit] key %q capped (%s), %d claw(s) parked until %s: %s",
 			keyID, record.Reason, len(latched), formatLLMLimitDeadline(record.RetryAt), record.Message)
-		s.recordLLMLimitEvent(clawID, record, true)
+		s.recordLLMLimitEvent(record, len(latched), "provider_limit_opened")
 	case relatched && record.Exhausted():
 		log.Printf("[llm-limit] key %q still capped after %d automatic retries, leaving it for an operator: %s",
 			keyID, record.Retries, record.Message)
 		for _, id := range latched {
 			s.publishHubNotice(id, fmt.Sprintf("[hub] The provider still reports a usage limit after %d automatic retries, so the hub stopped retrying. Raise the account limit and clear the block to resume. Last provider message: %s", record.Retries, record.Message))
 		}
-		s.recordLLMLimitEvent(clawID, record, false)
+		s.recordLLMLimitEvent(record, len(latched), "provider_limit_exhausted")
 	case relatched:
 		log.Printf("[llm-limit] key %q still capped, retry %d scheduled for %s",
 			keyID, record.Retries, formatLLMLimitDeadline(record.RetryAt))
@@ -230,6 +231,11 @@ func (s *Server) setClawLLMLimitMirror(clawID string, until time.Time) {
 // claw_retry can revive it later on the same row.
 func (s *Server) releaseLLMUsageLimit(keyID, reason string, announce bool) {
 	s.llmLimitMu.Lock()
+	record, had := s.loadLLMUsageLimit(keyID)
+	if !had || !record.Active() {
+		s.llmLimitMu.Unlock()
+		return
+	}
 	if _, err := s.db.Exec(
 		`UPDATE claws SET llm_limited_until=0 WHERE COALESCE(llm_key,'')=? AND COALESCE(llm_limited_until,0)<>0 AND status<>'deleted'`,
 		keyID); err != nil {
@@ -247,6 +253,7 @@ func (s *Server) releaseLLMUsageLimit(keyID, reason string, announce bool) {
 		return
 	}
 	s.llmLimitMu.Unlock()
+	s.recordLLMLimitEvent(record, len(clawIDs), "provider_limit_released")
 
 	// Notices and wakes touch sockets, so they happen outside the lock.
 	for _, clawID := range clawIDs {
@@ -616,33 +623,37 @@ func formatLLMLimitDeadline(at time.Time) string {
 	return at.UTC().Format("2006-01-02 15:04 UTC")
 }
 
-// recordLLMLimitEvent tells the operator, reusing agent_idle for the same
-// reason notifyBridgeErrorPause does: the operator-visible fact is "this agent
-// is not moving", and that event already carries the toggle, the severity and
-// the delivery passes.
-func (s *Server) recordLLMLimitEvent(clawID string, record llmUsageLimitRecord, opening bool) {
-	kind := "exhausted"
-	if opening {
-		kind = "opened"
-	}
-	if err := s.recordTaskRunEventForClaw(clawID, TaskRunEvent{
-		EventKey:        taskRunEventAgentIdle + ":llm-limit:" + kind + ":" + strconv.FormatInt(epochMillis(record.DetectedAt), 10),
-		Source:          taskRunSourceHub,
-		EventType:       taskRunEventAgentIdle,
-		ActorType:       taskRunActorSystem,
-		InteractionRole: taskRunInteractionNeutral,
+// recordLLMLimitEvent records the fleet-wide account fact once per key. Four
+// claws sharing a key formerly produced four "Agent stalled" reports, which
+// sent operators looking for four agent bugs instead of one billing cap.
+func (s *Server) recordLLMLimitEvent(record llmUsageLimitRecord, parked int, eventType string) {
+	maskedKey := maskLLMLimitKeyID(record.KeyID)
+	eventKey := fmt.Sprintf("%s:%s:%d:%d", eventType, maskedKey, epochMillis(record.DetectedAt), record.Retries)
+	if err := s.recordInfraEvent(infraEvent{
+		EventKey: eventKey, EventType: eventType, Subject: record.Provider,
 		Detail: map[string]any{
-			"llmUsageLimit":         record.Message,
-			"llmUsageLimitReason":   record.Reason,
-			"llmUsageLimitRetryAt":  formatLLMLimitDeadline(record.RetryAt),
-			"llmUsageLimitRetries":  record.Retries,
-			"llmUsageLimitProvider": record.Provider,
-			"noProgressPaused":      true,
-		},
-		OccurredAt: now(),
+			"provider": record.Provider, "key_id": maskedKey, "parked_claws": parked,
+			"deadline": formatLLMLimitDeadline(record.RetryAt), "retry_count": record.Retries,
+			"message": redactLLMLimitEventMessage(record.Message, record.KeyID),
+		}, OccurredAt: now(),
 	}); err != nil {
-		log.Printf("[llm-limit] record notification event for claw %s: %v", shortID(clawID), err)
+		log.Printf("[llm-limit] record %s event: %v", eventType, err)
 	}
+}
+
+func maskLLMLimitKeyID(keyID string) string {
+	if keyID == "" {
+		return "default"
+	}
+	sum := sha256.Sum256([]byte(keyID))
+	return "key_" + hex.EncodeToString(sum[:6])
+}
+
+func redactLLMLimitEventMessage(message, keyID string) string {
+	if keyID == "" {
+		return message
+	}
+	return strings.ReplaceAll(message, keyID, "[redacted]")
 }
 
 // handleClawLLMLimit exposes the block on a claw, and clears it.

--- a/pkg/hub/llm_usage_limit.go
+++ b/pkg/hub/llm_usage_limit.go
@@ -422,11 +422,7 @@ func (s *Server) releaseDueLLMUsageLimits() {
 	nowAt := now()
 	for _, record := range s.llmUsageLimitRecords() {
 		if !record.Active() {
-			if nowAt.Sub(record.ReleasedAt) > llmLimitEpisodeMemory {
-				if _, err := s.db.Exec(`DELETE FROM llm_usage_limits WHERE key_id=? AND released_at<>0`, record.KeyID); err != nil {
-					log.Printf("[llm-limit] prune released limit for key %q: %v", record.KeyID, err)
-				}
-			}
+			s.pruneReleasedLLMUsageLimit(record, nowAt)
 			continue
 		}
 		// Exhausted limits stay latched on purpose: the block is real, the hub
@@ -435,6 +431,29 @@ func (s *Server) releaseDueLLMUsageLimits() {
 			continue
 		}
 		s.releaseLLMUsageLimit(record.KeyID, llmLimitReleaseReason(record), true)
+	}
+}
+
+// pruneReleasedLLMUsageLimit forgets a released episode once it is old
+// enough (llmLimitEpisodeMemory) — but not while its lift is still unproven.
+// The released record is the only durable trace of a pending probe: the
+// proving turn reads it (confirmLLMLimitLift) and a restart re-derives the
+// probe from it (seedLLMLimitProbes). Pruning it first left the operator's
+// channel with an "account capped" alert whose recovery could never arrive:
+// the claw that was offline through the release wakes hours later, authors
+// its turn, and finds nothing to confirm. An unproven release is not an
+// episode that ended, so it keeps its memory until a turn says otherwise.
+func (s *Server) pruneReleasedLLMUsageLimit(record llmUsageLimitRecord, nowAt time.Time) {
+	if nowAt.Sub(record.ReleasedAt) <= llmLimitEpisodeMemory {
+		return
+	}
+	s.llmLimitMu.Lock()
+	defer s.llmLimitMu.Unlock()
+	if s.llmLimitProbing[record.KeyID] {
+		return
+	}
+	if _, err := s.db.Exec(`DELETE FROM llm_usage_limits WHERE key_id=? AND released_at<>0`, record.KeyID); err != nil {
+		log.Printf("[llm-limit] prune released limit for key %q: %v", record.KeyID, err)
 	}
 }
 

--- a/pkg/hub/llm_usage_limit.go
+++ b/pkg/hub/llm_usage_limit.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"regexp"
 	"strings"
 	"time"
 
@@ -763,30 +762,15 @@ func maskLLMLimitKeyID(keyID string) string {
 	return "key_" + hex.EncodeToString(sum[:6])
 }
 
-// llmLimitTokenPatterns match credential-shaped substrings a provider error
-// body may quote back at us. The configured key ID is often an alias
-// ("anthropic-prod"), so replacing only the literal ID would wave the raw
-// token straight through into infra_events and Slack. Over-redaction is the
-// safe failure mode here: nothing in a billing-cap message needs a 28-char
-// opaque string to be actionable.
-var llmLimitTokenPatterns = []*regexp.Regexp{
-	// Provider API keys: sk-..., sk-ant-..., sk-proj-... and friends.
-	regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{8,}`),
-	// An echoed Authorization header: whatever follows "Bearer" is the
-	// credential, however short or oddly spelled.
-	regexp.MustCompile(`(?i)\bbearer\s+[^\s;,'"]+`),
-	// Any long opaque run that reads as a credential, not prose.
-	regexp.MustCompile(`[A-Za-z0-9_-]{28,}`),
-}
-
+// redactLLMLimitEventMessage strips the configured key ID from a provider
+// message on top of the credential shapes recordInfraEvent strips from every
+// event. The ID is often an alias ("anthropic-prod") that no pattern would
+// catch, and it is the one string only this producer knows.
 func redactLLMLimitEventMessage(message, keyID string) string {
 	if keyID != "" {
 		message = strings.ReplaceAll(message, keyID, "[redacted]")
 	}
-	for _, pattern := range llmLimitTokenPatterns {
-		message = pattern.ReplaceAllString(message, "[redacted]")
-	}
-	return message
+	return redactInfraEventMessage(message)
 }
 
 // handleClawLLMLimit exposes the block on a claw, and clears it.

--- a/pkg/hub/llm_usage_limit.go
+++ b/pkg/hub/llm_usage_limit.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -649,11 +650,27 @@ func maskLLMLimitKeyID(keyID string) string {
 	return "key_" + hex.EncodeToString(sum[:6])
 }
 
+// llmLimitTokenPatterns match credential-shaped substrings a provider error
+// body may quote back at us. The configured key ID is often an alias
+// ("anthropic-prod"), so replacing only the literal ID would wave the raw
+// token straight through into infra_events and Slack. Over-redaction is the
+// safe failure mode here: nothing in a billing-cap message needs a 28-char
+// opaque string to be actionable.
+var llmLimitTokenPatterns = []*regexp.Regexp{
+	// Provider API keys: sk-..., sk-ant-..., sk-proj-... and friends.
+	regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{8,}`),
+	// Any long opaque run that reads as a credential, not prose.
+	regexp.MustCompile(`[A-Za-z0-9_-]{28,}`),
+}
+
 func redactLLMLimitEventMessage(message, keyID string) string {
-	if keyID == "" {
-		return message
+	if keyID != "" {
+		message = strings.ReplaceAll(message, keyID, "[redacted]")
 	}
-	return strings.ReplaceAll(message, keyID, "[redacted]")
+	for _, pattern := range llmLimitTokenPatterns {
+		message = pattern.ReplaceAllString(message, "[redacted]")
+	}
+	return message
 }
 
 // handleClawLLMLimit exposes the block on a claw, and clears it.

--- a/pkg/hub/llm_usage_limit.go
+++ b/pkg/hub/llm_usage_limit.go
@@ -265,8 +265,9 @@ func (s *Server) releaseLLMUsageLimit(keyID, reason string, announce bool) {
 	// the re-latch a minute later would make "Provider cap lifted" a lie the
 	// operator reads three times per episode. The lift is announced by
 	// confirmLLMLimitLift once proven — an authored turn on the key, or an
-	// operator clearing the block. A hub restart forgets the probe, in which
-	// case the lift goes unannounced rather than misannounced.
+	// operator clearing the block. The probe itself is derivable from durable
+	// state — a released record with no released event yet — so a restart
+	// re-arms it (seedLLMLimitProbes) instead of forgetting it.
 	if s.llmLimitProbing == nil {
 		s.llmLimitProbing = map[string]bool{}
 	}
@@ -360,9 +361,40 @@ func (s *Server) resumeClawAfterLLMLimit(clawID string) {
 // the claw comes back.
 const llmLimitResumeWake = "[hub] The model provider's allowance is back. Continue where you left off."
 
+// seedLLMLimitProbes re-arms, after a restart, every release that is still
+// waiting for its proof. The probe set lives in memory, and losing it between
+// the release and the first successful turn would leave the operator with an
+// "account capped" alert whose recovery never arrives: the record says
+// released, no turn can confirm it, and nothing else looks again. Durable
+// state answers the question on its own — a released record whose released
+// event has not been recorded is exactly a pending probe.
+func (s *Server) seedLLMLimitProbes() {
+	for _, record := range s.llmUsageLimitRecords() {
+		if record.Active() {
+			continue
+		}
+		var announced int
+		if err := s.db.QueryRow(`SELECT EXISTS(SELECT 1 FROM infra_events WHERE event_key=?)`,
+			llmLimitEventKey(record, "provider_limit_released")).Scan(&announced); err != nil {
+			log.Printf("[llm-limit] check released event for key %q: %v", record.KeyID, err)
+			continue
+		}
+		if announced != 0 {
+			continue
+		}
+		s.llmLimitMu.Lock()
+		if s.llmLimitProbing == nil {
+			s.llmLimitProbing = map[string]bool{}
+		}
+		s.llmLimitProbing[record.KeyID] = true
+		s.llmLimitMu.Unlock()
+	}
+}
+
 // startLLMUsageLimitScheduler releases limits whose deadline has passed and
 // reconciles stored latches against the record table.
 func (s *Server) startLLMUsageLimitScheduler() {
+	s.seedLLMLimitProbes()
 	go func() {
 		ticker := time.NewTicker(llmLimitScheduleInterval)
 		defer ticker.Stop()
@@ -679,18 +711,23 @@ func formatLLMLimitDeadline(at time.Time) string {
 // claws sharing a key formerly produced four "Agent stalled" reports, which
 // sent operators looking for four agent bugs instead of one billing cap.
 func (s *Server) recordLLMLimitEvent(record llmUsageLimitRecord, parked int, eventType string) {
-	maskedKey := maskLLMLimitKeyID(record.KeyID)
-	eventKey := fmt.Sprintf("%s:%s:%d:%d", eventType, maskedKey, epochMillis(record.DetectedAt), record.Retries)
 	if err := s.recordInfraEvent(infraEvent{
-		EventKey: eventKey, EventType: eventType, Subject: record.Provider,
+		EventKey: llmLimitEventKey(record, eventType), EventType: eventType, Subject: record.Provider,
 		Detail: map[string]any{
-			"provider": record.Provider, "key_id": maskedKey, "parked_claws": parked,
+			"provider": record.Provider, "key_id": maskLLMLimitKeyID(record.KeyID), "parked_claws": parked,
 			"deadline": formatLLMLimitDeadline(record.RetryAt), "retry_count": record.Retries,
 			"message": redactLLMLimitEventMessage(record.Message, record.KeyID),
 		}, OccurredAt: now(),
 	}); err != nil {
 		log.Printf("[llm-limit] record %s event: %v", eventType, err)
 	}
+}
+
+// llmLimitEventKey names one edge of one episode: the retry number keeps each
+// re-latch its own message, and the same key derived at seed time is how a
+// restarted hub tells an announced lift from a pending one.
+func llmLimitEventKey(record llmUsageLimitRecord, eventType string) string {
+	return fmt.Sprintf("%s:%s:%d:%d", eventType, maskLLMLimitKeyID(record.KeyID), epochMillis(record.DetectedAt), record.Retries)
 }
 
 func maskLLMLimitKeyID(keyID string) string {

--- a/pkg/hub/llm_usage_limit.go
+++ b/pkg/hub/llm_usage_limit.go
@@ -288,11 +288,17 @@ func (s *Server) releaseLLMUsageLimit(keyID, reason string, announce bool) {
 // releaseLLMUsageLimit for why the release itself stays quiet. Idempotent:
 // the event key is fixed while the record stays released, so a second proof
 // is absorbed by the event store's dedupe.
+//
+// The read and the event write happen under ONE hold of llmLimitMu. Claws on
+// a key are resumed together, so one claw's proving turn and another claw's
+// fresh rejection arrive together too; with the write outside the lock, the
+// re-latch could land between them and the record this read as released was
+// announced as lifted while the key was already capped again.
 func (s *Server) confirmLLMLimitLift(keyID string) {
 	s.llmLimitMu.Lock()
+	defer s.llmLimitMu.Unlock()
 	record, had := s.loadLLMUsageLimit(keyID)
 	delete(s.llmLimitProbing, keyID)
-	s.llmLimitMu.Unlock()
 	if !had || record.Active() {
 		return
 	}

--- a/pkg/hub/llm_usage_limit.go
+++ b/pkg/hub/llm_usage_limit.go
@@ -710,6 +710,9 @@ func maskLLMLimitKeyID(keyID string) string {
 var llmLimitTokenPatterns = []*regexp.Regexp{
 	// Provider API keys: sk-..., sk-ant-..., sk-proj-... and friends.
 	regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{8,}`),
+	// An echoed Authorization header: whatever follows "Bearer" is the
+	// credential, however short or oddly spelled.
+	regexp.MustCompile(`(?i)\bbearer\s+[^\s;,'"]+`),
 	// Any long opaque run that reads as a credential, not prose.
 	regexp.MustCompile(`[A-Za-z0-9_-]{28,}`),
 }

--- a/pkg/hub/llm_usage_limit.go
+++ b/pkg/hub/llm_usage_limit.go
@@ -118,6 +118,9 @@ func (s *Server) handleLLMUsageLimit(cc *clawConn, clawID string, limit types.LL
 
 	s.llmLimitMu.Lock()
 	record, had := s.loadLLMUsageLimit(keyID)
+	// Whatever this turn decides, the key is capped now: a release that was
+	// still awaiting proof has just been disproved.
+	delete(s.llmLimitProbing, keyID)
 	opened, relatched := false, false
 	switch {
 	case had && record.Active():
@@ -177,6 +180,10 @@ func (s *Server) handleLLMUsageLimit(cc *clawConn, clawID string, limit types.LL
 	case relatched:
 		log.Printf("[llm-limit] key %q still capped, retry %d scheduled for %s",
 			keyID, record.Retries, formatLLMLimitDeadline(record.RetryAt))
+		// Said out loud: the operator watched the release and must not read
+		// silence as recovery. The event key carries the retry number, so
+		// each re-latch is its own message.
+		s.recordLLMLimitEvent(record, len(latched), "provider_limit_opened")
 	}
 }
 
@@ -253,8 +260,18 @@ func (s *Server) releaseLLMUsageLimit(keyID, reason string, announce bool) {
 		log.Printf("[llm-limit] mark limit released for key %q: %v", keyID, err)
 		return
 	}
+	// A release is a probe until a turn goes through: the cap may well still
+	// be there (clock skew, a late reset, a balance nobody topped up), and
+	// the re-latch a minute later would make "Provider cap lifted" a lie the
+	// operator reads three times per episode. The lift is announced by
+	// confirmLLMLimitLift once proven — an authored turn on the key, or an
+	// operator clearing the block. A hub restart forgets the probe, in which
+	// case the lift goes unannounced rather than misannounced.
+	if s.llmLimitProbing == nil {
+		s.llmLimitProbing = map[string]bool{}
+	}
+	s.llmLimitProbing[keyID] = true
 	s.llmLimitMu.Unlock()
-	s.recordLLMLimitEvent(record, len(clawIDs), "provider_limit_released")
 
 	// Notices and wakes touch sockets, so they happen outside the lock.
 	for _, clawID := range clawIDs {
@@ -264,6 +281,40 @@ func (s *Server) releaseLLMUsageLimit(keyID, reason string, announce bool) {
 		s.resumeClawAfterLLMLimit(clawID)
 	}
 	log.Printf("[llm-limit] key %q released (%s), %d claw(s) resumed", keyID, reason, len(clawIDs))
+}
+
+// confirmLLMLimitLift announces a proven release of the key's latch. See
+// releaseLLMUsageLimit for why the release itself stays quiet. Idempotent:
+// the event key is fixed while the record stays released, so a second proof
+// is absorbed by the event store's dedupe.
+func (s *Server) confirmLLMLimitLift(keyID string) {
+	s.llmLimitMu.Lock()
+	record, had := s.loadLLMUsageLimit(keyID)
+	delete(s.llmLimitProbing, keyID)
+	s.llmLimitMu.Unlock()
+	if !had || record.Active() {
+		return
+	}
+	s.recordLLMLimitEvent(record, len(s.clawsForLLMKey(keyID)), "provider_limit_released")
+}
+
+// observeAuthoredTurnForLLMLimit is the proof a scheduled release waits for:
+// a claw on the key got an answer from the provider. Free when nothing is
+// probing, which is nearly always.
+func (s *Server) observeAuthoredTurnForLLMLimit(clawID string) {
+	s.llmLimitMu.Lock()
+	probing := len(s.llmLimitProbing) != 0
+	s.llmLimitMu.Unlock()
+	if !probing {
+		return
+	}
+	keyID, _ := s.resolveClawLLMKey(clawID)
+	s.llmLimitMu.Lock()
+	waiting := s.llmLimitProbing[keyID]
+	s.llmLimitMu.Unlock()
+	if waiting {
+		s.confirmLLMLimitLift(keyID)
+	}
 }
 
 // resumeClawAfterLLMLimit restarts a parked claw.
@@ -710,6 +761,8 @@ func (s *Server) handleClawLLMLimit(w http.ResponseWriter, r *http.Request, claw
 	case http.MethodDelete:
 		keyID, _ := s.resolveClawLLMKey(clawID)
 		s.releaseLLMUsageLimit(keyID, "An operator cleared the provider usage limit.", true)
+		// The operator says the cap is gone; that is the proof.
+		s.confirmLLMLimitLift(keyID)
 		jsonOK(w, map[string]any{"limited": false})
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/pkg/hub/llm_usage_limit.go
+++ b/pkg/hub/llm_usage_limit.go
@@ -121,6 +121,11 @@ func (s *Server) handleLLMUsageLimit(cc *clawConn, clawID string, limit types.LL
 	// still awaiting proof has just been disproved.
 	delete(s.llmLimitProbing, keyID)
 	opened, relatched := false, false
+	// The release this turn disproves. It is the last time the hub actually
+	// tried, which is what an exhausted alert reports: the schedule below is
+	// bumped as usual, but releaseDueLLMUsageLimits never acts on an
+	// exhausted record, so that deadline is not a retry anyone will see.
+	var lastRetryAt time.Time
 	switch {
 	case had && record.Active():
 		// Same episode, another claw. Keep the schedule exactly as it is: a
@@ -129,6 +134,7 @@ func (s *Server) handleLLMUsageLimit(cc *clawConn, clawID string, limit types.LL
 		// claw.
 	case had:
 		// Released, and the wall is still there. Same episode: back off.
+		lastRetryAt = record.ReleasedAt
 		record.ReleasedAt = time.Time{}
 		record.Retries++
 		record.Provider, record.Message, record.RegainAt = provider, limit.Message, limit.RegainAt
@@ -168,21 +174,21 @@ func (s *Server) handleLLMUsageLimit(cc *clawConn, clawID string, limit types.LL
 	case opened:
 		log.Printf("[llm-limit] key %q capped (%s), %d claw(s) parked until %s: %s",
 			keyID, record.Reason, len(latched), formatLLMLimitDeadline(record.RetryAt), record.Message)
-		s.recordLLMLimitEvent(record, len(latched), "provider_limit_opened")
+		s.recordLLMLimitEvent(record, len(latched), "provider_limit_opened", nil)
 	case relatched && record.Exhausted():
 		log.Printf("[llm-limit] key %q still capped after %d automatic retries, leaving it for an operator: %s",
 			keyID, record.Retries, record.Message)
 		for _, id := range latched {
 			s.publishHubNotice(id, fmt.Sprintf("[hub] The provider still reports a usage limit after %d automatic retries, so the hub stopped retrying. Raise the account limit and clear the block to resume. Last provider message: %s", record.Retries, record.Message))
 		}
-		s.recordLLMLimitEvent(record, len(latched), "provider_limit_exhausted")
+		s.recordLLMLimitEvent(record, len(latched), "provider_limit_exhausted", map[string]any{"last_retry": formatLLMLimitDeadline(lastRetryAt)})
 	case relatched:
 		log.Printf("[llm-limit] key %q still capped, retry %d scheduled for %s",
 			keyID, record.Retries, formatLLMLimitDeadline(record.RetryAt))
 		// Said out loud: the operator watched the release and must not read
 		// silence as recovery. The event key carries the retry number, so
 		// each re-latch is its own message.
-		s.recordLLMLimitEvent(record, len(latched), "provider_limit_opened")
+		s.recordLLMLimitEvent(record, len(latched), "provider_limit_opened", nil)
 	}
 }
 
@@ -301,7 +307,7 @@ func (s *Server) confirmLLMLimitLift(keyID string) {
 	if !had || record.Active() {
 		return
 	}
-	s.recordLLMLimitEvent(record, len(s.clawsForLLMKey(keyID)), "provider_limit_released")
+	s.recordLLMLimitEvent(record, len(s.clawsForLLMKey(keyID)), "provider_limit_released", nil)
 }
 
 // observeAuthoredTurnForLLMLimit is the proof a scheduled release waits for:
@@ -734,14 +740,25 @@ func formatLLMLimitDeadline(at time.Time) string {
 // recordLLMLimitEvent records the fleet-wide account fact once per key. Four
 // claws sharing a key formerly produced four "Agent stalled" reports, which
 // sent operators looking for four agent bugs instead of one billing cap.
-func (s *Server) recordLLMLimitEvent(record llmUsageLimitRecord, parked int, eventType string) {
+//
+// The deadline is left off an exhausted event on purpose: the record still
+// carries one (the latch column needs a non-zero instant), but nothing acts
+// on it, and a message that names it promises a retry that never comes. The
+// caller passes the time of the last real attempt in extra instead.
+func (s *Server) recordLLMLimitEvent(record llmUsageLimitRecord, parked int, eventType string, extra map[string]any) {
+	detail := map[string]any{
+		"provider": record.Provider, "key_id": maskLLMLimitKeyID(record.KeyID), "parked_claws": parked,
+		"retry_count": record.Retries, "message": redactLLMLimitEventMessage(record.Message, record.KeyID),
+	}
+	if eventType != "provider_limit_exhausted" {
+		detail["deadline"] = formatLLMLimitDeadline(record.RetryAt)
+	}
+	for key, value := range extra {
+		detail[key] = value
+	}
 	if err := s.recordInfraEvent(infraEvent{
 		EventKey: llmLimitEventKey(record, eventType), EventType: eventType, Subject: record.Provider,
-		Detail: map[string]any{
-			"provider": record.Provider, "key_id": maskLLMLimitKeyID(record.KeyID), "parked_claws": parked,
-			"deadline": formatLLMLimitDeadline(record.RetryAt), "retry_count": record.Retries,
-			"message": redactLLMLimitEventMessage(record.Message, record.KeyID),
-		}, OccurredAt: now(),
+		Detail: detail, OccurredAt: now(),
 	}); err != nil {
 		log.Printf("[llm-limit] record %s event: %v", eventType, err)
 	}

--- a/pkg/hub/llm_usage_limit_test.go
+++ b/pkg/hub/llm_usage_limit_test.go
@@ -3,6 +3,8 @@ package hub
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
@@ -633,3 +635,63 @@ func TestRedactLLMLimitEventMessageRedactsTokenShapes(t *testing.T) {
 		t.Fatalf("plain prose was mangled: %q", out)
 	}
 }
+
+// A scheduled release is a probe, not a recovery: "Provider cap lifted" must
+// only be said once a turn proves the wall is gone, and every re-latch must
+// tell the operator the hub is still capped instead of staying silent.
+func TestLLMUsageLimitReleaseIsAnnouncedOnlyOnceProven(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	limitClaw(t, s, "claw-limit-probe", "faster", false)
+	limit := types.LLMUsageLimit{Reason: types.LLMLimitUsage, RegainAt: now().Add(-time.Minute), Message: "capped"}
+	s.handleLLMUsageLimit(nil, "claw-limit-probe", limit)
+
+	for attempt := 1; attempt <= llmLimitMaxAutoRetries; attempt++ {
+		s.releaseLLMUsageLimit("faster", "test release", false)
+		s.handleLLMUsageLimit(nil, "claw-limit-probe", limit)
+	}
+	want := "provider_limit_opened,provider_limit_opened,provider_limit_opened,provider_limit_exhausted"
+	if got := strings.Join(infraEventTypes(t, s), ","); got != want {
+		t.Fatalf("events = %s, want %s", got, want)
+	}
+}
+
+// Once a claw on the key authors a turn after a scheduled release, the lift
+// is real and is announced exactly once.
+func TestLLMUsageLimitAuthoredTurnConfirmsTheLift(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	limitClaw(t, s, "claw-limit-proof", "faster", false)
+	limitClaw(t, s, "claw-limit-other-key", "other", false)
+	s.handleLLMUsageLimit(nil, "claw-limit-proof", types.LLMUsageLimit{Reason: types.LLMLimitUsage, RegainAt: now().Add(-time.Minute), Message: "capped"})
+	s.releaseLLMUsageLimit("faster", "test release", false)
+	if got := strings.Join(infraEventTypes(t, s), ","); got != "provider_limit_opened" {
+		t.Fatalf("events after a scheduled release = %s, want the release to stay unannounced", got)
+	}
+
+	s.observeTurnOutcome(nil, "claw-limit-other-key", "msg-other", "Working on the other key.")
+	if got := strings.Join(infraEventTypes(t, s), ","); got != "provider_limit_opened" {
+		t.Fatalf("a turn on an unrelated key confirmed the lift: %s", got)
+	}
+	s.observeTurnOutcome(nil, "claw-limit-proof", "msg-1", "Back to work.")
+	s.observeTurnOutcome(nil, "claw-limit-proof", "msg-2", "Still working.")
+	if got := strings.Join(infraEventTypes(t, s), ","); got != "provider_limit_opened,provider_limit_released" {
+		t.Fatalf("events = %s, want exactly one released after the proving turn", got)
+	}
+}
+
+// An operator clearing the block is a confirmed lift in itself.
+func TestLLMUsageLimitOperatorClearAnnouncesTheLift(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	limitClaw(t, s, "claw-limit-clear", "faster", false)
+	s.handleLLMUsageLimit(nil, "claw-limit-clear", types.LLMUsageLimit{Reason: types.LLMLimitUsage, RegainAt: now().Add(time.Hour), Message: "capped"})
+	req := httptest.NewRequest(http.MethodDelete, "/api/claws/claw-limit-clear/llm-limit", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxTenantKey{}, "test-tenant-id"))
+	rr := httptest.NewRecorder()
+	s.handleClawLLMLimit(rr, req, "claw-limit-clear")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("DELETE = %d: %s", rr.Code, rr.Body.String())
+	}
+	if got := strings.Join(infraEventTypes(t, s), ","); got != "provider_limit_opened,provider_limit_released" {
+		t.Fatalf("events = %s, want the operator clear announced", got)
+	}
+}
+

--- a/pkg/hub/llm_usage_limit_test.go
+++ b/pkg/hub/llm_usage_limit_test.go
@@ -740,3 +740,52 @@ func TestLLMUsageLimitProbeSurvivesRestart(t *testing.T) {
 		t.Fatal("reseed re-armed a probe for a lift that was already announced")
 	}
 }
+
+// The proving turn and a fresh rejection arrive together (claws sharing a
+// key are resumed together), so confirming the lift must be atomic with the
+// re-latch: whichever wins, the log never says "lifted" after "capped again".
+func TestLLMUsageLimitLiftConfirmationIsAtomicWithRelatch(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	limitClaw(t, s, "claw-limit-race-a", "faster", false)
+	limitClaw(t, s, "claw-limit-race-b", "faster", false)
+	limit := types.LLMUsageLimit{Reason: types.LLMLimitUsage, RegainAt: now().Add(-time.Minute), Message: "capped"}
+	eventKeys := func() []string {
+		rows, err := s.db.Query(`SELECT event_key FROM infra_events ORDER BY rowid`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+		var out []string
+		for rows.Next() {
+			var key string
+			if err := rows.Scan(&key); err != nil {
+				t.Fatal(err)
+			}
+			out = append(out, key)
+		}
+		return out
+	}
+	for i := 0; i < 100; i++ {
+		for _, table := range []string{"llm_usage_limits", "infra_events"} {
+			if _, err := s.db.Exec(`DELETE FROM ` + table); err != nil {
+				t.Fatal(err)
+			}
+		}
+		s.handleLLMUsageLimit(nil, "claw-limit-race-a", limit)
+		s.releaseLLMUsageLimit("faster", "test release", false)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); s.observeTurnOutcome(nil, "claw-limit-race-a", "msg-proof", "Back to work.") }()
+		go func() { defer wg.Done(); s.handleLLMUsageLimit(nil, "claw-limit-race-b", limit) }()
+		wg.Wait()
+		relatched := false
+		for _, key := range eventKeys() {
+			if strings.HasPrefix(key, "provider_limit_opened:") && strings.HasSuffix(key, ":1") {
+				relatched = true
+			}
+			if strings.HasPrefix(key, "provider_limit_released:") && relatched {
+				t.Fatalf("run %d announced the lift after the re-latch: %v", i, eventKeys())
+			}
+		}
+	}
+}

--- a/pkg/hub/llm_usage_limit_test.go
+++ b/pkg/hub/llm_usage_limit_test.go
@@ -842,3 +842,43 @@ func TestLLMUsageLimitUnprovenReleaseOutlivesEpisodeMemory(t *testing.T) {
 		t.Fatal("a proven, expired episode was kept")
 	}
 }
+
+// An exhausted cap reports the last attempt the hub actually made. The
+// record's deadline is bumped on every re-latch, exhausted or not, but
+// releaseDueLLMUsageLimits never acts on an exhausted one, so rendering it
+// as "Last retry" named a future instant nothing would honour.
+func TestLLMUsageLimitExhaustedEventReportsTheLastRealRetry(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	limitClaw(t, s, "claw-limit-final", "faster", false)
+	limit := types.LLMUsageLimit{Reason: types.LLMLimitUsage, RegainAt: now().Add(-time.Minute), Message: "capped"}
+	s.handleLLMUsageLimit(nil, "claw-limit-final", limit)
+	var lastRelease time.Time
+	for attempt := 1; attempt <= llmLimitMaxAutoRetries; attempt++ {
+		s.releaseLLMUsageLimit("faster", "test release", false)
+		record, _ := s.loadLLMUsageLimit("faster")
+		lastRelease = record.ReleasedAt
+		s.handleLLMUsageLimit(nil, "claw-limit-final", limit)
+	}
+	var raw string
+	if err := s.db.QueryRow(`SELECT detail FROM infra_events WHERE event_type='provider_limit_exhausted'`).Scan(&raw); err != nil {
+		t.Fatal(err)
+	}
+	var detail map[string]any
+	if err := json.Unmarshal([]byte(raw), &detail); err != nil {
+		t.Fatal(err)
+	}
+	if got := detail["last_retry"]; got != formatLLMLimitDeadline(lastRelease) {
+		t.Fatalf("last_retry = %v, want the release at %s", got, formatLLMLimitDeadline(lastRelease))
+	}
+	if _, has := detail["deadline"]; has {
+		t.Fatalf("exhausted event still carries a deadline nothing will honour: %v", detail["deadline"])
+	}
+	msg := buildInfraMessage(infraEventRow{EventType: "provider_limit_exhausted", Subject: "anthropic", Detail: detail, OccurredAt: now()}, now())
+	fields := map[string]string{}
+	for _, f := range msg.Fields {
+		fields[f.Label] = f.Value
+	}
+	if fields["Last retry"] != formatLLMLimitDeadline(lastRelease) || fields["Deadline"] != "" {
+		t.Fatalf("exhausted fields = %v, want only the last real retry", fields)
+	}
+}

--- a/pkg/hub/llm_usage_limit_test.go
+++ b/pkg/hub/llm_usage_limit_test.go
@@ -603,3 +603,33 @@ func TestLLMUsageLimitIgnoresTheGenericReplayPrefix(t *testing.T) {
 		t.Error("a non-definite bridge body created a usage-limit record for the whole key")
 	}
 }
+
+// redactLLMLimitEventMessage must catch credential-shaped substrings a
+// provider error quotes back, not merely the literal configured key id —
+// which is often an alias that never appears in the provider's text at all.
+func TestRedactLLMLimitEventMessageRedactsTokenShapes(t *testing.T) {
+	cases := []struct {
+		name    string
+		message string
+		secret  string
+	}{
+		{"sk token with unrelated alias key", "invalid key sk-ant-api03-AAAA1111BBBB2222", "sk-ant-api03-AAAA1111BBBB2222"},
+		{"long opaque credential", "token ghp_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4 rejected", "ghp_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"},
+		{"configured key id itself", "key anthropic-prod is over its cap", "anthropic-prod"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := redactLLMLimitEventMessage(tc.message, "anthropic-prod")
+			if strings.Contains(out, tc.secret) {
+				t.Fatalf("secret survived redaction: %q", out)
+			}
+			if !strings.Contains(out, "[redacted]") {
+				t.Fatalf("nothing was redacted from %q -> %q", tc.message, out)
+			}
+		})
+	}
+	const prose = "monthly allowance reached, resets at midnight UTC"
+	if out := redactLLMLimitEventMessage(prose, "anthropic-prod"); out != prose {
+		t.Fatalf("plain prose was mangled: %q", out)
+	}
+}

--- a/pkg/hub/llm_usage_limit_test.go
+++ b/pkg/hub/llm_usage_limit_test.go
@@ -789,3 +789,41 @@ func TestLLMUsageLimitLiftConfirmationIsAtomicWithRelatch(t *testing.T) {
 		}
 	}
 }
+
+// A released episode is forgotten after llmLimitEpisodeMemory — unless its
+// lift is still unproven. The record is what the proving turn confirms
+// against and what a restart re-derives the probe from; pruning it first
+// left the channel's "account capped" alert without a recovery forever (the
+// only claw on the key was offline through the release and turned hours
+// later), and a reseed after that had nothing to find.
+func TestLLMUsageLimitUnprovenReleaseOutlivesEpisodeMemory(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	limitClaw(t, s, "claw-limit-late", "faster", false)
+	s.handleLLMUsageLimit(nil, "claw-limit-late", types.LLMUsageLimit{Reason: types.LLMLimitUsage, RegainAt: now().Add(-time.Minute), Message: "capped"})
+	s.releaseLLMUsageLimit("faster", "test release", false)
+	if _, err := s.db.Exec(`UPDATE llm_usage_limits SET released_at=? WHERE key_id='faster'`, epochMillis(now().Add(-llmLimitEpisodeMemory-time.Hour))); err != nil {
+		t.Fatal(err)
+	}
+	s.releaseDueLLMUsageLimits()
+	if _, had := s.loadLLMUsageLimit("faster"); !had {
+		t.Fatal("the scheduler pruned a released record whose lift was never proven")
+	}
+
+	// The same restart-shaped gap: the probe set is gone, the durable state
+	// still has to be enough to re-arm it.
+	s.llmLimitMu.Lock()
+	s.llmLimitProbing = nil
+	s.llmLimitMu.Unlock()
+	s.seedLLMLimitProbes()
+	s.releaseDueLLMUsageLimits()
+	s.observeTurnOutcome(nil, "claw-limit-late", "msg-1", "Back to work.")
+	if got := strings.Join(infraEventTypes(t, s), ","); got != "provider_limit_opened,provider_limit_released" {
+		t.Fatalf("events after the late proving turn = %s, want the lift announced", got)
+	}
+
+	// Proven, and older than the memory window: now it is history.
+	s.releaseDueLLMUsageLimits()
+	if _, had := s.loadLLMUsageLimit("faster"); had {
+		t.Fatal("a proven, expired episode was kept")
+	}
+}

--- a/pkg/hub/llm_usage_limit_test.go
+++ b/pkg/hub/llm_usage_limit_test.go
@@ -695,3 +695,14 @@ func TestLLMUsageLimitOperatorClearAnnouncesTheLift(t *testing.T) {
 	}
 }
 
+// A short bearer token echoed in an Authorization header is a credential too,
+// whatever its length or alphabet.
+func TestRedactLLMLimitEventMessageRedactsBearerEchoes(t *testing.T) {
+	out := redactLLMLimitEventMessage("429: Authorization: Bearer dG9rZW4tdGVzdA==; org org_abc123 over quota", "prod-openai")
+	if strings.Contains(out, "dG9rZW4tdGVzdA==") {
+		t.Fatalf("bearer token survived redaction: %q", out)
+	}
+	if !strings.Contains(out, "org_abc123") {
+		t.Fatalf("account identifier needed to act on the message was mangled: %q", out)
+	}
+}

--- a/pkg/hub/llm_usage_limit_test.go
+++ b/pkg/hub/llm_usage_limit_test.go
@@ -706,3 +706,37 @@ func TestRedactLLMLimitEventMessageRedactsBearerEchoes(t *testing.T) {
 		t.Fatalf("account identifier needed to act on the message was mangled: %q", out)
 	}
 }
+
+// A restart between the scheduled release and its proving turn must not lose
+// the recovery alert: the probe is re-derived from the record and the event
+// log, so the first authored turn after boot still announces the lift once.
+func TestLLMUsageLimitProbeSurvivesRestart(t *testing.T) {
+	s, _ := NewTestServerWithConfig(t, nil, "", "", "")
+	limitClaw(t, s, "claw-limit-reboot", "faster", false)
+	s.handleLLMUsageLimit(nil, "claw-limit-reboot", types.LLMUsageLimit{Reason: types.LLMLimitUsage, RegainAt: now().Add(-time.Minute), Message: "capped"})
+	s.releaseLLMUsageLimit("faster", "test release", false)
+
+	// The restart: in-memory probes are gone, durable state is what it was.
+	s.llmLimitMu.Lock()
+	s.llmLimitProbing = nil
+	s.llmLimitMu.Unlock()
+	s.observeTurnOutcome(nil, "claw-limit-reboot", "msg-0", "Nobody re-armed me.")
+	if got := strings.Join(infraEventTypes(t, s), ","); got != "provider_limit_opened" {
+		t.Fatalf("events without a reseed = %s, want the lift still pending", got)
+	}
+
+	s.seedLLMLimitProbes()
+	s.observeTurnOutcome(nil, "claw-limit-reboot", "msg-1", "Back to work.")
+	if got := strings.Join(infraEventTypes(t, s), ","); got != "provider_limit_opened,provider_limit_released" {
+		t.Fatalf("events after reseed = %s, want exactly one released", got)
+	}
+
+	// An already-announced lift is not re-armed by a later restart.
+	s.seedLLMLimitProbes()
+	s.llmLimitMu.Lock()
+	probing := s.llmLimitProbing["faster"]
+	s.llmLimitMu.Unlock()
+	if probing {
+		t.Fatal("reseed re-armed a probe for a lift that was already announced")
+	}
+}

--- a/pkg/hub/llm_usage_limit_test.go
+++ b/pkg/hub/llm_usage_limit_test.go
@@ -705,6 +705,21 @@ func TestRedactLLMLimitEventMessageRedactsBearerEchoes(t *testing.T) {
 	if !strings.Contains(out, "org_abc123") {
 		t.Fatalf("account identifier needed to act on the message was mangled: %q", out)
 	}
+	// A quoted token is one token, delimiters and all; a header block's next
+	// line is a different header, not the credential.
+	for _, tc := range []struct{ message, secret, keep string }{
+		{`429: Authorization: Bearer "tok;part2" rejected`, "tok;part2", "rejected"},
+		{"429: Authorization: Bearer 'a,b c' rejected", "a,b", "rejected"},
+		{"Authorization: Bearer\nRetry-After: 120", "", "Retry-After: 120"},
+	} {
+		out := redactLLMLimitEventMessage(tc.message, "prod-openai")
+		if tc.secret != "" && strings.Contains(out, tc.secret) {
+			t.Fatalf("bearer token survived redaction: %q -> %q", tc.message, out)
+		}
+		if !strings.Contains(out, tc.keep) {
+			t.Fatalf("redaction swallowed adjacent text: %q -> %q", tc.message, out)
+		}
+	}
 }
 
 // A restart between the scheduled release and its proving turn must not lose

--- a/pkg/hub/notify_validate.go
+++ b/pkg/hub/notify_validate.go
@@ -228,6 +228,18 @@ func validateNotifierRemovals(current, patch *types.NotificationsConfig, factori
 			references[trimmed] = append(references[trimmed], fmt.Sprintf("scheduled report %q", scheduled.ID))
 		}
 	}
+	// Enabled infrastructure routes are guarded the same way as schedules:
+	// the patch carries an absent infra block forward, so a client that
+	// never saw the key can drop a notifier the stored route still names.
+	if patch.Infra.IsEnabled() {
+		for _, route := range patch.Infra.Routes {
+			trimmed := strings.TrimSpace(route.Via)
+			if trimmed == "" {
+				continue
+			}
+			references[trimmed] = append(references[trimmed], "infrastructure route")
+		}
+	}
 	var problems []string
 	for _, name := range removed {
 		used := references[name]

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -213,6 +213,9 @@ type Server struct {
 	scheduledNotifierStop chan struct{}
 	scheduledNotifierDone chan struct{}
 
+	infraNotifierStop chan struct{}
+	infraNotifierDone chan struct{}
+
 	// dependencyWatcherStop/Done give the status poll the same shutdown
 	// guarantee as notifiers: its DB write must finish before the DB closes.
 	dependencyWatcherStop chan struct{}
@@ -581,6 +584,7 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 	srv.startIntegrationPoller()
 	srv.startLifecycleNotifier()
 	srv.startScheduledNotifier()
+	srv.startInfraNotifier()
 	srv.startLLMUsageLimitScheduler()
 	srv.attachLLMUsageLimitsToDependencyStatus(srv.dependencyStatus)
 	srv.startDependencyWatcher()
@@ -662,6 +666,7 @@ func (s *Server) run(ctx context.Context, opts ...RunOptions) error {
 		// stash dies with the process).
 		s.stopLifecycleNotifier(10 * time.Second)
 		s.stopScheduledNotifier(10 * time.Second)
+		s.stopInfraNotifier(10 * time.Second)
 		s.stopDependencyWatcher(10 * time.Second)
 		if closeErr := s.db.Close(); closeErr != nil {
 			return fmt.Errorf("close database: %w", closeErr)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -216,6 +216,12 @@ type Server struct {
 	infraNotifierStop chan struct{}
 	infraNotifierDone chan struct{}
 
+	// infraPendingDeliveries mirrors lifecyclePendingDeliveries for the infra
+	// loop: a delivery row whose insert failed after a successful send is
+	// stashed and retried, never re-sent. Only touched from the infra tick
+	// goroutine — ticks never overlap.
+	infraPendingDeliveries map[infraDeliveryKey]infraPendingDelivery
+
 	// dependencyWatcherStop/Done give the status poll the same shutdown
 	// guarantee as notifiers: its DB write must finish before the DB closes.
 	dependencyWatcherStop chan struct{}
@@ -573,6 +579,11 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 	// emitted in that window would be stamped as pre-existing history and
 	// silently dropped.
 	srv.initLifecycleNotifierBaseline()
+	// The infra baseline needs the same ordering guarantee: the dependency
+	// watcher and the LLM limit latch below produce infra events whether or
+	// not any route is configured, and a route must never replay the history
+	// recorded before it existed.
+	srv.initInfraNotifierBaseline()
 
 	srv.startPRWatcher()
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -157,6 +157,10 @@ type Server struct {
 	pollWarnings              map[string]struct{}
 	noProgressMu              sync.Mutex // serializes pause/resume state across the DB and active connection
 	llmLimitMu                sync.Mutex // serializes provider usage-limit records (see llm_usage_limit.go)
+	// llmLimitProbing holds keys whose latch was released on a deadline and
+	// whose lift is not yet proven by a turn (see releaseLLMUsageLimit).
+	// Guarded by llmLimitMu.
+	llmLimitProbing map[string]bool
 
 	// webhookDedup prevents duplicate Linear webhook deliveries from creating
 	// duplicate claws. Keyed by issue transition fingerprint; entries expire after 30s.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -213,6 +213,11 @@ type Server struct {
 	scheduledNotifierStop chan struct{}
 	scheduledNotifierDone chan struct{}
 
+	// dependencyWatcherStop/Done give the status poll the same shutdown
+	// guarantee as notifiers: its DB write must finish before the DB closes.
+	dependencyWatcherStop chan struct{}
+	dependencyWatcherDone chan struct{}
+
 	// scheduledTransientFailures tracks consecutive transient send failures
 	// per scheduled (id, via) state key, bounding minutely retries of one
 	// slot (see scheduledMaxTransientFailures). Shared between the
@@ -578,6 +583,7 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 	srv.startScheduledNotifier()
 	srv.startLLMUsageLimitScheduler()
 	srv.attachLLMUsageLimitsToDependencyStatus(srv.dependencyStatus)
+	srv.startDependencyWatcher()
 
 	return srv, nil
 }
@@ -649,13 +655,14 @@ func (s *Server) run(ctx context.Context, opts ...RunOptions) error {
 		// ListenAndServe returns as soon as Shutdown starts. Wait for it to
 		// finish draining active requests before closing their database.
 		<-shutdownDone
-		// Stop both notifier loops before the DB closes: a tick in flight
+		// Stop the notifier loops and dependency watcher before the DB closes: a tick in flight
 		// could otherwise complete an external Slack send and then fail the
 		// delivery-row insert (or scheduled dedupe-state upsert) against the
 		// closed DB, re-sending the event after restart (the in-memory retry
 		// stash dies with the process).
 		s.stopLifecycleNotifier(10 * time.Second)
 		s.stopScheduledNotifier(10 * time.Second)
+		s.stopDependencyWatcher(10 * time.Second)
 		if closeErr := s.db.Close(); closeErr != nil {
 			return fmt.Errorf("close database: %w", closeErr)
 		}

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -81,6 +81,7 @@ type SettingsView struct {
 	Auth                 *AuthView                   `json:"auth,omitempty"`
 	Notifications        *NotificationsView          `json:"notifications"`
 	LifecycleEventTypes  []string                    `json:"lifecycleEventTypes"`
+	InfraEventTypes      []string                    `json:"infraEventTypes"`
 	// ConcurrencyGroups limits simultaneously running claws per group. 0 = unlimited.
 	ConcurrencyGroups []ConcurrencyGroupView `json:"concurrencyGroups"`
 	// MaxConcurrentClaws limits simultaneously running claws. 0 = unlimited.
@@ -93,6 +94,7 @@ type SettingsView struct {
 type NotificationsView struct {
 	Notifiers map[string]NotifierView     `json:"notifiers"`
 	Lifecycle *LifecycleNotificationsView `json:"lifecycle,omitempty"`
+	Infra     *InfraNotificationsView     `json:"infra,omitempty"`
 	// Scheduled mirrors notifications.scheduled. It holds no secret — a
 	// schedule only names notifiers, a report and a wall-clock slot.
 	Scheduled []ScheduledNotificationView `json:"scheduled"`
@@ -140,6 +142,15 @@ type LifecycleNotificationsView struct {
 	IdleAfter          string                       `json:"idleAfter,omitempty"`
 	StageProgressAfter string                       `json:"stageProgressAfter,omitempty"`
 	Events             *types.LifecycleEventToggles `json:"events,omitempty"`
+}
+
+// InfraNotificationsView uses the same names as types.InfraNotificationsConfig
+// so the settings screen can safely send the redacted view back in a PATCH.
+type InfraNotificationsView struct {
+	Enabled      bool               `json:"enabled"`
+	Routes       []types.InfraRoute `json:"routes"`
+	PollInterval string             `json:"pollInterval,omitempty"`
+	RepeatAfter  string             `json:"repeatAfter,omitempty"`
 }
 
 type AuthView struct {
@@ -530,6 +541,7 @@ func (s *Server) getSettings(w http.ResponseWriter, r *http.Request) {
 	}
 	view.ModelAuthProfiles = []ModelAuthProfileView{}
 	view.LifecycleEventTypes = append([]string(nil), types.LifecycleEventTypes...)
+	view.InfraEventTypes = append([]string(nil), types.InfraEventTypes...)
 	view.Notifications = buildNotificationsView(s.hubCfg.Notifications)
 	for _, profile := range s.hubCfg.ModelAuthProfiles {
 		if profile == nil {
@@ -767,6 +779,16 @@ func buildNotificationsView(cfg *types.NotificationsConfig) *NotificationsView {
 			lifecycle.Events = &events
 		}
 		view.Lifecycle = lifecycle
+	}
+	if ic := cfg.Infra; ic != nil {
+		infra := &InfraNotificationsView{
+			Enabled: ic.IsEnabled(), Routes: make([]types.InfraRoute, len(ic.Routes)),
+			PollInterval: ic.PollInterval, RepeatAfter: ic.RepeatAfter,
+		}
+		for i, route := range ic.Routes {
+			infra.Routes[i] = types.InfraRoute{Via: route.Via, Events: append([]string(nil), route.Events...)}
+		}
+		view.Infra = infra
 	}
 	for _, scheduled := range cfg.Scheduled {
 		view.Scheduled = append(view.Scheduled, scheduledNotificationViewOf(scheduled))
@@ -1235,6 +1257,14 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 		// its own change.
 		if patch.Notifications.Scheduled == nil && s.hubCfg.Notifications != nil {
 			patch.Notifications.Scheduled = append([]types.ScheduledNotificationConfig(nil), s.hubCfg.Notifications.Scheduled...)
+		}
+		if patch.Notifications.Infra == nil && s.hubCfg.Notifications != nil && s.hubCfg.Notifications.Infra != nil {
+			infra := *s.hubCfg.Notifications.Infra
+			infra.Routes = append([]types.InfraRoute(nil), infra.Routes...)
+			for i := range infra.Routes {
+				infra.Routes[i].Events = append([]string(nil), infra.Routes[i].Events...)
+			}
+			patch.Notifications.Infra = &infra
 		}
 		mergeNotifierSettings(s.hubCfg.Notifications, patch.Notifications)
 		dropRejectedLifecycleDurations(s.hubCfg.Notifications, patch.Notifications)

--- a/pkg/hub/settings.go
+++ b/pkg/hub/settings.go
@@ -869,6 +869,13 @@ func validateSettingsNotifications(current, cfg *types.NotificationsConfig) erro
 	if err := types.ValidateLifecycleNotificationsConfig(cfg); err != nil {
 		return err
 	}
+	// The infra block gets the same whole-block judgement: the infra tick
+	// gates on ValidateInfraNotificationsConfig and pauses every outage and
+	// provider-cap alert when it fails, with one log line as the only
+	// signal, so a defect must be refused here where the screen can show it.
+	if err := types.ValidateInfraNotificationsConfig(cfg); err != nil {
+		return err
+	}
 	for name, notifier := range cfg.Notifiers {
 		// Checked before the unchanged short-circuit and against the stored
 		// value key by key, so editing a notifier that already carries an
@@ -1268,13 +1275,17 @@ func (s *Server) patchSettings(w http.ResponseWriter, r *http.Request) {
 		}
 		mergeNotifierSettings(s.hubCfg.Notifications, patch.Notifications)
 		dropRejectedLifecycleDurations(s.hubCfg.Notifications, patch.Notifications)
-		if err := validateSettingsNotifications(s.hubCfg.Notifications, patch.Notifications); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
+		// Removals are judged first so a notifier an enabled infra route still
+		// names is refused as "still in use" — the message the screen shows
+		// for pipelines and schedules — rather than as the dangling-via
+		// structural error the same patch would also trip below.
 		// s.hubCfg.Factories is read directly: resolveFactories takes the lock
 		// this handler already holds.
 		if err := validateNotifierRemovals(s.hubCfg.Notifications, patch.Notifications, s.hubCfg.Factories); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := validateSettingsNotifications(s.hubCfg.Notifications, patch.Notifications); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}

--- a/pkg/hub/settings_notifications_test.go
+++ b/pkg/hub/settings_notifications_test.go
@@ -1156,3 +1156,66 @@ func TestSettingsPatchNormalizationDoesNotDefeatUnchangedExemption(t *testing.T)
 		t.Fatalf("at = %q, want the normalized %q", got, "09:00")
 	}
 }
+
+// PATCH /api/settings must judge the infra block the way the notifier tick
+// does: a persisted defect there pauses every outage and provider-cap alert
+// hub-wide with one log line as the only signal.
+func TestSettingsPatchRejectsInvalidInfraBlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hub.yaml")
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", path)
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Notifications: &types.NotificationsConfig{
+		Notifiers: map[string]types.NotifierConfig{
+			"ops": {Type: "slack", Settings: map[string]any{"channel": "C0123ABCD", "token_secret": "slack_token"}},
+			"eng": {Type: "slack", Settings: map[string]any{"channel": "C0456EFGH", "token_secret": "slack_token"}},
+		},
+		Infra: &types.InfraNotificationsConfig{Routes: []types.InfraRoute{{Via: "ops"}}},
+	}}, "", "", "")
+	if err := config.SaveHubConfig(s.hubCfg); err != nil {
+		t.Fatal(err)
+	}
+	notifiers := `"notifiers":{"ops":{"type":"slack","channel":"C0123ABCD","token_secret":"slack_token"},"eng":{"type":"slack","channel":"C0456EFGH","token_secret":"slack_token"}}`
+	cases := []struct{ name, infra, want string }{
+		{"enabled without routes", `{"enabled":true,"routes":[]}`, "routes are required"},
+		{"duplicated via", `{"enabled":true,"routes":[{"via":"ops"},{"via":"ops","events":["dependency_down"]}]}`, "duplicated"},
+		{"unknown event", `{"enabled":true,"routes":[{"via":"ops","events":["agent_started"]}]}`, "not a supported infrastructure event"},
+		{"bad repeat_after", `{"enabled":true,"routes":[{"via":"ops"}],"repeatAfter":"tomorrow"}`, "invalid repeat_after"},
+		{"dangling via", `{"enabled":true,"routes":[{"via":"oncall"}]}`, "does not name a configured notifier"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := []byte(`{"notifications":{` + notifiers + `,"infra":` + tc.infra + `}}`)
+			rr := httptest.NewRecorder()
+			s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+			if rr.Code != http.StatusBadRequest || !strings.Contains(rr.Body.String(), tc.want) {
+				t.Fatalf("PATCH = %d (%s), want 400 mentioning %q", rr.Code, rr.Body.String(), tc.want)
+			}
+			if got := s.hubCfg.Notifications.Infra.Routes; len(got) != 1 || got[0].Via != "ops" {
+				t.Fatalf("rejected infra block was persisted: %#v", got)
+			}
+		})
+	}
+
+	// Removing the notifier an enabled infra route still names — from a client
+	// that never saw the infra key, so the stored route is carried forward —
+	// is the same dangle and must be rejected, not persisted.
+	body := []byte(`{"notifications":{"notifiers":{"eng":{"type":"slack","channel":"C0456EFGH","token_secret":"slack_token"}}}}`)
+	rr := httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusBadRequest || !strings.Contains(rr.Body.String(), "still in use") {
+		t.Fatalf("carry-forward removal = %d (%s), want 400 naming the infrastructure route", rr.Code, rr.Body.String())
+	}
+	if _, kept := s.hubCfg.Notifications.Notifiers["ops"]; !kept {
+		t.Fatal("rejected removal still persisted")
+	}
+
+	// A valid block still saves.
+	body = []byte(`{"notifications":{` + notifiers + `,"infra":{"enabled":true,"routes":[{"via":"ops"},{"via":"eng","events":["provider_limit_exhausted"]}],"repeatAfter":"2h"}}}`)
+	rr = httptest.NewRecorder()
+	s.patchSettings(rr, httptest.NewRequest(http.MethodPatch, "/api/settings", bytes.NewReader(body)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("valid infra PATCH = %d: %s", rr.Code, rr.Body.String())
+	}
+	if got := s.hubCfg.Notifications.Infra.Routes; len(got) != 2 || got[1].Via != "eng" {
+		t.Fatalf("valid infra block not persisted: %#v", got)
+	}
+}

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -676,8 +676,12 @@ type InfraRoute struct {
 }
 
 // InfraNotificationsConfig configures edge-triggered infrastructure alerts.
-// RepeatAfter is deliberately opt-in: an outage does not become more actionable
-// because it repeats in a channel every hour.
+// RepeatAfter re-alerts about a dependency that is still degraded or down once
+// the interval elapses after the previous alert. It is deliberately opt-in: an
+// outage does not become more actionable because it repeats in a channel every
+// hour. Provider caps are not repeated by it — the usage-limit latch already
+// re-emits on its own cadence (opened, exhausted when retries run out,
+// released), each with a stated deadline.
 type InfraNotificationsConfig struct {
 	Enabled      *bool        `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	Routes       []InfraRoute `yaml:"routes,omitempty" json:"routes,omitempty"`

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -585,6 +585,8 @@ type NotificationsConfig struct {
 	Lifecycle *LifecycleNotificationsConfig `yaml:"lifecycle,omitempty" json:"lifecycle,omitempty"`
 	// Scheduled configures time-driven reports sent through named notifiers.
 	Scheduled []ScheduledNotificationConfig `yaml:"scheduled,omitempty" json:"scheduled,omitempty"`
+	// Infra configures fleet-wide dependency and provider-limit notifications.
+	Infra *InfraNotificationsConfig `yaml:"infra,omitempty" json:"infra,omitempty"`
 }
 
 // ScheduledNotificationConfig configures a report sent at a wall-clock time.
@@ -664,6 +666,27 @@ func IsInfraEventType(event string) bool {
 type LifecycleRoute struct {
 	Via    string   `yaml:"via" json:"via"`
 	Events []string `yaml:"events,omitempty" json:"events,omitempty"`
+}
+
+// InfraRoute sends selected infrastructure events through a named notifier.
+// An empty Events list receives every infrastructure event type.
+type InfraRoute struct {
+	Via    string   `yaml:"via" json:"via"`
+	Events []string `yaml:"events,omitempty" json:"events,omitempty"`
+}
+
+// InfraNotificationsConfig configures edge-triggered infrastructure alerts.
+// RepeatAfter is deliberately opt-in: an outage does not become more actionable
+// because it repeats in a channel every hour.
+type InfraNotificationsConfig struct {
+	Enabled      *bool        `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Routes       []InfraRoute `yaml:"routes,omitempty" json:"routes,omitempty"`
+	PollInterval string       `yaml:"poll_interval,omitempty" json:"pollInterval,omitempty"`
+	RepeatAfter  string       `yaml:"repeat_after,omitempty" json:"repeatAfter,omitempty"`
+}
+
+func (c *InfraNotificationsConfig) IsEnabled() bool {
+	return c != nil && (c.Enabled == nil || *c.Enabled)
 }
 
 // LifecycleNotificationsConfig configures outbound notifications for agent

--- a/pkg/types/template.go
+++ b/pkg/types/template.go
@@ -284,8 +284,8 @@ type GitHubAppConfig struct {
 // GitHubRepoAccess specifies a repo and the permissions needed. Workspace
 // repository lists may also use glob patterns.
 type GitHubRepoAccess struct {
-	Repo        string `yaml:"repo"        json:"repo"`        // e.g. "owner/repo", "*-infra-*", or "owner/*"
-	Permissions string `yaml:"permissions" json:"permissions"` // "read" or "write" (default: "read")
+	Repo        string `yaml:"repo"        json:"repo"`            // e.g. "owner/repo", "*-infra-*", or "owner/*"
+	Permissions string `yaml:"permissions" json:"permissions"`     // "read" or "write" (default: "read")
 	Clone       *bool  `yaml:"clone"       json:"clone,omitempty"` // whether to clone the repo; nil/true means clone
 }
 
@@ -631,6 +631,27 @@ var LifecycleEventTypes = []string{
 // wire type.
 func IsLifecycleEventType(event string) bool {
 	for _, eventType := range LifecycleEventTypes {
+		if event == eventType {
+			return true
+		}
+	}
+	return false
+}
+
+// InfraEventTypes is the vocabulary persisted for fleet-wide infrastructure
+// changes. It intentionally does not share lifecycle's per-task-run stream.
+var InfraEventTypes = []string{
+	"dependency_down",
+	"dependency_degraded",
+	"dependency_recovered",
+	"provider_limit_opened",
+	"provider_limit_exhausted",
+	"provider_limit_released",
+}
+
+// IsInfraEventType reports whether event is a supported infrastructure event.
+func IsInfraEventType(event string) bool {
+	for _, eventType := range InfraEventTypes {
 		if event == eventType {
 			return true
 		}

--- a/pkg/types/validation.go
+++ b/pkg/types/validation.go
@@ -779,7 +779,10 @@ func ValidateNotificationsConfig(cfg *NotificationsConfig) error {
 	if err := validateScheduledBlock(cfg); err != nil {
 		return err
 	}
-	return validateLifecycleBlock(cfg)
+	if err := validateLifecycleBlock(cfg); err != nil {
+		return err
+	}
+	return validateInfraBlock(cfg)
 }
 
 // ValidateScheduledNotificationsConfig validates only what the scheduled
@@ -812,6 +815,19 @@ func ValidateLifecycleNotificationsConfig(cfg *NotificationsConfig) error {
 		return err
 	}
 	return validateLifecycleBlock(cfg)
+}
+
+// ValidateInfraNotificationsConfig validates only the config consumed by the
+// infrastructure notifier, so an unrelated scheduled or lifecycle typo never
+// silences an outage alert.
+func ValidateInfraNotificationsConfig(cfg *NotificationsConfig) error {
+	if cfg == nil {
+		return nil
+	}
+	if err := validateNotifiersBlock(cfg); err != nil {
+		return err
+	}
+	return validateInfraBlock(cfg)
 }
 
 func validateNotifiersBlock(cfg *NotificationsConfig) error {
@@ -1023,6 +1039,52 @@ func validateLifecycleBlock(cfg *NotificationsConfig) error {
 	via := strings.TrimSpace(lc.Via)
 	if _, ok := cfg.Notifiers[via]; !ok {
 		return fmt.Errorf("notifications.lifecycle: via %q does not name a configured notifier (defined: %s)", via, notifierNames(cfg.Notifiers))
+	}
+	return nil
+}
+
+func validateInfraBlock(cfg *NotificationsConfig) error {
+	ic := cfg.Infra
+	if ic == nil {
+		return nil
+	}
+	for _, field := range []struct{ name, value string }{{"poll_interval", ic.PollInterval}, {"repeat_after", ic.RepeatAfter}} {
+		if field.value == "" {
+			continue
+		}
+		if _, err := time.ParseDuration(field.value); err != nil {
+			return fmt.Errorf("notifications.infra: invalid %s %q: %w", field.name, field.value, err)
+		}
+	}
+	if !ic.IsEnabled() {
+		return nil
+	}
+	if len(ic.Routes) == 0 {
+		return fmt.Errorf("notifications.infra: routes are required when enabled")
+	}
+	seenRoutes := map[string]struct{}{}
+	for i, route := range ic.Routes {
+		via := strings.TrimSpace(route.Via)
+		if via == "" {
+			return fmt.Errorf("notifications.infra.routes[%d]: via is required (the name of a notifier under notifications.notifiers)", i)
+		}
+		if _, ok := cfg.Notifiers[via]; !ok {
+			return fmt.Errorf("notifications.infra.routes[%d]: via %q does not name a configured notifier (defined: %s)", i, via, notifierNames(cfg.Notifiers))
+		}
+		if _, ok := seenRoutes[via]; ok {
+			return fmt.Errorf("notifications.infra.routes[%d]: via %q is duplicated", i, via)
+		}
+		seenRoutes[via] = struct{}{}
+		seenEvents := map[string]struct{}{}
+		for _, event := range route.Events {
+			if !IsInfraEventType(event) {
+				return fmt.Errorf("notifications.infra.routes[%d]: event %q is not a supported infrastructure event type", i, event)
+			}
+			if _, ok := seenEvents[event]; ok {
+				return fmt.Errorf("notifications.infra.routes[%d]: event %q is duplicated", i, event)
+			}
+			seenEvents[event] = struct{}{}
+		}
 	}
 	return nil
 }

--- a/pkg/types/validation_notifications_test.go
+++ b/pkg/types/validation_notifications_test.go
@@ -107,6 +107,20 @@ func TestValidateNotificationsConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "valid infrastructure routes",
+			cfg:  &NotificationsConfig{Notifiers: slack(), Infra: &InfraNotificationsConfig{PollInterval: "1m", Routes: []InfraRoute{{Via: "eng-agents", Events: []string{"dependency_down", "provider_limit_exhausted"}}}}},
+		},
+		{
+			name:    "infrastructure route rejects unknown event",
+			cfg:     &NotificationsConfig{Notifiers: slack(), Infra: &InfraNotificationsConfig{Routes: []InfraRoute{{Via: "eng-agents", Events: []string{"agent_started"}}}}},
+			wantErr: true, errMsg: "not a supported infrastructure event type",
+		},
+		{
+			name:    "infrastructure validates durations",
+			cfg:     &NotificationsConfig{Notifiers: slack(), Infra: &InfraNotificationsConfig{PollInterval: "tomorrow", Routes: []InfraRoute{{Via: "eng-agents"}}}},
+			wantErr: true, errMsg: "invalid poll_interval",
+		},
+		{
 			name: "valid lifecycle routes",
 			cfg: &NotificationsConfig{
 				Notifiers: map[string]NotifierConfig{

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -6772,13 +6772,21 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
   // the hub until Save.
   const [showDialog, setShowDialog] = useState(false)
   const [dialogMode, setDialogMode] = useState<"add" | "edit">("add")
-  // The ROW being edited. Routes have no id, so position is the only address.
-  const [editIndex, setEditIndex] = useState<number | null>(null)
+  // The ROUTE being edited, addressed by the channel it posted to when the
+  // dialog opened — null while adding. Identity, not position: the hub allows
+  // exactly one infrastructure route per channel, so `via` is a key, whereas an
+  // index is only a key for as long as the list holds still. It does not have
+  // to hold still. Every save on this page re-fetches the whole config, and the
+  // routes that come back are whatever the hub now holds — reordered, or short
+  // one entry another writer dropped. An index captured before that round trip
+  // would then address a DIFFERENT route, and the save would quietly overwrite
+  // a route the operator never opened.
+  //
+  // It doubles as the name the heading shows, which is why it is frozen at open
+  // time rather than read from draftVia: reading the draft would rename the
+  // dialog under the operator the moment they picked another channel.
+  const [editKey, setEditKey] = useState<string | null>(null)
   const [draftVia, setDraftVia] = useState("")
-  // The name the heading uses, frozen when the dialog opens: reading draftVia
-  // there would rename the dialog under the operator as soon as they picked
-  // another channel in the select.
-  const [editVia, setEditVia] = useState("")
   // The receive-all choice, made explicitly rather than inferred from an empty
   // checkbox set. The hub reads `events: []` as "every alert type, including
   // any added in a later version", so an operator who unticks their way down
@@ -6796,13 +6804,13 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
   // The hub rejects two routes through one notifier, so a name another route
   // already uses is not on offer — the route being edited keeps its own.
   const viaOptions = names.filter(
-    (name) => name === draftVia || !routes.some((route, i) => i !== editIndex && route.via === name),
+    (name) => name === draftVia || name === editKey || !routes.some((route) => route.via === name),
   )
   const unroutedName = names.find((name) => !routes.some((route) => route.via === name))
 
   const openAddRoute = () => {
     setDialogMode("add")
-    setEditIndex(null)
+    setEditKey(null)
     setDraftVia(unroutedName || "")
     setDraftAll(true)
     setDraftEvents([])
@@ -6810,11 +6818,10 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
     setShowDialog(true)
   }
 
-  const openEditRoute = (route: InfraRoute, index: number) => {
+  const openEditRoute = (route: InfraRoute) => {
     setDialogMode("edit")
-    setEditIndex(index)
+    setEditKey(viaName(route.via))
     setDraftVia(viaName(route.via))
-    setEditVia(viaName(route.via))
     setDraftAll((route.events || []).length === 0)
     // De-duplicated because a checkbox can only be on or off: a type stored
     // twice would otherwise be counted twice in the dialog and re-sent
@@ -6847,7 +6854,7 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
     // tab between opening this dialog and saving it could still be sitting in
     // the select, and the hub answers a duplicated via with a routes[n] index
     // that names nothing on screen.
-    if (routes.some((route, i) => i !== editIndex && route.via === via)) {
+    if (routes.some((route) => route.via === via && route.via !== editKey)) {
       setDraftError(`"${via}" already carries an infrastructure route. A channel can only have one.`)
       return
     }
@@ -6860,9 +6867,23 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
     // "every type, including any added later". A narrowed route stores its own
     // types, de-duplicated for the reason the dialog seeds a Set.
     const entry: InfraRoute = { via, events: draftAll ? [] : [...new Set(draftEvents)] }
-    const nextRoutes = editIndex !== null
-      ? routes.map((route, i) => (i === editIndex ? entry : route))
-      : [...routes, entry]
+    // The row this draft belongs to is located NOW, in the list the hub last
+    // handed back, rather than trusted from where it sat when the dialog
+    // opened. If it is gone, the edit is refused outright: writing the draft
+    // into whatever occupies that position instead would silently repoint a
+    // route the operator never looked at, and an operator told nothing would
+    // assume their edit landed.
+    let nextRoutes: InfraRoute[]
+    if (editKey === null) {
+      nextRoutes = [...routes, entry]
+    } else {
+      const at = routes.findIndex((route) => route.via === editKey)
+      if (at === -1) {
+        setDraftError(`The route through "${editKey}" is no longer there — it was removed while this was open. Close this and add it again.`)
+        return
+      }
+      nextRoutes = routes.map((route, i) => (i === at ? entry : route))
+    }
     const { persisted, message } = await saveInfra({ ...infra, enabled, routes: nextRoutes })
     // Closed on `persisted`, not on the absence of a message: a PATCH the hub
     // took whose follow-up re-read failed already changed the routing, and
@@ -6872,13 +6893,20 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
     setShowDialog(false)
   }
 
-  async function removeRoute(index: number) {
+  async function removeRoute(key: string) {
+    // Removed by identity, for the reason saveRoute resolves one: "the row at
+    // index 1" and "the route through ops" stop meaning the same thing the
+    // moment anything else edits the list.
+    const at = routes.findIndex((route) => route.via === key)
+    if (at === -1) {
+      setDraftError(`The route through "${key}" is already gone.`)
+      return
+    }
     // The hub rejects an enabled block with no routes ("via is required when
     // enabled"), so dropping the last route pauses infrastructure alerts
     // instead of failing the save — the same clamp deleteNotifier applies when
     // it removes the channel a route pointed at.
-    const removed = routes[index]
-    const nextRoutes = routes.filter((_, i) => i !== index)
+    const nextRoutes = routes.filter((_, i) => i !== at)
     const clamped = enabled && nextRoutes.length === 0
     const { persisted, message } = await saveInfra({ ...infra, enabled: nextRoutes.length > 0 && enabled, routes: nextRoutes })
     // Recorded on `persisted` rather than on a clean save, and before the
@@ -6886,7 +6914,7 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
     // turned the alerts off, and this notice is the only record on the screen
     // that the switch moved without the operator touching it. Losing it there
     // is exactly the case that leaves someone believing their alerts are on.
-    if (persisted && clamped && removed) setRemovalPause(removed.via)
+    if (persisted && clamped) setRemovalPause(key)
     if (!persisted) { setDraftError(message || "The hub refused the change."); return }
     setShowDialog(false)
   }
@@ -7099,7 +7127,7 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
                       variant="ghost"
                       disabled={saving}
                       aria-label={`Edit the ${route.via} route`}
-                      onClick={() => openEditRoute(route, index)}
+                      onClick={() => openEditRoute(route)}
                     >
                       Edit
                     </Button>
@@ -7173,10 +7201,10 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
       <Dialog open={showDialog} onOpenChange={setShowDialog}>
         <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto p-0 gap-0">
           <DialogTitle className="sr-only">
-            {dialogMode === "add" ? "Add infrastructure route" : `Edit the ${editVia} route`}
+            {dialogMode === "add" ? "Add infrastructure route" : `Edit the ${editKey} route`}
           </DialogTitle>
           <div className="flex items-center justify-between px-5 py-4 border-b border-border">
-            <h3 className="font-medium">{dialogMode === "add" ? "Add infrastructure route" : `Edit the ${editVia} route`}</h3>
+            <h3 className="font-medium">{dialogMode === "add" ? "Add infrastructure route" : `Edit the ${editKey} route`}</h3>
           </div>
 
           <div className="p-5 space-y-4">
@@ -7314,13 +7342,13 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
               </div>
             )}
             <div className="flex items-center justify-between px-5 py-4">
-              {dialogMode === "edit" && editIndex !== null && (
+              {dialogMode === "edit" && editKey !== null && (
                 <Button
                   size="sm"
                   variant="ghost"
                   className="text-destructive hover:text-destructive"
                   disabled={saving}
-                  onClick={() => removeRoute(editIndex)}
+                  onClick={() => removeRoute(editKey)}
                 >
                   <Trash2 className="size-3.5 mr-1" /> Remove route
                 </Button>

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -5211,6 +5211,11 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       enabled: nextInfraRoutes.length > 0 && infra.enabled,
       routes: nextInfraRoutes,
     }
+    // The clamp above turns infrastructure alerts off when this channel was
+    // their last route. Recorded for the same reason pausedIds is: after the
+    // delete the infra section shows a neutral empty state that reads as
+    // never-configured, and a notice is the only record of why they are off.
+    const infraPausedByDelete = Boolean(infra?.enabled) && nextInfraRoutes.length === 0 && nextInfraRoutes.length < (infra?.routes || []).length
     const generation = saveGeneration.current
     const { persisted, message: failure } = await savePatch({
       notifiers: nextNotifiers,
@@ -5237,6 +5242,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
           { ids: pausedIds, channel: name },
         ])
       }
+      if (infraPausedByDelete) setInfraPause({ channel: name })
     }
     setSaveErrors((current) => { const { [name]: _cleared, ...rest } = current; return rest })
     if (generation !== saveGeneration.current) {
@@ -5345,6 +5351,10 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
   // has to add a second notice, not replace the only record of why the first
   // batch of reports is off.
   const [schedulePauses, setSchedulePauses] = useState<{ ids: string[]; channel: string }[]>([])
+  // The channel whose deletion paused infrastructure alerts (see
+  // deleteNotifier). One entry, not a list: infra has a single master switch,
+  // so a later pause by another delete supersedes rather than accumulates.
+  const [infraPause, setInfraPause] = useState<{ channel: string } | null>(null)
   const [reportTests, setReportTests] = useState<Record<string, ReportTestState>>({})
   // Invalidates an in-flight probe whose schedule has meanwhile been edited or
   // deleted: its result describes a report that went somewhere else.
@@ -6146,7 +6156,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
         )}
       </div>
 
-      <InfraNotificationsSection settings={settings} onSave={onSave} saving={saving} />
+      <InfraNotificationsSection settings={settings} onSave={onSave} saving={saving} pause={infraPause} />
 
       {/* Add / edit modal */}
       {/* Closing only closes: DialogContent stays mounted for its 200ms exit
@@ -6706,19 +6716,36 @@ const INFRA_EVENT_LABELS: Record<InfraEventType, string> = {
   provider_limit_released: "Provider cap lifted",
 }
 
-function InfraNotificationsSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => Promise<SaveOutcome>; saving: boolean }) {
+function InfraNotificationsSection({ settings, onSave, saving, pause }: { settings: SettingsData; onSave: (p: object) => Promise<SaveOutcome>; saving: boolean; pause: { channel: string } | null }) {
   const notifications = settings.notifications
   const notifiers = notifications?.notifiers || {}
   const names = Object.keys(notifiers).sort((a, b) => a.localeCompare(b))
   const infra = notifications?.infra
+  const enabled = infra?.enabled ?? false
   const routes = (infra?.routes || []).map((route) => ({ ...route, via: route.via.trim(), events: route.events || [] }))
   const eventTypes = settings.infraEventTypes?.length ? settings.infraEventTypes : INFRA_EVENT_TYPES
   const [tests, setTests] = useState<Record<string, TestState>>({})
+  // The last save the hub refused, rendered in the section. The page-level
+  // banner is the only other place it goes, and this section sits at the
+  // bottom of a long page: a checkbox that snaps back with the reason
+  // scrolled a screen or more above it just looks dead.
+  const [saveError, setSaveError] = useState("")
+  // Routes whose notifier is gone. The hub keeps them on disk while alerts
+  // are off but rejects the whole notifications block the moment they are
+  // on — and PATCH replaces the whole block, so one dangling route under an
+  // enabled switch fails every save on this screen, the channel and report
+  // sections included, until it is removed. The master switch is gated on
+  // it the way the lifecycle switch is, and the banner below says why.
+  const orphanRoutes = routes.filter((route) => !names.includes(route.via))
+  const orphan = orphanRoutes.length > 0
+  // Shown while the pause deleteNotifier recorded still stands; turning the
+  // alerts back on answers it.
+  const pauseNotice = pause && !enabled ? pause : null
 
   const saveInfra = async (next: InfraNotificationsConfig) => {
     // PATCH replaces the notifications block, so carry the sibling sections
     // through unchanged when this compact editor changes only infra routing.
-    await onSave({
+    const { message } = await onSave({
       notifications: {
         notifiers,
         lifecycle: notifications?.lifecycle,
@@ -6726,11 +6753,12 @@ function InfraNotificationsSection({ settings, onSave, saving }: { settings: Set
         infra: next,
       },
     })
+    setSaveError(message || "")
   }
 
   const updateRoute = async (index: number, route: InfraRoute) => {
     const nextRoutes = routes.map((current, i) => i === index ? route : current)
-    await saveInfra({ ...infra, enabled: infra?.enabled ?? false, routes: nextRoutes })
+    await saveInfra({ ...infra, enabled, routes: nextRoutes })
   }
 
   const sendTest = async (route: InfraRoute, index: number) => {
@@ -6751,20 +6779,65 @@ function InfraNotificationsSection({ settings, onSave, saving }: { settings: Set
       <div className="flex items-start justify-between gap-4">
         <div>
           <h3 className="text-sm font-medium">Infrastructure alerts</h3>
-          <p className="text-xs text-muted-foreground mt-0.5">Dependency outages and provider usage limits, routed independently from lifecycle alerts.</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {routes.length === 0
+              ? "Dependency outages and provider usage limits, routed independently from lifecycle alerts. Add a channel route before turning them on."
+              : orphan
+                ? "Remove the routes pointing at deleted channels below — the hub refuses to enable alerts while one is left."
+                : "Dependency outages and provider usage limits, routed independently from lifecycle alerts."}
+          </p>
         </div>
         <Switch
-          checked={infra?.enabled ?? false}
-          disabled={saving || routes.length === 0}
-          onCheckedChange={(enabled) => saveInfra({ ...infra, enabled, routes })}
+          checked={enabled}
+          // Gated on the shapes the hub rejects once the block is enabled: no
+          // routes, and a route naming a notifier that no longer exists.
+          disabled={saving || routes.length === 0 || orphan}
+          title={routes.length === 0 ? "Add a channel route first" : orphan ? "Remove the routes pointing at deleted channels first" : undefined}
+          onCheckedChange={(next) => saveInfra({ ...infra, enabled: next, routes })}
           aria-label="Enable infrastructure alerts"
         />
       </div>
 
+      {pauseNotice && (
+        <div className="flex items-start gap-2 rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-400">
+          <AlertTriangle className="size-3.5 mt-px shrink-0" />
+          <span className="break-words">
+            Infrastructure alerts paused — &quot;{pauseNotice.channel}&quot; was the only channel they were routed to.{" "}
+            {notifiers[pauseNotice.channel]
+              ? "A channel by that name exists again: add a route through it and turn the alerts back on."
+              : "Add a route through another channel and turn them back on."}
+          </span>
+        </div>
+      )}
+      {orphan && (
+        <div className="flex items-start gap-2 rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-400">
+          <AlertTriangle className="size-3.5 mt-px shrink-0" />
+          <span className="break-words">
+            {orphanRoutes.length === 1 ? "The route through " : "The routes through "}
+            {orphanRoutes.map((route, i) => (
+              <React.Fragment key={route.via}>
+                {i > 0 && ", "}
+                <span className="font-mono">{route.via}</span>
+              </React.Fragment>
+            ))}
+            {orphanRoutes.length === 1 ? " points at a channel that no longer exists. " : " point at channels that no longer exist. "}
+            {enabled
+              ? "While infrastructure alerts are on, the hub refuses every save on this screen — channels, scheduled reports and test sends included — until the route is removed or pointed at another channel."
+              : "The hub refuses to turn infrastructure alerts on until the route is removed or pointed at another channel."}
+          </span>
+        </div>
+      )}
+      {saveError && (
+        <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          <AlertTriangle className="size-3.5 mt-px shrink-0" />
+          <span className="break-words">Last save failed: {saveError}</span>
+        </div>
+      )}
+
       {routes.length === 0 ? (
         <p className="text-sm text-muted-foreground px-4 py-4 text-center border border-border rounded-lg">Add a channel route before turning infrastructure alerts on.</p>
       ) : (
-        <div className={cn("space-y-2", !(infra?.enabled ?? false) && "opacity-50")}>
+        <div className={cn("space-y-2", !enabled && "opacity-50")}>
           {routes.map((route, index) => {
             const key = `${index}:${route.via}`
             const test = tests[key]
@@ -6772,7 +6845,14 @@ function InfraNotificationsSection({ settings, onSave, saving }: { settings: Set
             // added later" — the same receive-all semantics the lifecycle
             // dialog spells out — so the card has to say so.
             const allEvents = route.events.length === 0
-            const orphan = !names.includes(route.via)
+            const missing = !names.includes(route.via)
+            // Unchecking the last box would save an empty list, which the hub
+            // reads as receive-all — the opposite of what the operator meant.
+            // Removing the route is how to stop it. Said in the description
+            // below, which every checkbox is described by: a disabled input
+            // leaves the tab order, so a tooltip on it is never reached.
+            const lastOne = !allEvents && route.events.length === 1
+            const hintId = `infra-route-${index}-events-hint`
             // The hub rejects two routes through one notifier, so a name
             // another route already uses is not on offer here.
             const options = names.filter((name) => name === route.via || !routes.some((other, i) => i !== index && other.via === name))
@@ -6783,10 +6863,12 @@ function InfraNotificationsSection({ settings, onSave, saving }: { settings: Set
                     value={route.via}
                     disabled={saving}
                     onChange={(e) => updateRoute(index, { ...route, via: e.target.value })}
-                    className={cn("h-8 min-w-0 flex-1 text-sm rounded-md border bg-background px-3", orphan ? "border-amber-500/50" : "border-input")}
-                    aria-label="Notifier for infrastructure alerts"
+                    className={cn("h-8 min-w-0 flex-1 text-sm rounded-md border bg-background px-3", missing ? "border-amber-500/50" : "border-input")}
+                    // Every card carries the same controls, so each name says
+                    // which route it belongs to — as the scheduled rows do.
+                    aria-label={`Notifier for infrastructure alerts (route ${index + 1}: ${route.via})`}
                   >
-                    {orphan && <option value={route.via} disabled>{route.via} — missing notifier</option>}
+                    {missing && <option value={route.via} disabled>{route.via} — missing notifier</option>}
                     {options.map((name) => <option key={name} value={name}>{name}</option>)}
                   </select>
                   <span className={cn("shrink-0 text-xs px-2 py-1 rounded font-medium", allEvents ? "bg-blue-500/10 text-blue-400 border border-blue-500/20" : "bg-muted text-muted-foreground")}>
@@ -6796,18 +6878,19 @@ function InfraNotificationsSection({ settings, onSave, saving }: { settings: Set
                     size="sm"
                     variant="ghost"
                     disabled={saving}
+                    aria-label={`Remove the ${route.via} route`}
                     onClick={() => {
                       // The hub rejects an enabled block with no routes, so
                       // losing the last route pauses alerts instead of failing
                       // the save — the same clamp deleteNotifier applies.
                       const nextRoutes = routes.filter((_, i) => i !== index)
-                      saveInfra({ ...infra, enabled: nextRoutes.length > 0 && (infra?.enabled ?? false), routes: nextRoutes })
+                      saveInfra({ ...infra, enabled: nextRoutes.length > 0 && enabled, routes: nextRoutes })
                     }}
                   >
                     <Trash2 className="size-3.5 mr-1" /> Remove
                   </Button>
                 </div>
-                {orphan && (
+                {missing && (
                   <p className="text-xs text-amber-400">
                     Notifier <span className="font-mono">{route.via}</span> no longer exists, so this route delivers nothing. Pick another channel or remove the route.
                   </p>
@@ -6815,18 +6898,16 @@ function InfraNotificationsSection({ settings, onSave, saving }: { settings: Set
                 <div className="grid gap-1 sm:grid-cols-2">
                   {eventTypes.map((eventType) => {
                     const checked = allEvents || route.events.includes(eventType)
-                    // Unchecking the last box would save an empty list, which
-                    // the hub reads as receive-all — the opposite of what the
-                    // operator meant. Removing the route is how to stop it.
-                    const lastChecked = checked && !allEvents && route.events.length === 1
+                    const lastChecked = checked && lastOne
                     return (
                       <label
                         key={eventType}
                         className={cn("flex items-center gap-2 text-sm rounded px-2 py-1", lastChecked ? "cursor-not-allowed" : "cursor-pointer hover:bg-muted/50")}
-                        title={lastChecked ? "At least one alert type must stay checked. Remove the route to stop it." : undefined}
                       >
                         <input
                           type="checkbox"
+                          aria-label={`${INFRA_EVENT_LABELS[eventType]} (${eventType}) for ${route.via}`}
+                          aria-describedby={hintId}
                           checked={checked}
                           disabled={saving || lastChecked}
                           onChange={(e) => {
@@ -6841,13 +6922,25 @@ function InfraNotificationsSection({ settings, onSave, saving }: { settings: Set
                     )
                   })}
                 </div>
-                <p className="text-xs text-muted-foreground">
+                <p id={hintId} className="text-xs text-muted-foreground">
                   {allEvents
                     ? "Saved as receive-all: this channel gets every alert type, including any added later. Uncheck a type to narrow it."
-                    : "Only the checked types reach this channel. Remove the route to stop it entirely."}
+                    : lastOne
+                      ? `Only "${INFRA_EVENT_LABELS[route.events[0]]}" reaches this channel, and it stays checked: at least one alert type must. Remove the route to stop it entirely.`
+                      : "Only the checked types reach this channel. Remove the route to stop it entirely."}
                 </p>
                 <div className="flex items-center gap-2">
-                  <Button size="sm" variant="outline" className="gap-1.5" disabled={saving || !(infra?.enabled ?? false) || test?.status === "sending"} onClick={() => sendTest(route, index)}>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="gap-1.5"
+                    // A missing notifier is already explained above the grid;
+                    // a test through it could only fail with the hub's
+                    // routes[n] message, which names nothing on this card.
+                    disabled={saving || !enabled || missing || test?.status === "sending"}
+                    aria-label={`Send a test through ${route.via}`}
+                    onClick={() => sendTest(route, index)}
+                  >
                     <Send className="size-3.5" />
                     {test?.status === "sending" ? "Sending…" : "Send test"}
                   </Button>
@@ -6864,7 +6957,7 @@ function InfraNotificationsSection({ settings, onSave, saving }: { settings: Set
         disabled={saving || names.length === 0 || names.every((name) => routes.some((route) => route.via === name))}
         onClick={() => {
           const via = names.find((name) => !routes.some((route) => route.via === name))
-          if (via) saveInfra({ ...infra, enabled: infra?.enabled ?? false, routes: [...routes, { via, events: [] }] })
+          if (via) saveInfra({ ...infra, enabled, routes: [...routes, { via, events: [] }] })
         }}
       >
         <span className="mr-1 text-sm">+</span> Add route

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -6744,9 +6744,25 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
   // it the way the lifecycle switch is, and the banner below says why.
   const orphanRoutes = routes.filter((route) => !names.includes(route.via))
   const orphan = orphanRoutes.length > 0
-  // Shown while the pause deleteNotifier recorded still stands; turning the
-  // alerts back on answers it.
-  const pauseNotice = pause && !enabled ? pause : null
+  // The channel whose route was the last one, recorded when removing it forced
+  // the clamp in removeRoute to turn the alerts off. Without this the switch
+  // moves on its own with nothing on screen saying so: the operator reshuffling
+  // their routing removes one route, adds another, and walks away believing
+  // infrastructure alerts are still on when the hub has them off. Held in this
+  // section rather than passed down like `pause`, because this section is the
+  // one that moved the switch.
+  const [removalPause, setRemovalPause] = useState<string | null>(null)
+  // Shown while a pause THIS SCREEN caused still stands; turning the alerts
+  // back on answers it either way. A removal supersedes a channel deletion —
+  // both leave the alerts off, and the last thing the operator did is the one
+  // that explains the switch they are looking at now.
+  const pauseNotice = enabled
+    ? null
+    : removalPause
+      ? { kind: "route" as const, channel: removalPause }
+      : pause
+        ? { kind: "channel" as const, channel: pause.channel }
+        : null
 
   // ── The route editor ───────────────────────────────────────────────────────
   // A dialog with its own draft, like the channel and schedule editors beside
@@ -6861,8 +6877,16 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
     // enabled"), so dropping the last route pauses infrastructure alerts
     // instead of failing the save — the same clamp deleteNotifier applies when
     // it removes the channel a route pointed at.
+    const removed = routes[index]
     const nextRoutes = routes.filter((_, i) => i !== index)
+    const clamped = enabled && nextRoutes.length === 0
     const { persisted, message } = await saveInfra({ ...infra, enabled: nextRoutes.length > 0 && enabled, routes: nextRoutes })
+    // Recorded on `persisted` rather than on a clean save, and before the
+    // early return: a PATCH the hub took whose follow-up re-read failed still
+    // turned the alerts off, and this notice is the only record on the screen
+    // that the switch moved without the operator touching it. Losing it there
+    // is exactly the case that leaves someone believing their alerts are on.
+    if (persisted && clamped && removed) setRemovalPause(removed.via)
     if (!persisted) { setDraftError(message || "The hub refused the change."); return }
     setShowDialog(false)
   }
@@ -6918,7 +6942,15 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
           // nobody.
           disabled={saving || routes.length === 0 || orphan}
           title={routes.length === 0 ? "Add a channel route first" : orphan ? "Remove the routes pointing at deleted channels first" : undefined}
-          onCheckedChange={(next) => saveInfra({ ...infra, enabled: next, routes })}
+          onCheckedChange={async (next) => {
+            const outcome = await saveInfra({ ...infra, enabled: next, routes })
+            // The notice answers "why is this off?". Turning the alerts back on
+            // answers it for good, so it is retired here rather than merely
+            // hidden — otherwise the next deliberate turn-off, weeks later,
+            // would resurface a stale explanation blaming a route removal the
+            // operator has already dealt with.
+            if (next && outcome.persisted) setRemovalPause(null)
+          }}
           aria-label="Enable infrastructure alerts"
         />
       </div>
@@ -6927,10 +6959,19 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
         <div className="flex items-start gap-2 rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-400">
           <AlertTriangle className="size-3.5 mt-px shrink-0" />
           <span className="break-words">
-            Infrastructure alerts paused — &quot;{pauseNotice.channel}&quot; was the only channel they were routed to.{" "}
-            {notifiers[pauseNotice.channel]
-              ? "A channel by that name exists again: add a route through it and turn the alerts back on."
-              : "Add a route through another channel and turn them back on."}
+            {pauseNotice.kind === "channel" ? (
+              <>
+                Infrastructure alerts paused — &quot;{pauseNotice.channel}&quot; was the only channel they were routed to.{" "}
+                {notifiers[pauseNotice.channel]
+                  ? "A channel by that name exists again: add a route through it and turn the alerts back on."
+                  : "Add a route through another channel and turn them back on."}
+              </>
+            ) : (
+              <>
+                Infrastructure alerts paused — the route through &quot;{pauseNotice.channel}&quot; was the last one, and the hub
+                will not keep them on with nowhere to send them. Add another route and turn them back on.
+              </>
+            )}
           </span>
         </div>
       )}

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -16,6 +16,7 @@ import { fetchWorkspaces, updateWorkflowControls, type RepositoryAccess, type Wo
 import { useBranding } from "@/hooks/use-branding"
 import { WorkflowName } from "@/components/workflow-name"
 import { WorkflowRunsDialog } from "@/components/workflow-runs-dialog"
+import { INFRA_EVENT_TYPES, type InfraEventType, type InfraNotificationsConfig, type InfraRoute } from "@/lib/types"
 
 function isValidSection(s: string): s is Section {
   return VALID_SECTIONS.includes(s as Section)
@@ -161,6 +162,7 @@ interface SettingsData {
   }
   notifications?: NotificationsView | null
   lifecycleEventTypes?: string[]
+  infraEventTypes?: InfraEventType[]
   concurrencyGroups?: ConcurrencyGroup[]
   maxConcurrentClaws?: number
 }
@@ -227,6 +229,7 @@ interface NotificationsView {
     stageProgressAfter?: string
     events?: LifecycleEventToggles
   }
+  infra?: InfraNotificationsConfig
 }
 
 // The outcome of one save. `persisted` says whether the hub accepted the PATCH;
@@ -4810,6 +4813,7 @@ function writeClampedPause(clamped: boolean): void {
 
 function NotifierSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => Promise<SaveOutcome>; saving: boolean }) {
   const lifecycle = settings.notifications?.lifecycle
+  const infra = settings.notifications?.infra
   const notifiers = settings.notifications?.notifiers || {}
   const schedules = settings.notifications?.scheduled || []
   const names = Object.keys(notifiers).sort((a, b) => a.localeCompare(b))
@@ -4999,6 +5003,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
     routes?: LifecycleRouteView[]
     events?: Record<LifecycleCategory, boolean>
     scheduled?: ScheduledNotificationView[]
+    infra?: InfraNotificationsConfig
   }): { patch: object; clamp: boolean } {
     const outNotifiers: Record<string, Record<string, string>> = {}
     for (const [name, notifier] of Object.entries(next.notifiers ?? notifiers)) {
@@ -5057,7 +5062,7 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       enabled: schedule.enabled,
     }))
     return {
-      patch: { notifications: { notifiers: outNotifiers, lifecycle: outLifecycle, scheduled: outScheduled } },
+      patch: { notifications: { notifiers: outNotifiers, lifecycle: outLifecycle, scheduled: outScheduled, infra: next.infra ?? infra } },
       // The never-configured hub is clamped too, and for the same reason: the
       // block this save creates carries `enabled:false` only because it has no
       // route to send to, which is this screen's own doing — the operator was
@@ -5200,11 +5205,18 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
       }
       return { ...schedule, via }
     })
+    const nextInfraRoutes = (infra?.routes || []).filter((route) => route.via.trim() !== name)
+    const nextInfra = infra && {
+      ...infra,
+      enabled: nextInfraRoutes.length > 0 && infra.enabled,
+      routes: nextInfraRoutes,
+    }
     const generation = saveGeneration.current
     const { persisted, message: failure } = await savePatch({
       notifiers: nextNotifiers,
       routes: routes.filter((route) => route.via !== name),
       scheduled: nextScheduled,
+      infra: nextInfra,
     })
     if (persisted) {
       invalidateTest(name)
@@ -6134,6 +6146,8 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
         )}
       </div>
 
+      <InfraNotificationsSection settings={settings} onSave={onSave} saving={saving} />
+
       {/* Add / edit modal */}
       {/* Closing only closes: DialogContent stays mounted for its 200ms exit
           animation, so clearing the form here would let the operator watch the
@@ -6683,6 +6697,141 @@ function NotifierSection({ settings, onSave, saving }: { settings: SettingsData;
 }
 
 // linkifyText converts URLs in text into clickable <a> elements.
+const INFRA_EVENT_LABELS: Record<InfraEventType, string> = {
+  dependency_down: "Dependency down",
+  dependency_degraded: "Dependency degraded",
+  dependency_recovered: "Dependency recovered",
+  provider_limit_opened: "Provider account capped",
+  provider_limit_exhausted: "Provider cap needs attention",
+  provider_limit_released: "Provider cap lifted",
+}
+
+function InfraNotificationsSection({ settings, onSave, saving }: { settings: SettingsData; onSave: (p: object) => Promise<SaveOutcome>; saving: boolean }) {
+  const notifications = settings.notifications
+  const notifiers = notifications?.notifiers || {}
+  const names = Object.keys(notifiers).sort((a, b) => a.localeCompare(b))
+  const infra = notifications?.infra
+  const routes = (infra?.routes || []).map((route) => ({ ...route, via: route.via.trim(), events: route.events || [] }))
+  const eventTypes = settings.infraEventTypes?.length ? settings.infraEventTypes : INFRA_EVENT_TYPES
+  const [tests, setTests] = useState<Record<string, TestState>>({})
+
+  const saveInfra = async (next: InfraNotificationsConfig) => {
+    // PATCH replaces the notifications block, so carry the sibling sections
+    // through unchanged when this compact editor changes only infra routing.
+    await onSave({
+      notifications: {
+        notifiers,
+        lifecycle: notifications?.lifecycle,
+        scheduled: notifications?.scheduled || [],
+        infra: next,
+      },
+    })
+  }
+
+  const updateRoute = async (index: number, route: InfraRoute) => {
+    const nextRoutes = routes.map((current, i) => i === index ? route : current)
+    await saveInfra({ ...infra, enabled: infra?.enabled ?? false, routes: nextRoutes })
+  }
+
+  const sendTest = async (route: InfraRoute, index: number) => {
+    const eventType = route.events?.[0] || eventTypes[0]
+    if (!eventType) return
+    const key = `${index}:${route.via}`
+    setTests((current) => ({ ...current, [key]: { status: "sending", message: "" } }))
+    try {
+      await sendTestNotification(eventType, route.via)
+      setTests((current) => ({ ...current, [key]: { status: "ok", message: `Sent a \"${INFRA_EVENT_LABELS[eventType]}\" test alert.` } }))
+    } catch (e) {
+      setTests((current) => ({ ...current, [key]: { status: "error", message: e instanceof Error ? e.message : "Test send failed" } }))
+    }
+  }
+
+  return (
+    <div className="space-y-3 border-t border-border pt-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-medium">Infrastructure alerts</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">Dependency outages and provider usage limits, routed independently from lifecycle alerts.</p>
+        </div>
+        <Switch
+          checked={infra?.enabled ?? false}
+          disabled={saving || routes.length === 0}
+          onCheckedChange={(enabled) => saveInfra({ ...infra, enabled, routes })}
+          aria-label="Enable infrastructure alerts"
+        />
+      </div>
+
+      {routes.length === 0 ? (
+        <p className="text-sm text-muted-foreground px-4 py-4 text-center border border-border rounded-lg">Add a channel route before turning infrastructure alerts on.</p>
+      ) : (
+        <div className={cn("space-y-2", !(infra?.enabled ?? false) && "opacity-50")}>
+          {routes.map((route, index) => {
+            const key = `${index}:${route.via}`
+            const test = tests[key]
+            const allEvents = route.events.length === 0
+            return (
+              <div key={key} className="border border-border rounded-lg p-4 space-y-3">
+                <div className="flex items-center gap-2">
+                  <select
+                    value={route.via}
+                    disabled={saving}
+                    onChange={(e) => updateRoute(index, { ...route, via: e.target.value })}
+                    className="h-8 min-w-0 flex-1 text-sm rounded-md border border-input bg-background px-3"
+                    aria-label="Notifier for infrastructure alerts"
+                  >
+                    {names.map((name) => <option key={name} value={name}>{name}</option>)}
+                  </select>
+                  <Button size="sm" variant="ghost" disabled={saving} onClick={() => saveInfra({ ...infra, enabled: infra?.enabled ?? false, routes: routes.filter((_, i) => i !== index) })}>
+                    <Trash2 className="size-3.5 mr-1" /> Remove
+                  </Button>
+                </div>
+                <div className="grid gap-1 sm:grid-cols-2">
+                  {eventTypes.map((eventType) => {
+                    const checked = allEvents || route.events.includes(eventType)
+                    return (
+                      <label key={eventType} className="flex items-center gap-2 text-sm cursor-pointer rounded px-2 py-1 hover:bg-muted/50">
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          disabled={saving}
+                          onChange={(e) => {
+                            const current = allEvents ? [...eventTypes] : route.events
+                            const events = e.target.checked ? [...new Set([...current, eventType])] : current.filter((type) => type !== eventType)
+                            updateRoute(index, { ...route, events })
+                          }}
+                        />
+                        <span>{INFRA_EVENT_LABELS[eventType]}</span>
+                      </label>
+                    )
+                  })}
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button size="sm" variant="outline" className="gap-1.5" disabled={saving || !(infra?.enabled ?? false) || test?.status === "sending"} onClick={() => sendTest(route, index)}>
+                    <Send className="size-3.5" />
+                    {test?.status === "sending" ? "Sending…" : "Send test"}
+                  </Button>
+                  {test && test.status !== "sending" && <span className={cn("text-xs", test.status === "ok" ? "text-green-400" : "text-destructive")}>{test.message}</span>}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+      <Button
+        size="sm"
+        variant="outline"
+        disabled={saving || names.length === 0 || names.every((name) => routes.some((route) => route.via === name))}
+        onClick={() => {
+          const via = names.find((name) => !routes.some((route) => route.via === name))
+          if (via) saveInfra({ ...infra, enabled: infra?.enabled ?? false, routes: [...routes, { via, events: [] }] })
+        }}
+      >
+        <span className="mr-1 text-sm">+</span> Add route
+      </Button>
+    </div>
+  )
+}
+
 function linkifyText(text: string): React.ReactNode {
   const urlRegex = /(https?:\/\/[^\s]+)/g
   const parts = text.split(urlRegex)

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -6768,7 +6768,14 @@ function InfraNotificationsSection({ settings, onSave, saving }: { settings: Set
           {routes.map((route, index) => {
             const key = `${index}:${route.via}`
             const test = tests[key]
+            // The hub reads an empty list as "every event type, including any
+            // added later" — the same receive-all semantics the lifecycle
+            // dialog spells out — so the card has to say so.
             const allEvents = route.events.length === 0
+            const orphan = !names.includes(route.via)
+            // The hub rejects two routes through one notifier, so a name
+            // another route already uses is not on offer here.
+            const options = names.filter((name) => name === route.via || !routes.some((other, i) => i !== index && other.via === name))
             return (
               <div key={key} className="border border-border rounded-lg p-4 space-y-3">
                 <div className="flex items-center gap-2">
@@ -6776,27 +6783,45 @@ function InfraNotificationsSection({ settings, onSave, saving }: { settings: Set
                     value={route.via}
                     disabled={saving}
                     onChange={(e) => updateRoute(index, { ...route, via: e.target.value })}
-                    className="h-8 min-w-0 flex-1 text-sm rounded-md border border-input bg-background px-3"
+                    className={cn("h-8 min-w-0 flex-1 text-sm rounded-md border bg-background px-3", orphan ? "border-amber-500/50" : "border-input")}
                     aria-label="Notifier for infrastructure alerts"
                   >
-                    {names.map((name) => <option key={name} value={name}>{name}</option>)}
+                    {orphan && <option value={route.via} disabled>{route.via} — missing notifier</option>}
+                    {options.map((name) => <option key={name} value={name}>{name}</option>)}
                   </select>
+                  <span className={cn("shrink-0 text-xs px-2 py-1 rounded font-medium", allEvents ? "bg-blue-500/10 text-blue-400 border border-blue-500/20" : "bg-muted text-muted-foreground")}>
+                    {allEvents ? "All alerts" : `${route.events.length} of ${eventTypes.length} alert types`}
+                  </span>
                   <Button size="sm" variant="ghost" disabled={saving} onClick={() => saveInfra({ ...infra, enabled: infra?.enabled ?? false, routes: routes.filter((_, i) => i !== index) })}>
                     <Trash2 className="size-3.5 mr-1" /> Remove
                   </Button>
                 </div>
+                {orphan && (
+                  <p className="text-xs text-amber-400">
+                    Notifier <span className="font-mono">{route.via}</span> no longer exists, so this route delivers nothing. Pick another channel or remove the route.
+                  </p>
+                )}
                 <div className="grid gap-1 sm:grid-cols-2">
                   {eventTypes.map((eventType) => {
                     const checked = allEvents || route.events.includes(eventType)
+                    // Unchecking the last box would save an empty list, which
+                    // the hub reads as receive-all — the opposite of what the
+                    // operator meant. Removing the route is how to stop it.
+                    const lastChecked = checked && !allEvents && route.events.length === 1
                     return (
-                      <label key={eventType} className="flex items-center gap-2 text-sm cursor-pointer rounded px-2 py-1 hover:bg-muted/50">
+                      <label
+                        key={eventType}
+                        className={cn("flex items-center gap-2 text-sm rounded px-2 py-1", lastChecked ? "cursor-not-allowed" : "cursor-pointer hover:bg-muted/50")}
+                        title={lastChecked ? "At least one alert type must stay checked. Remove the route to stop it." : undefined}
+                      >
                         <input
                           type="checkbox"
                           checked={checked}
-                          disabled={saving}
+                          disabled={saving || lastChecked}
                           onChange={(e) => {
                             const current = allEvents ? [...eventTypes] : route.events
                             const events = e.target.checked ? [...new Set([...current, eventType])] : current.filter((type) => type !== eventType)
+                            if (events.length === 0) return
                             updateRoute(index, { ...route, events })
                           }}
                         />
@@ -6805,6 +6830,11 @@ function InfraNotificationsSection({ settings, onSave, saving }: { settings: Set
                     )
                   })}
                 </div>
+                <p className="text-xs text-muted-foreground">
+                  {allEvents
+                    ? "Saved as receive-all: this channel gets every alert type, including any added later. Uncheck a type to narrow it."
+                    : "Only the checked types reach this channel. Remove the route to stop it entirely."}
+                </p>
                 <div className="flex items-center gap-2">
                   <Button size="sm" variant="outline" className="gap-1.5" disabled={saving || !(infra?.enabled ?? false) || test?.status === "sending"} onClick={() => sendTest(route, index)}>
                     <Send className="size-3.5" />

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -6940,9 +6940,11 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
   // What a card says the route receives, without opening anything. An empty
   // list is receive-all, so it is named as such rather than rendered as "0
   // alert types"; a long list is cut short because a card is a summary, and
-  // the badge beside it already carries the exact count.
+  // the badge beside it already carries the exact count. The strings continue
+  // the card's "Receives …" sentence, so this one starts lower case while the
+  // event labels, which are proper names of alert types, keep their capital.
   const receivesLine = (events: InfraEventType[]): string => {
-    if (events.length === 0) return "Every alert type, including any added in a later hub version."
+    if (events.length === 0) return "every alert type, including any added in a later hub version."
     const labels = [...new Set(events)].map((eventType) => INFRA_EVENT_LABELS[eventType])
     if (labels.length <= 3) return `${labels.join(", ")}.`
     return `${labels.slice(0, 3).join(", ")} and ${labels.length - 3} more.`

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -6971,10 +6971,13 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
             : "No infrastructure routes. Add one to get dependency outages and provider caps in Slack."}
         </p>
       ) : (
-        // Dimmed while the alerts are off, as the lifecycle categories are.
-        // Nothing that gates a save hides in here: the banners above are at
-        // full opacity and name every broken route by channel.
-        <div className={cn("space-y-2", !enabled && "opacity-50")}>
+        // Dimmed while the alerts are off, as the lifecycle categories are —
+        // but PER CARD, so a broken route can opt out below. Dimming the whole
+        // list would put the one line that names the remedy ("open Edit and
+        // pick another channel") at 50% while the amber banner repeating the
+        // problem sits above it at full strength: the screen would shout the
+        // symptom and mumble the cure.
+        <div className="space-y-2">
           {routes.map((route, index) => {
             const key = `${index}:${route.via}`
             const test = tests[key]
@@ -6992,17 +6995,38 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
               ? "Infrastructure alerts are turned off — this channel receives nothing."
               : null
             return (
-              <div key={key} className="border border-border rounded-lg p-4">
+              <div
+                key={key}
+                className={cn(
+                  "rounded-lg border p-4",
+                  // A route pointing at a deleted channel gets the amber
+                  // framing the Channels section gives its own orphans, so the
+                  // two sections flag one condition one way. It is also the
+                  // card exempted from the dimming above: this is the route
+                  // that fails EVERY save on the screen while the alerts are
+                  // on, and greying out the only card that explains that hides
+                  // the way out of the state the operator is stuck in.
+                  missing ? "border-amber-500/20 bg-amber-500/5" : cn("border-border", !enabled && "opacity-50"),
+                )}
+              >
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
                     <div className="flex items-center gap-2 flex-wrap">
                       <code className="text-sm font-mono font-medium">{route.via}</code>
+                      {/* Sized like the Channels badges above, not like the
+                          "Paused" pill on a report card, because these two
+                          carry the CHANNELS wording verbatim — "All alerts"
+                          and "N of 6 alert types" are the same strings that
+                          section uses. Two sizes for one sentence read as one
+                          component rendered twice by accident rather than as
+                          two sections agreeing, so the padding here follows
+                          the words. */}
                       {allEvents ? (
-                        <span className="text-xs bg-blue-500/10 text-blue-400 border border-blue-500/20 px-2 py-0.5 rounded font-medium">
+                        <span className="text-xs bg-blue-500/10 text-blue-400 border border-blue-500/20 px-2 py-1 rounded font-medium">
                           All alerts
                         </span>
                       ) : (
-                        <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded font-medium">
+                        <span className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded font-medium">
                           {new Set(route.events).size} of {eventTypes.length} alert types
                         </span>
                       )}

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -6722,14 +6722,20 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
   const names = Object.keys(notifiers).sort((a, b) => a.localeCompare(b))
   const infra = notifications?.infra
   const enabled = infra?.enabled ?? false
-  const routes = (infra?.routes || []).map((route) => ({ ...route, via: route.via.trim(), events: route.events || [] }))
+  // `via` is trimmed exactly where the hub trims it before looking the notifier
+  // up, so a hand-written " eng " names the channel `eng` rather than reading
+  // as an orphan whose only offered remedy — Remove — silently pauses alerts.
+  const routes = (infra?.routes || []).map((route) => ({ ...route, via: viaName(route.via), events: route.events || [] }))
   const eventTypes = settings.infraEventTypes?.length ? settings.infraEventTypes : INFRA_EVENT_TYPES
   const [tests, setTests] = useState<Record<string, TestState>>({})
-  // The last save the hub refused, rendered in the section. The page-level
+  // The outcome of the last save, rendered in the section. The page-level
   // banner is the only other place it goes, and this section sits at the
-  // bottom of a long page: a checkbox that snaps back with the reason
-  // scrolled a screen or more above it just looks dead.
-  const [saveError, setSaveError] = useState("")
+  // bottom of a long page: a switch that snaps back with the reason scrolled a
+  // screen or more above it just looks dead. Kept as the whole SaveOutcome
+  // because a PATCH the hub ACCEPTED whose follow-up re-read failed still
+  // changed the config — calling that "Last save failed" would tell the
+  // operator the opposite of what the hub now holds.
+  const [saveOutcome, setSaveOutcome] = useState<SaveOutcome | null>(null)
   // Routes whose notifier is gone. The hub keeps them on disk while alerts
   // are off but rejects the whole notifications block the moment they are
   // on — and PATCH replaces the whole block, so one dangling route under an
@@ -6742,10 +6748,71 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
   // alerts back on answers it.
   const pauseNotice = pause && !enabled ? pause : null
 
-  const saveInfra = async (next: InfraNotificationsConfig) => {
-    // PATCH replaces the notifications block, so carry the sibling sections
-    // through unchanged when this compact editor changes only infra routing.
-    const { message } = await onSave({
+  // ── The route editor ───────────────────────────────────────────────────────
+  // A dialog with its own draft, like the channel and schedule editors beside
+  // it. The section used to save on every keystroke — each checkbox was a
+  // PATCH of the whole notifications block — so a half-made change was already
+  // on disk and there was nothing for Cancel to discard. Nothing here reaches
+  // the hub until Save.
+  const [showDialog, setShowDialog] = useState(false)
+  const [dialogMode, setDialogMode] = useState<"add" | "edit">("add")
+  // The ROW being edited. Routes have no id, so position is the only address.
+  const [editIndex, setEditIndex] = useState<number | null>(null)
+  const [draftVia, setDraftVia] = useState("")
+  // The name the heading uses, frozen when the dialog opens: reading draftVia
+  // there would rename the dialog under the operator as soon as they picked
+  // another channel in the select.
+  const [editVia, setEditVia] = useState("")
+  // The receive-all choice, made explicitly rather than inferred from an empty
+  // checkbox set. The hub reads `events: []` as "every alert type, including
+  // any added in a later version", so an operator who unticks their way down
+  // to nothing would silently get the firehose — the opposite of what the
+  // unticking meant. Splitting the two apart makes receive-all reachable ON
+  // PURPOSE (it is what keeps a route picking up alert types this hub does not
+  // have yet) and unreachable by accident: an empty "Only these" list is a
+  // save the dialog refuses, in text, rather than a save that quietly widens
+  // the route.
+  const [draftAll, setDraftAll] = useState(true)
+  const [draftEvents, setDraftEvents] = useState<InfraEventType[]>([])
+  const [draftError, setDraftError] = useState("")
+
+  const draftMissing = Boolean(draftVia) && !names.includes(draftVia)
+  // The hub rejects two routes through one notifier, so a name another route
+  // already uses is not on offer — the route being edited keeps its own.
+  const viaOptions = names.filter(
+    (name) => name === draftVia || !routes.some((route, i) => i !== editIndex && route.via === name),
+  )
+  const unroutedName = names.find((name) => !routes.some((route) => route.via === name))
+
+  const openAddRoute = () => {
+    setDialogMode("add")
+    setEditIndex(null)
+    setDraftVia(unroutedName || "")
+    setDraftAll(true)
+    setDraftEvents([])
+    setDraftError("")
+    setShowDialog(true)
+  }
+
+  const openEditRoute = (route: InfraRoute, index: number) => {
+    setDialogMode("edit")
+    setEditIndex(index)
+    setDraftVia(viaName(route.via))
+    setEditVia(viaName(route.via))
+    setDraftAll((route.events || []).length === 0)
+    // De-duplicated because a checkbox can only be on or off: a type stored
+    // twice would otherwise be counted twice in the dialog and re-sent
+    // verbatim by a save that changed nothing.
+    setDraftEvents([...new Set(route.events || [])])
+    setDraftError("")
+    setShowDialog(true)
+  }
+
+  // PATCH replaces the whole notifications block, so every save carries the
+  // sibling sections through byte for byte: omitting `scheduled` here would
+  // delete every scheduled report the first time anyone touches infra routing.
+  const saveInfra = async (next: InfraNotificationsConfig): Promise<SaveOutcome> => {
+    const outcome = await onSave({
       notifications: {
         notifiers,
         lifecycle: notifications?.lifecycle,
@@ -6753,25 +6820,80 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
         infra: next,
       },
     })
-    setSaveError(message || "")
+    setSaveOutcome(outcome)
+    return outcome
   }
 
-  const updateRoute = async (index: number, route: InfraRoute) => {
-    const nextRoutes = routes.map((current, i) => i === index ? route : current)
-    await saveInfra({ ...infra, enabled, routes: nextRoutes })
+  async function saveRoute() {
+    const via = viaName(draftVia)
+    if (!via) { setDraftError("Pick the channel this route posts to."); return }
+    // Belt and braces over the filtered picker: a channel deleted in another
+    // tab between opening this dialog and saving it could still be sitting in
+    // the select, and the hub answers a duplicated via with a routes[n] index
+    // that names nothing on screen.
+    if (routes.some((route, i) => i !== editIndex && route.via === via)) {
+      setDraftError(`"${via}" already carries an infrastructure route. A channel can only have one.`)
+      return
+    }
+    if (!draftAll && draftEvents.length === 0) {
+      setDraftError("Pick at least one alert type, or choose “All alert types”.")
+      return
+    }
+    setDraftError("")
+    // Receive-all is stored as the empty list — the shape the hub reads as
+    // "every type, including any added later". A narrowed route stores its own
+    // types, de-duplicated for the reason the dialog seeds a Set.
+    const entry: InfraRoute = { via, events: draftAll ? [] : [...new Set(draftEvents)] }
+    const nextRoutes = editIndex !== null
+      ? routes.map((route, i) => (i === editIndex ? entry : route))
+      : [...routes, entry]
+    const { persisted, message } = await saveInfra({ ...infra, enabled, routes: nextRoutes })
+    // Closed on `persisted`, not on the absence of a message: a PATCH the hub
+    // took whose follow-up re-read failed already changed the routing, and
+    // holding the dialog open invites a second save of a change that landed.
+    // The re-read failure is real, so the section banner states it verbatim.
+    if (!persisted) { setDraftError(message || "The hub refused the change."); return }
+    setShowDialog(false)
+  }
+
+  async function removeRoute(index: number) {
+    // The hub rejects an enabled block with no routes ("via is required when
+    // enabled"), so dropping the last route pauses infrastructure alerts
+    // instead of failing the save — the same clamp deleteNotifier applies when
+    // it removes the channel a route pointed at.
+    const nextRoutes = routes.filter((_, i) => i !== index)
+    const { persisted, message } = await saveInfra({ ...infra, enabled: nextRoutes.length > 0 && enabled, routes: nextRoutes })
+    if (!persisted) { setDraftError(message || "The hub refused the change."); return }
+    setShowDialog(false)
   }
 
   const sendTest = async (route: InfraRoute, index: number) => {
     const eventType = route.events?.[0] || eventTypes[0]
     if (!eventType) return
+    // The via is part of the key on purpose: a route repointed at another
+    // channel gets a fresh slot rather than inheriting a green "Sent" that
+    // describes a message delivered somewhere else. Removing a row renumbers
+    // the ones after it, which re-keys them the same way — their results
+    // disappear instead of landing on a route that never made them.
     const key = `${index}:${route.via}`
     setTests((current) => ({ ...current, [key]: { status: "sending", message: "" } }))
     try {
       await sendTestNotification(eventType, route.via)
-      setTests((current) => ({ ...current, [key]: { status: "ok", message: `Sent a \"${INFRA_EVENT_LABELS[eventType]}\" test alert.` } }))
+      setTests((current) => ({ ...current, [key]: { status: "ok", message: `Sent a "${INFRA_EVENT_LABELS[eventType]}" test alert.` } }))
     } catch (e) {
       setTests((current) => ({ ...current, [key]: { status: "error", message: e instanceof Error ? e.message : "Test send failed" } }))
     }
+  }
+
+  // What a card says the route receives, without opening anything. An empty
+  // list is receive-all, so it is named as such rather than rendered as "0
+  // alert types"; a long list is cut short because a card is a summary, and
+  // the badge beside it already carries the exact count.
+  const receivesLine = (events: InfraEventType[]): string => {
+    if (events.length === 0) return "Every alert type, including any added in a later hub version."
+    const labels = [...new Set(events)].map((eventType) => INFRA_EVENT_LABELS[eventType])
+    if (labels.length <= 3) return `${labels.join(", ")}.`
+    return `${labels.slice(0, 3).join(", ")} and ${labels.length - 3} more.`
   }
 
   return (
@@ -6790,7 +6912,10 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
         <Switch
           checked={enabled}
           // Gated on the shapes the hub rejects once the block is enabled: no
-          // routes, and a route naming a notifier that no longer exists.
+          // routes, and a route naming a notifier that no longer exists. The
+          // reason is in the paragraph on the left, not only in the tooltip: a
+          // disabled switch leaves the tab order, so a `title` on it reaches
+          // nobody.
           disabled={saving || routes.length === 0 || orphan}
           title={routes.length === 0 ? "Add a channel route first" : orphan ? "Remove the routes pointing at deleted channels first" : undefined}
           onCheckedChange={(next) => saveInfra({ ...infra, enabled: next, routes })}
@@ -6827,141 +6952,330 @@ function InfraNotificationsSection({ settings, onSave, saving, pause }: { settin
           </span>
         </div>
       )}
-      {saveError && (
+      {saveOutcome?.message && (
         <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
           <AlertTriangle className="size-3.5 mt-px shrink-0" />
-          <span className="break-words">Last save failed: {saveError}</span>
+          {/* A message that came back with `persisted` describes the re-read,
+              not the save: the change is on disk, so it is stated verbatim
+              rather than blamed on a save that went through. */}
+          <span className="break-words">
+            {saveOutcome.persisted ? saveOutcome.message : `Last save failed: ${saveOutcome.message}`}
+          </span>
         </div>
       )}
 
       {routes.length === 0 ? (
-        <p className="text-sm text-muted-foreground px-4 py-4 text-center border border-border rounded-lg">Add a channel route before turning infrastructure alerts on.</p>
+        <p className="text-sm text-muted-foreground px-4 py-6 text-center border border-border rounded-lg">
+          {names.length === 0
+            ? "No infrastructure routes. Add a channel first, then route dependency and provider-limit alerts into it."
+            : "No infrastructure routes. Add one to get dependency outages and provider caps in Slack."}
+        </p>
       ) : (
+        // Dimmed while the alerts are off, as the lifecycle categories are.
+        // Nothing that gates a save hides in here: the banners above are at
+        // full opacity and name every broken route by channel.
         <div className={cn("space-y-2", !enabled && "opacity-50")}>
           {routes.map((route, index) => {
             const key = `${index}:${route.via}`
             const test = tests[key]
             // The hub reads an empty list as "every event type, including any
             // added later" — the same receive-all semantics the lifecycle
-            // dialog spells out — so the card has to say so.
+            // section spells out — so the card has to say so rather than
+            // render the route as receiving nothing.
             const allEvents = route.events.length === 0
             const missing = !names.includes(route.via)
-            // Unchecking the last box would save an empty list, which the hub
-            // reads as receive-all — the opposite of what the operator meant.
-            // Removing the route is how to stop it. Said in the description
-            // below, which every checkbox is described by: a disabled input
-            // leaves the tab order, so a tooltip on it is never reached.
-            const lastOne = !allEvents && route.events.length === 1
-            const hintId = `infra-route-${index}-events-hint`
-            // The hub rejects two routes through one notifier, so a name
-            // another route already uses is not on offer here.
-            const options = names.filter((name) => name === route.via || !routes.some((other, i) => i !== index && other.via === name))
+            // Rendered as text, not as the disabled button's `title`: the
+            // Button base class sets `disabled:pointer-events-none`, so a
+            // native tooltip on it can never fire. The orphan case has its own
+            // amber line below, which carries the same answer.
+            const testBlockedReason = !enabled
+              ? "Infrastructure alerts are turned off — this channel receives nothing."
+              : null
             return (
-              <div key={key} className="border border-border rounded-lg p-4 space-y-3">
-                <div className="flex items-center gap-2">
-                  <select
-                    value={route.via}
-                    disabled={saving}
-                    onChange={(e) => updateRoute(index, { ...route, via: e.target.value })}
-                    className={cn("h-8 min-w-0 flex-1 text-sm rounded-md border bg-background px-3", missing ? "border-amber-500/50" : "border-input")}
-                    // Every card carries the same controls, so each name says
-                    // which route it belongs to — as the scheduled rows do.
-                    aria-label={`Notifier for infrastructure alerts (route ${index + 1}: ${route.via})`}
-                  >
-                    {missing && <option value={route.via} disabled>{route.via} — missing notifier</option>}
-                    {options.map((name) => <option key={name} value={name}>{name}</option>)}
-                  </select>
-                  <span className={cn("shrink-0 text-xs px-2 py-1 rounded font-medium", allEvents ? "bg-blue-500/10 text-blue-400 border border-blue-500/20" : "bg-muted text-muted-foreground")}>
-                    {allEvents ? "All alerts" : `${route.events.length} of ${eventTypes.length} alert types`}
-                  </span>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    disabled={saving}
-                    aria-label={`Remove the ${route.via} route`}
-                    onClick={() => {
-                      // The hub rejects an enabled block with no routes, so
-                      // losing the last route pauses alerts instead of failing
-                      // the save — the same clamp deleteNotifier applies.
-                      const nextRoutes = routes.filter((_, i) => i !== index)
-                      saveInfra({ ...infra, enabled: nextRoutes.length > 0 && enabled, routes: nextRoutes })
-                    }}
-                  >
-                    <Trash2 className="size-3.5 mr-1" /> Remove
-                  </Button>
+              <div key={key} className="border border-border rounded-lg p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <code className="text-sm font-mono font-medium">{route.via}</code>
+                      {allEvents ? (
+                        <span className="text-xs bg-blue-500/10 text-blue-400 border border-blue-500/20 px-2 py-0.5 rounded font-medium">
+                          All alerts
+                        </span>
+                      ) : (
+                        <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded font-medium">
+                          {new Set(route.events).size} of {eventTypes.length} alert types
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-1">Receives {receivesLine(route.events)}</p>
+                    {!missing && (
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Posts to <span className="font-mono">{notifiers[route.via]?.channel || "no channel"}</span> in Slack.
+                      </p>
+                    )}
+                    {missing && (
+                      <p className="text-xs text-amber-400 mt-2">
+                        No channel named <span className="font-mono">{route.via}</span> is configured, so this route delivers nothing — open Edit and pick another channel, or remove the route.
+                      </p>
+                    )}
+                    {testBlockedReason && <p className="text-xs text-muted-foreground mt-2">{testBlockedReason}</p>}
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    {/* Every card carries the same two controls, so each is
+                        named by its route: two buttons announcing "Edit" tell
+                        a screen reader nothing about which channel they open.
+                        Held while a save is in flight for the reason the
+                        channel and schedule cards' Edit is — the dialog seeds
+                        from the pre-save snapshot, so opening it mid-save
+                        would hand the next save a stale copy of the change
+                        still landing. */}
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      disabled={saving}
+                      aria-label={`Edit the ${route.via} route`}
+                      onClick={() => openEditRoute(route, index)}
+                    >
+                      Edit
+                    </Button>
+                  </div>
                 </div>
-                {missing && (
-                  <p className="text-xs text-amber-400">
-                    Notifier <span className="font-mono">{route.via}</span> no longer exists, so this route delivers nothing. Pick another channel or remove the route.
-                  </p>
-                )}
-                <div className="grid gap-1 sm:grid-cols-2">
-                  {eventTypes.map((eventType) => {
-                    const checked = allEvents || route.events.includes(eventType)
-                    const lastChecked = checked && lastOne
-                    return (
-                      <label
-                        key={eventType}
-                        className={cn("flex items-center gap-2 text-sm rounded px-2 py-1", lastChecked ? "cursor-not-allowed" : "cursor-pointer hover:bg-muted/50")}
-                      >
-                        <input
-                          type="checkbox"
-                          aria-label={`${INFRA_EVENT_LABELS[eventType]} (${eventType}) for ${route.via}`}
-                          aria-describedby={hintId}
-                          checked={checked}
-                          disabled={saving || lastChecked}
-                          onChange={(e) => {
-                            const current = allEvents ? [...eventTypes] : route.events
-                            const events = e.target.checked ? [...new Set([...current, eventType])] : current.filter((type) => type !== eventType)
-                            if (events.length === 0) return
-                            updateRoute(index, { ...route, events })
-                          }}
-                        />
-                        <span>{INFRA_EVENT_LABELS[eventType]}</span>
-                      </label>
-                    )
-                  })}
-                </div>
-                <p id={hintId} className="text-xs text-muted-foreground">
-                  {allEvents
-                    ? "Saved as receive-all: this channel gets every alert type, including any added later. Uncheck a type to narrow it."
-                    : lastOne
-                      ? `Only "${INFRA_EVENT_LABELS[route.events[0]]}" reaches this channel, and it stays checked: at least one alert type must. Remove the route to stop it entirely.`
-                      : "Only the checked types reach this channel. Remove the route to stop it entirely."}
-                </p>
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 mt-3">
+                  {/* Kept on the row rather than inside the dialog: a test send
+                      is something you do to a route that already exists, and
+                      burying it behind Edit puts it a click away from every
+                      unsaved draft. Dead on an orphan route — a test through a
+                      notifier the hub does not have can only come back as the
+                      hub's routes[n] message, which names nothing on screen. */}
                   <Button
                     size="sm"
                     variant="outline"
                     className="gap-1.5"
-                    // A missing notifier is already explained above the grid;
-                    // a test through it could only fail with the hub's
-                    // routes[n] message, which names nothing on this card.
                     disabled={saving || !enabled || missing || test?.status === "sending"}
-                    aria-label={`Send a test through ${route.via}`}
+                    aria-label={`Send a test alert through ${route.via}`}
                     onClick={() => sendTest(route, index)}
                   >
                     <Send className="size-3.5" />
                     {test?.status === "sending" ? "Sending…" : "Send test"}
                   </Button>
-                  {test && test.status !== "sending" && <span className={cn("text-xs", test.status === "ok" ? "text-green-400" : "text-destructive")}>{test.message}</span>}
                 </div>
+                {test && test.status !== "sending" && (
+                  <div
+                    className={cn(
+                      "mt-3 flex items-start gap-2 rounded-md border px-3 py-2 text-xs",
+                      test.status === "ok"
+                        ? "border-green-500/20 bg-green-500/10 text-green-400"
+                        : "border-destructive/30 bg-destructive/10 text-destructive",
+                    )}
+                  >
+                    {test.status === "ok"
+                      ? <CheckCircle2 className="size-3.5 mt-px shrink-0" />
+                      : <AlertTriangle className="size-3.5 mt-px shrink-0" />}
+                    <span className="break-words">{test.message}</span>
+                  </div>
+                )}
               </div>
             )
           })}
         </div>
       )}
-      <Button
-        size="sm"
-        variant="outline"
-        disabled={saving || names.length === 0 || names.every((name) => routes.some((route) => route.via === name))}
-        onClick={() => {
-          const via = names.find((name) => !routes.some((route) => route.via === name))
-          if (via) saveInfra({ ...infra, enabled, routes: [...routes, { via, events: [] }] })
-        }}
-      >
-        <span className="mr-1 text-sm">+</span> Add route
-      </Button>
+
+      <div className="flex flex-col items-start gap-1">
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={saving || !unroutedName}
+          onClick={openAddRoute}
+        >
+          <span className="mr-1 text-sm">+</span> Add route
+        </Button>
+        {/* Text, not the disabled button's `title`: a disabled Button sets
+            `disabled:pointer-events-none`, so its tooltip never fires — and
+            once a route exists the empty state that carries the same hint is
+            gone, leaving a greyed-out button with nothing explaining it. */}
+        {!unroutedName && (
+          <p className="text-xs text-muted-foreground">
+            {names.length === 0
+              ? "Add a channel first — an infrastructure route needs somewhere to post."
+              : "Every channel already carries a route. The hub allows one infrastructure route per channel."}
+          </p>
+        )}
+      </div>
+
+      {/* Add / edit route. Like its siblings, closing only closes: the openers
+          re-seed every field, so nothing is cleared on the way out and the
+          heading does not blank during the dialog's 200ms exit animation. */}
+      <Dialog open={showDialog} onOpenChange={setShowDialog}>
+        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto p-0 gap-0">
+          <DialogTitle className="sr-only">
+            {dialogMode === "add" ? "Add infrastructure route" : `Edit the ${editVia} route`}
+          </DialogTitle>
+          <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+            <h3 className="font-medium">{dialogMode === "add" ? "Add infrastructure route" : `Edit the ${editVia} route`}</h3>
+          </div>
+
+          <div className="p-5 space-y-4">
+            <div>
+              <label htmlFor="infra-route-via" className="text-xs text-muted-foreground mb-1 block">Channel</label>
+              {/* Every control below is disabled while this dialog's own save
+                  is in flight: saveRoute snapshots the draft at click time and
+                  closes on success, so an edit made during the round trip
+                  would be discarded with nothing on screen saying so. */}
+              <select
+                id="infra-route-via"
+                value={draftVia}
+                disabled={saving}
+                onChange={(e) => setDraftVia(e.target.value)}
+                className="w-full h-8 text-sm rounded-md border border-input bg-background px-3"
+              >
+                {/* A channel that no longer exists has no option of its own, so
+                    the controlled select would render blank while Save writes
+                    the dangling name straight back. Give it one, flagged. */}
+                {draftMissing && <option value={draftVia}>{draftVia} (channel no longer configured)</option>}
+                {viaOptions.map((name) => <option key={name} value={name}>{name}</option>)}
+              </select>
+              {draftMissing ? (
+                <p className="text-xs text-amber-400 mt-1">
+                  No channel named <span className="font-mono">{draftVia}</span> is configured, so nothing is delivered here — and the hub refuses to turn infrastructure alerts on while this route is left. Pick another channel, or remove the route below.
+                </p>
+              ) : (
+                <p className="text-xs text-muted-foreground mt-1">
+                  Infrastructure alerts land in this channel. A channel carries one infrastructure route, so the ones already routed are not listed.
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-3 border-t border-border pt-4">
+              <div>
+                <div className="text-sm font-medium">What lands here</div>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Dependency outages and provider usage limits are checked on the hub&apos;s own poll — the lifecycle switches above do not mute them.
+                </p>
+              </div>
+
+              {/* Receive-all is a choice, not the shape you fall into by
+                  unticking. The hub stores it as an empty list and reads that
+                  as "every alert type, including any added in a later
+                  version", so this pair is what keeps a narrowed route from
+                  silently becoming the firehose — and keeps the firehose
+                  reachable on purpose for an operator who wants the route to
+                  pick up types this hub does not have yet. */}
+              <div className="space-y-1" role="radiogroup" aria-label="Which alerts this route receives">
+                <label className="flex items-start gap-2 text-sm cursor-pointer rounded px-2 py-1 hover:bg-muted/50">
+                  <input
+                    type="radio"
+                    name="infra-route-scope"
+                    className="mt-1"
+                    checked={draftAll}
+                    disabled={saving}
+                    onChange={() => setDraftAll(true)}
+                  />
+                  <span className="min-w-0">
+                    All alert types
+                    <span className="block text-xs text-muted-foreground">
+                      Including any this hub adds in a later version.
+                    </span>
+                  </span>
+                </label>
+                <label className="flex items-start gap-2 text-sm cursor-pointer rounded px-2 py-1 hover:bg-muted/50">
+                  <input
+                    type="radio"
+                    name="infra-route-scope"
+                    className="mt-1"
+                    checked={!draftAll}
+                    disabled={saving}
+                    onChange={() => setDraftAll(false)}
+                  />
+                  <span className="min-w-0">
+                    Only the types you pick
+                    <span className="block text-xs text-muted-foreground">
+                      Anything you add to this hub later stays out until you come back and tick it.
+                    </span>
+                  </span>
+                </label>
+              </div>
+
+              {!draftAll && (
+                <>
+                  <div className="space-y-1">
+                    {eventTypes.map((eventType) => {
+                      const checked = draftEvents.includes(eventType)
+                      return (
+                        <label
+                          key={eventType}
+                          className="flex items-center gap-2 text-sm cursor-pointer rounded px-2 py-1 hover:bg-muted/50"
+                        >
+                          <input
+                            type="checkbox"
+                            aria-label={`${INFRA_EVENT_LABELS[eventType]} (${eventType})`}
+                            checked={checked}
+                            disabled={saving}
+                            onChange={(e) =>
+                              setDraftEvents(
+                                e.target.checked
+                                  ? [...draftEvents, eventType]
+                                  : draftEvents.filter((type) => type !== eventType),
+                              )
+                            }
+                          />
+                          <span className={cn(!checked && "text-muted-foreground")}>{INFRA_EVENT_LABELS[eventType]}</span>
+                          <code className="text-xs text-muted-foreground font-mono">{eventType}</code>
+                        </label>
+                      )
+                    })}
+                  </div>
+                  {/* The empty selection is refused here rather than saved: an
+                      empty list is exactly how the hub stores receive-all, so
+                      saving one would widen the route the operator was
+                      narrowing. Said in text beside the Save button it
+                      disables, since a disabled button carries no tooltip. */}
+                  {draftEvents.length === 0 && (
+                    <p className="text-xs text-amber-400 rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2">
+                      Tick at least one alert type. The hub reads a route with nothing ticked as every alert type — if that is what you want, choose &quot;All alert types&quot; above.
+                    </p>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+
+          <div className="border-t border-border">
+            {/* The error sits with the buttons, never below the fold of a long
+                scrolling form. */}
+            {draftError && (
+              <div className="mx-5 mt-4 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                <AlertTriangle className="size-3.5 mt-px shrink-0" />
+                <span className="break-words">{draftError}</span>
+              </div>
+            )}
+            <div className="flex items-center justify-between px-5 py-4">
+              {dialogMode === "edit" && editIndex !== null && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-destructive hover:text-destructive"
+                  disabled={saving}
+                  onClick={() => removeRoute(editIndex)}
+                >
+                  <Trash2 className="size-3.5 mr-1" /> Remove route
+                </Button>
+              )}
+              <div className="flex items-center gap-2 ml-auto">
+                {/* Cancel throws the draft away: nothing here has reached the
+                    hub yet. */}
+                <Button size="sm" variant="outline" disabled={saving} onClick={() => setShowDialog(false)}>Cancel</Button>
+                <Button
+                  size="sm"
+                  disabled={saving || !draftVia || (!draftAll && draftEvents.length === 0)}
+                  onClick={saveRoute}
+                >
+                  {dialogMode === "add" ? "Add route" : "Save changes"}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/web/app/settings/[[...parts]]/settings-content.tsx
+++ b/web/app/settings/[[...parts]]/settings-content.tsx
@@ -6792,7 +6792,18 @@ function InfraNotificationsSection({ settings, onSave, saving }: { settings: Set
                   <span className={cn("shrink-0 text-xs px-2 py-1 rounded font-medium", allEvents ? "bg-blue-500/10 text-blue-400 border border-blue-500/20" : "bg-muted text-muted-foreground")}>
                     {allEvents ? "All alerts" : `${route.events.length} of ${eventTypes.length} alert types`}
                   </span>
-                  <Button size="sm" variant="ghost" disabled={saving} onClick={() => saveInfra({ ...infra, enabled: infra?.enabled ?? false, routes: routes.filter((_, i) => i !== index) })}>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={saving}
+                    onClick={() => {
+                      // The hub rejects an enabled block with no routes, so
+                      // losing the last route pauses alerts instead of failing
+                      // the save — the same clamp deleteNotifier applies.
+                      const nextRoutes = routes.filter((_, i) => i !== index)
+                      saveInfra({ ...infra, enabled: nextRoutes.length > 0 && (infra?.enabled ?? false), routes: nextRoutes })
+                    }}
+                  >
                     <Trash2 className="size-3.5 mr-1" /> Remove
                   </Button>
                 </div>

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -1,5 +1,28 @@
 export type ClawStatus = "connected" | "idle" | "offline" | "provisioning" | "error"
 
+export const INFRA_EVENT_TYPES = [
+  "dependency_down",
+  "dependency_degraded",
+  "dependency_recovered",
+  "provider_limit_opened",
+  "provider_limit_exhausted",
+  "provider_limit_released",
+] as const
+
+export type InfraEventType = (typeof INFRA_EVENT_TYPES)[number]
+
+export interface InfraRoute {
+  via: string
+  events?: InfraEventType[]
+}
+
+export interface InfraNotificationsConfig {
+  enabled?: boolean
+  routes?: InfraRoute[]
+  pollInterval?: string
+  repeatAfter?: string
+}
+
 export interface Claw {
   id: string
   name: string


### PR DESCRIPTION
## What

Notifications for the two failure modes the hub could already see but never told anyone about:

1. **Dependency downtime** — the status-page checks in `dependency_status.go` only ran on demand from `GET /api/dependencies/status`. If nobody had the dashboard open, an Anthropic/Daytona/Linear outage was invisible.
2. **Provider usage limits** — a capped LLM key parked every claw on it, but the only operator-facing signal was a per-claw `agent_idle` event rendering as "Agent stalled". Four claws on one key produced four messages pointing at four agent bugs that did not exist, and nothing at all was emitted when the cap lifted.

Both now flow through a third notification feature, `notifications.infra`, riding the same named notifiers as lifecycle and scheduled but with its own event source and its own delivery cursor.

## How

**Event store** — new `infra_events` table (rowid-ordered, `event_key` unique for idempotent dedupe), shaped like `task_run_events`. The lifecycle cursor could not carry these: it is per claw/run, and these facts are fleet-wide.

**Dependency watcher** (`pkg/hub/dependency_watcher.go`) — 1-minute tick over the existing snapshot, per-dependency state persisted in `dependency_status_state` so a hub restart does not re-alert everything. A dependency must report the same non-operational status on two consecutive *fresh* observations before an event fires; `unknown` never alerts (a hub with no egress would otherwise manufacture outages) and `limited` is left to the usage-limit path, which knows the deadline and the number of parked claws.

**Provider limit events** — emitted per key, not per claw: `provider_limit_opened`, `provider_limit_exhausted`, `provider_limit_released`. A plain re-latch that has not exhausted its retries emits nothing; it is the system working as designed. Key IDs are hashed and credential-shaped substrings are redacted out of provider messages before they reach the store.

**Delivery** (`pkg/hub/infra_notifier.go`) — per-route watermark, per-(event, route) dedupe, bounded transient-failure streak, 30s send timeout, config re-read each tick, injected clock. New routes baseline at the head of the stream instead of replaying history into a freshly-connected channel.

**Config** — `notifications.infra` with `enabled`, `routes[{via, events}]`, `poll_interval`, `repeat_after`, full validation, a doctor check, the settings UI, and the six event types added to the test-send endpoint.

## Notable decisions

- `provider_limit_opened` is **warning**, not error: it is expected, it resolves itself, and the hub already names the instant it lifts. Only `provider_limit_exhausted` means a human must go raise the cap.
- `repeat_after` is **off by default**, and applies to dependency outages only — a six-hour outage re-alerting hourly trains everyone to mute the channel, and provider caps already have their own opened/exhausted/released cadence.
- Routing is global/admin, not per tenant: a capped key is a fact about the key.
- `dependency_status_state` and `infra_events` are new tables created additively — no table rebuild, no column drop.

## Testing

`go build ./...`, `go vet`, `gofmt` clean. `go test ./pkg/hub/... ./pkg/types/...` passes except `TestDoneSignalRejectedWhenPRPersistenceFails`, `TestHandleClawDoneSignal_IssueLessWorkflowWatchesPR` and `TestCompleteIssueLessDoneClawKeepsRunningOnStoreFailure`, which fail identically on the base commit `904e79b0` (verified in a detached worktree) — they reach the real GitHub API from a local host config.

New coverage: debounce against a re-served cache, `unknown` never alerting, restart not re-alerting, one event per key with four claws sharing it, release/exhausted emission, route event filtering, per-route dedupe, streak cap, watermark baselining, validation rejections, and a no-secrets assertion on rendered messages.

UI screenshots are not attached — the settings section was verified by typecheck/lint only. Say the word and I will run the seeded hub and capture it.

## Upgrade note for existing deployments

This PR **removes** the per-claw `agent_idle` event a capped provider key used to
produce. A hub that today routes lifecycle `agent_idle` to Slack and does not
configure `notifications.infra` will stop being told about provider caps. That is
the point of the change — four claws on one key produced four "Agent stalled"
reports and sent operators hunting for four agent bugs that did not exist — but it
is a silent loss if nobody adds the new routes, so `doctor` now raises a **critical**
check when a lifecycle block routes `agent_idle` while no infra route carries the
`provider_limit_*` events. Add an infra route when upgrading.

The claw-level explanation is unchanged: the hub notice in the conversation and the
limit badge / `GET /api/claws/{id}/llm-limit` still say why that agent stopped.

## Review

Two rounds of paired review — five specialties (concurrency, schema/idempotency,
secrets, operator semantics, frontend contract), each covered once by a Claude model
and once by gpt-5.6, on the theory that a single model family has systematic rather
than random blind spots. Round 1: 36 findings, 20 critical/major. Round 2 re-reviewed
the two specialties with the most defects as a verification pass over the fixes: 13
findings, 4 major, one of them a regression the first fix round introduced.

What the loop actually caught, beyond the obvious:

- **`provider_limit_released` was a lie.** It fired on every speculative automatic
  retry, and the re-latch that followed was silent — one cap produced a stream of
  "cap lifted" messages and no correction. A lift is now announced only once an
  authored turn proves it, re-latches say so explicitly, and the pending probe is
  re-armed after a restart (that last part was the round-2 regression).
- **Route state outlived the route.** Removing a route, or toggling the feature off,
  left its watermark behind; re-adding replayed the whole absence window into the
  channel. `pruneInfraRouteState` now mirrors the lifecycle notifier's pruning.
- **PATCH /api/settings never validated the infra block**, and notifier-removal
  checks did not count infra routes — a notifier could be deleted out from under a
  live route.
- **The `exhausted` message told the operator to wait for a reset that never comes.**
  Exhausted limits are not auto-released; the copy now says so and points at the
  clear action.
- **A recovery could arrive with no opening.** When a route burned its transient
  budget on the down alert, the recovery landed alone and read as good news about an
  outage nobody had been told about. The recovery is now paired with its episode and
  relabelled when the opening never went out, and `doctor` lists dropped deliveries.
- **The settings UI could save `events: []`**, which the backend reads as *all*
  events — unchecking the last box silently turned a narrow route into a firehose.

Findings rejected with reasons (not silently dropped): masking org/project ids
(identifiers, not credentials, and the message needs them), reconciling a dependency
removed mid-outage (would emit a recovery the hub never observed), and the bounded
60-attempt transient cap (retrying one event forever head-of-line blocks every later
event on that route, including the recovery).

## Runtime verification

The feature was driven end to end against a real hub process (a throwaway harness over
`NewTestServerWithConfig` plus the repo's fake Slack notifier), because fourteen review
passes had read this code and none had executed it. Eight scenarios: the debounce, the
5-minute cache fence, one cap on a key shared by three claws, the full release path, a
**restart mid-probe on the same file-backed database** (the round-2 regression, re-proven
in a second process), exhausted retries, route removed/re-added and the feature toggled
off/on, and a notifier answering HTTP 500 until its transient budget burned.

Seven behaved as documented. The divergences it found are fixed in this branch:
`provider_limit_exhausted` was rendering a `Last retry` in the *future* (the record's
deadline, an instant nothing honours once retries are exhausted), a recovery never said
how long the outage lasted although the watcher had always recorded it, and a lifted cap
quoted the rejection that opened the episode underneath "Provider access has recovered".

Rendered output, seen for the first time by a human:

```
:fire: *Dependency is down*
Anthropic
> Wait for recovery and watch the dependency's status page.
> Elevated errors on the Claude API
Event dependency down · Status page https://status.anthropic.com · Occurred …

:credit_card: *Provider account is capped*
anthropic
> Raise the provider account cap in its billing console, or wait until the stated reset time.
> LLM request rejected: You have reached your specified API usage limits… (org org_[redacted]123, key [redacted], Authorization: [redacted])
Event provider limit opened · Provider anthropic · Key key_cb7a5742346e · Claws parked 3 · Deadline 2026-09-10 00:00 UTC

:no_entry: *Provider cap needs a human*
> Automatic retries are exhausted; the hub will not retry on its own. Raise the cap in the
> provider's billing console, then clear the block (a parked claw's page, or
> DELETE /api/claws/{id}/llm-limit) to resume.
Event provider limit exhausted · Claws parked 2 · Last retry 2026-09-03 17:35 UTC

:white_check_mark: *Dependency recovered*
> Service has recovered; resume watching normal work.
Event dependency recovered · Down for 47m · Status page …
```

## Settings section rework

The section this PR first shipped worked, but spoke a different control language than the
notifier screen it lives on: a native `select` and a grid of native checkboxes, inline,
saving on every keystroke, sitting under Lifecycle, Channels and Scheduled reports, which
are all row cards plus a dialog. It was flagged as a follow-up and then done, and the
commits are in this branch.

Each route is now a row card in the screen's own pattern — the channel as a mono name, the
"All alerts" / "N of 6 alert types" badge in the Channels section's size and treatment, a
line saying what it receives and where it posts, Send test on the card. Add and Edit open a
dialog with its own draft, a Cancel that discards, and nothing reaching the hub until Save.

The receive-all trap changed shape rather than disappearing. The hub reads `events: []` as
receive-all, so unchecking the last box was a silent flip from one alert type to the
firehose; the first version prevented it by disabling the last checked box and explaining
why. It is now an explicit **All alert types** / **Only the types you pick** choice — the
same guarantee stated in the shape of the question instead of in a constraint — and an
empty "only these" list cannot be saved.

Every guard in that section is scar tissue from a review round, so the rework was done
against an inventory rather than from scratch: the master-switch gating, the in-section
"Last save failed" strip, the channel-delete pause notice, per-route accessible names, the
picker omitting channels another route already uses, the PATCH carry-forward, and the clamp
that turns alerts off with the last route. It was then re-reviewed for parity (Claude),
for state and save-contract correctness (gpt-5.6), and by hand against a running hub, which
found four defects — routes addressed by array index instead of by channel, badges a size
smaller than the identical strings above them, the orphan card's amber remedy dimmed by the
disabled wrapper, and the last-route removal pausing alerts without saying so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



