### PR TITLE
fix(hub): scope the idle auto-resume cap to a unit of work

### DIFF
--- a/pkg/hub/agent_idle.go
+++ b/pkg/hub/agent_idle.go
@@ -430,12 +430,16 @@ const (
 	// ONE unit of work. The counter (claws.idle_resume_count) is reset when the
 	// unit changes: on a won pipeline stage transition
 	// (claimPipelineStageTransition), when the sandbox is replaced with a new
-	// session (resetClawForRetry), and when the session itself is lost and
-	// re-briefed (enqueueSessionLostResume, which covers both the process
-	// restart and the session rotation). The last two are the same idea as the
-	// first — an agent with no memory of the earlier conversation is starting
-	// its unit of work over — and missing either of them leaves the identical
-	// hole this cap-scoping exists to close. It is NOT reset per stretch, see
+	// session (resetClawForRetry), and when the session itself is lost — either
+	// at the re-brief (enqueueSessionLostResume, the funnel for a loss detected
+	// with a turn open or recent) or, for a loss detected while the claw was
+	// idle, when the parked notice is finally delivered with the next real
+	// prompt (server.go). Both session paths are needed: noteSessionLoss splits
+	// on turnOpenOrRecent and only one side re-briefs immediately. All of these
+	// are the same idea as the stage transition — an agent with no memory of the
+	// earlier conversation is starting its unit of work over — and missing any
+	// one of them leaves the identical hole this cap-scoping exists to close.
+	// It is NOT reset per stretch, see
 	// clearAgentIdleResumeLatch.
 	//
 	// The PRIMARY backstop is the existing no-progress watchdog: a resume that
@@ -776,7 +780,8 @@ func (s *Server) clearAgentIdleLatch(clawID string, cc *clawConn) {
 // would make the per-work-unit cap unreachable in precisely the runaway case
 // it exists to bound (wake, do nothing, idle, repeat). The counter only resets
 // when the unit of work itself changes (claimPipelineStageTransition,
-// resetClawForRetry).
+// resetClawForRetry, enqueueSessionLostResume, and the session-loss notice
+// delivery in server.go).
 func (s *Server) clearAgentIdleResumeLatch(clawID string) {
 	if _, err := s.db.Exec(`UPDATE claws SET idle_resume_at=0 WHERE id=? AND idle_resume_at != 0`, clawID); err != nil {
 		log.Printf("[agent-idle] clear resume latch for claw %s: %v", shortID(clawID), err)

--- a/pkg/hub/agent_idle.go
+++ b/pkg/hub/agent_idle.go
@@ -429,8 +429,13 @@ const (
 	// agentIdleResumeMaxAttempts bounds the resumes a claw can receive within
 	// ONE unit of work. The counter (claws.idle_resume_count) is reset when the
 	// unit changes: on a won pipeline stage transition
-	// (claimPipelineStageTransition) and when the sandbox is replaced with a
-	// new session (resetClawForRetry). It is NOT reset per stretch, see
+	// (claimPipelineStageTransition), when the sandbox is replaced with a new
+	// session (resetClawForRetry), and when the session itself is lost and
+	// re-briefed (enqueueSessionLostResume, which covers both the process
+	// restart and the session rotation). The last two are the same idea as the
+	// first — an agent with no memory of the earlier conversation is starting
+	// its unit of work over — and missing either of them leaves the identical
+	// hole this cap-scoping exists to close. It is NOT reset per stretch, see
 	// clearAgentIdleResumeLatch.
 	//
 	// The PRIMARY backstop is the existing no-progress watchdog: a resume that

--- a/pkg/hub/agent_idle.go
+++ b/pkg/hub/agent_idle.go
@@ -426,13 +426,30 @@ const (
 	// the notification config at all, by design.
 	agentIdleResumeBaselineKey = "agent_idle_resume_baseline"
 
-	// agentIdleResumeMaxAttempts bounds the resumes a single claw can ever
-	// receive. The PRIMARY backstop is the existing no-progress watchdog: a
-	// resume that produces the same empty outcome three times sets
-	// no_progress_paused, which this check honours (see below). The cap covers
-	// the pathological case that watchdog cannot see — turns whose outcomes
-	// keep differing just enough to reset its observation window — so a
-	// wake-do-nothing-idle loop cannot poke forever.
+	// agentIdleResumeMaxAttempts bounds the resumes a claw can receive within
+	// ONE unit of work. The counter (claws.idle_resume_count) is reset when the
+	// unit changes: on a won pipeline stage transition
+	// (claimPipelineStageTransition) and when the sandbox is replaced with a
+	// new session (resetClawForRetry). It is NOT reset per stretch, see
+	// clearAgentIdleResumeLatch.
+	//
+	// The PRIMARY backstop is the existing no-progress watchdog: a resume that
+	// produces the same empty outcome three times sets no_progress_paused,
+	// which this check honours (see below). The cap covers the pathological
+	// case that watchdog cannot see — turns whose outcomes keep differing just
+	// enough to reset its observation window — so a wake-do-nothing-idle loop
+	// cannot poke forever.
+	//
+	// The cap used to be lifetime, and that is what stranded NEXT-647: ten
+	// pokes over two days, eight of them in a stage whose work was already
+	// merged (each resume woke the claw, it correctly found nothing to do and
+	// slept again — the mechanism working), spent the whole budget. When a
+	// replacement sandbox later parked on sessions_yield in review_loop, the
+	// no-progress watchdog did not latch (the outcomes differed) and the cap
+	// had nothing left, so the claw sat silent for 8h16m until a human typed.
+	// Ten pokes inside one stage is still the runaway this exists to stop; ten
+	// spread across unrelated units of work is not, and must not disarm the
+	// recovery for the next one.
 	agentIdleResumeMaxAttempts = 10
 
 	agentIdleResumePrefix = "[hub] No turn has been running for"
@@ -562,7 +579,7 @@ func (s *Server) checkAgentIdleResume(nowAt time.Time, clawID string, cc *clawCo
 	if snap.stretchStartAt.Before(baseline) {
 		// The stretch began before the resume could have observed it (first
 		// deploy or first enable, or during a disabled window): park it —
-		// latch without injecting, without consuming the lifetime cap — so
+		// latch without injecting, without consuming the per-work-unit cap — so
 		// turning the feature on never replays history. This is what keeps
 		// the first tick against an existing database from poking every
 		// long-idle claw on it at once. A real turn re-arms the claw
@@ -580,7 +597,7 @@ func (s *Server) checkAgentIdleResume(nowAt time.Time, clawID string, cc *clawCo
 	}
 	log.Printf("[agent-idle] auto-resuming claw %s after %d minutes idle (attempt %d/%d)", shortID(clawID), int(idleFor.Minutes()), resumeCount+1, agentIdleResumeMaxAttempts)
 	if resumeCount+1 >= agentIdleResumeMaxAttempts {
-		log.Printf("[agent-idle] claw %s reached the lifetime auto-resume cap of %d; no further resumes will be sent", shortID(clawID), agentIdleResumeMaxAttempts)
+		log.Printf("[agent-idle] claw %s reached the auto-resume cap of %d for its current unit of work; no further resumes until the stage changes or the sandbox is replaced", shortID(clawID), agentIdleResumeMaxAttempts)
 	}
 	// What makes the resume once-per-stretch is the idle_resume_at latch
 	// written just above, NOT injectMessage's dedupe: the message embeds the
@@ -593,7 +610,7 @@ func (s *Server) checkAgentIdleResume(nowAt time.Time, clawID string, cc *clawCo
 }
 
 // parkAgentIdleResumeStretch latches a stretch as handled WITHOUT injecting a
-// prompt and without consuming an attempt from the lifetime cap: nothing is
+// prompt and without consuming an attempt from the per-work-unit cap: nothing is
 // delivered, so nothing was spent. The latch alone dedupes every future
 // re-detection of the stretch, including across hub restarts.
 func (s *Server) parkAgentIdleResumeStretch(clawID string, stretchStart int64) {
@@ -749,10 +766,12 @@ func (s *Server) clearAgentIdleLatch(clawID string, cc *clawConn) {
 // checkAgentIdleResume; see clearAgentIdleLatch for why observing busy is not
 // good enough.
 //
-// idle_resume_count is deliberately NOT reset. A resume that produces an empty
-// turn still ends the stretch, so resetting the counter on every turn would
-// make the lifetime cap unreachable in precisely the runaway case it exists to
-// bound (wake, do nothing, idle, repeat).
+// idle_resume_count is deliberately NOT reset here. A resume that produces an
+// empty turn still ends the stretch, so resetting the counter on every turn
+// would make the per-work-unit cap unreachable in precisely the runaway case
+// it exists to bound (wake, do nothing, idle, repeat). The counter only resets
+// when the unit of work itself changes (claimPipelineStageTransition,
+// resetClawForRetry).
 func (s *Server) clearAgentIdleResumeLatch(clawID string) {
 	if _, err := s.db.Exec(`UPDATE claws SET idle_resume_at=0 WHERE id=? AND idle_resume_at != 0`, clawID); err != nil {
 		log.Printf("[agent-idle] clear resume latch for claw %s: %v", shortID(clawID), err)

--- a/pkg/hub/agent_idle_resume_test.go
+++ b/pkg/hub/agent_idle_resume_test.go
@@ -526,3 +526,55 @@ func TestAgentIdleResumeBudgetRearmsOnStageTransition(t *testing.T) {
 		t.Fatalf("after the second transition: idle_resume_at=%d count=%d, want latch %d kept and count 0", at2, count, at)
 	}
 }
+
+// A lost session re-arms the resume budget, for both callers that produce one.
+// Without this, the NEXT-647 shape reappears with a different trigger: the cap
+// is spent inside a stage, a lock conflict rotates the session, and the
+// amnesiac agent that takes over inherits a spent budget while its stage never
+// changes — so nothing at all can wake it.
+func TestEnqueueSessionLostResumeRearmsIdleResumeBudget(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		prefix string
+	}{
+		{"process restart", restartResumePrefix},
+		{"session rotation", sessionRotatedResumePrefix},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, db := NewTestServerWithConfig(t, nil, "", "", "")
+			const clawID = "claw-session-lost-budget"
+			if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, status, bootstrap_ok, pipeline_stage, idle_resume_at, idle_resume_count, created_at) VALUES(?,?,?,?,?,?,?,?,datetime('now'))`,
+				clawID, "test-tenant-id", "session lost", "connected", 1, "review_loop", int64(1_700_000_000_000), agentIdleResumeMaxAttempts); err != nil {
+				t.Fatalf("seed claw: %v", err)
+			}
+
+			s.enqueueSessionLostResume(clawID, tc.prefix, "marker-"+tc.name)
+
+			at, count := clawIdleResumeState(t, db, clawID)
+			if count != 0 {
+				t.Fatalf("session-lost resume left idle_resume_count=%d, want 0", count)
+			}
+			if at != 0 {
+				t.Fatalf("session-lost resume left idle_resume_at=%d, want 0", at)
+			}
+		})
+	}
+}
+
+// The re-arm sits behind the same guard as the resume itself: a claw that is
+// not getting a resume prompt must not have its budget silently refilled.
+func TestEnqueueSessionLostResumeLeavesBudgetWhenClawIneligible(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, nil, "", "", "")
+	const clawID = "claw-session-lost-ineligible"
+	if _, err := db.Exec(`INSERT INTO claws(id, tenant_id, name, status, bootstrap_ok, pipeline_stage, idle_resume_at, idle_resume_count, created_at) VALUES(?,?,?,?,?,?,?,?,datetime('now'))`,
+		clawID, "test-tenant-id", "not connected", "offline", 1, "review_loop", int64(1_700_000_000_000), agentIdleResumeMaxAttempts); err != nil {
+		t.Fatalf("seed claw: %v", err)
+	}
+
+	s.enqueueSessionLostResume(clawID, restartResumePrefix, "ineligible-marker")
+
+	_, count := clawIdleResumeState(t, db, clawID)
+	if count != agentIdleResumeMaxAttempts {
+		t.Fatalf("budget was re-armed for an ineligible claw: idle_resume_count=%d, want %d", count, agentIdleResumeMaxAttempts)
+	}
+}

--- a/pkg/hub/agent_idle_resume_test.go
+++ b/pkg/hub/agent_idle_resume_test.go
@@ -226,10 +226,10 @@ func TestAgentIdleResumeExclusions(t *testing.T) {
 }
 
 // The runaway backstop: a claw that keeps waking, doing nothing, and idling
-// again clears the per-stretch latch every time, so only the lifetime cap
+// again clears the per-stretch latch every time, so only the per-work-unit cap
 // stops the poking. (The primary backstop is the no-progress watchdog, which
 // pauses such a claw after three identical outcomes — see the exclusion test.)
-func TestAgentIdleResumeStopsAtLifetimeCap(t *testing.T) {
+func TestAgentIdleResumeStopsAtCapWithinOneWorkUnit(t *testing.T) {
 	s, db := newIdleResumeTestServer(t, nil)
 	const clawID = "resume-cap"
 	insertSlackTestClaw(t, db, clawID, "connected", 0, "", oldEnough)
@@ -239,7 +239,7 @@ func TestAgentIdleResumeStopsAtLifetimeCap(t *testing.T) {
 		// Each iteration is a genuinely distinct stretch: the claw woke, ran
 		// an empty turn and stalled again, so lastTurnFinishedAt moves forward
 		// every time and re-arms the per-stretch latch on its own. Only the
-		// lifetime cap can stop the poking. The steps are wider than
+		// per-work-unit cap can stop the poking. The steps are wider than
 		// agentIdleStretchSlack so no two stretches are mistaken for one.
 		cc := idleTestConn(clawID, time.Hour-time.Duration(i)*2*time.Minute)
 		s.checkAgentIdleResume(time.Now(), clawID, cc)
@@ -257,7 +257,7 @@ func TestAgentIdleResumeStopsAtLifetimeCap(t *testing.T) {
 // every long-idle claw in the database at once — including pipeline claws a
 // human deliberately walked away from hours ago. A stretch that began before
 // the resume baseline is parked: latched so it is never re-examined, never
-// injected, and never charged against the lifetime cap.
+// injected, and never charged against the per-work-unit cap.
 func TestAgentIdleResumeParksStretchesOlderThanBaseline(t *testing.T) {
 	s, db := newIdleResumeTestServerAtEnable(t, nil)
 	const clawID = "resume-pre-existing"
@@ -277,7 +277,7 @@ func TestAgentIdleResumeParksStretchesOlderThanBaseline(t *testing.T) {
 		t.Fatal("pre-baseline stretch was not parked: it will be reconsidered on every future tick")
 	}
 	if count != 0 {
-		t.Fatalf("parking consumed %d of the lifetime cap, want 0", count)
+		t.Fatalf("parking consumed %d of the per-work-unit cap, want 0", count)
 	}
 
 	// Still parked on later ticks, and across a hub restart (fresh clawConn,
@@ -443,5 +443,86 @@ func TestAgentIdleResumeCarriesTurnVisibilityAcrossReconnect(t *testing.T) {
 	after.turnBoundarySeen = busy.turnBoundarySeen && !busy.isBusyLocked()
 	if after.turnBoundarySeen {
 		t.Fatal("a reconnect from a busy connection must start blind")
+	}
+}
+
+// claimPipelineStageTransition is the only writer of pipeline_stage, so it is
+// where the auto-resume budget must re-arm: a won transition zeroes
+// idle_resume_count, a re-entry into the current stage (no row changed) leaves
+// it alone, and neither touches idle_resume_at — the once-per-stretch latch is
+// dedupe, not budget, and moving it would let one stretch be poked twice.
+func TestClaimPipelineStageTransitionResetsIdleResumeBudgetOnly(t *testing.T) {
+	s, db := newIdleResumeTestServer(t, nil)
+	const clawID = "resume-stage-reset"
+	insertSlackTestClaw(t, db, clawID, "connected", 0, "", oldEnough)
+	setClawPipelineStage(t, db, clawID, "implement")
+	const latch = int64(1_700_000_000_000)
+	if _, err := db.Exec(`UPDATE claws SET idle_resume_at=?, idle_resume_count=? WHERE id=?`, latch, agentIdleResumeMaxAttempts, clawID); err != nil {
+		t.Fatalf("seed idle_resume state: %v", err)
+	}
+
+	if s.claimPipelineStageTransition(clawID, "implement") {
+		t.Fatal("re-entering the current stage claimed a transition")
+	}
+	if at, count := clawIdleResumeState(t, db, clawID); at != latch || count != agentIdleResumeMaxAttempts {
+		t.Fatalf("same-stage no-op changed idle_resume state to at=%d count=%d", at, count)
+	}
+
+	if !s.claimPipelineStageTransition(clawID, "review_loop") {
+		t.Fatal("transition to a new stage was not claimed")
+	}
+	at, count := clawIdleResumeState(t, db, clawID)
+	if count != 0 {
+		t.Fatalf("stage transition left idle_resume_count=%d, want 0", count)
+	}
+	if at != latch {
+		t.Fatalf("stage transition moved idle_resume_at to %d, want the latch untouched at %d", at, latch)
+	}
+}
+
+// The NEXT-647 shape end to end: a claw that spent its whole resume budget in
+// an earlier stage must be resumable again once the pipeline moves it to a new
+// one — and the transition must not turn into a second poke of a stretch that
+// was already handled.
+func TestAgentIdleResumeBudgetRearmsOnStageTransition(t *testing.T) {
+	s, db := newIdleResumeTestServer(t, nil)
+	const clawID = "resume-budget-rearm"
+	insertSlackTestClaw(t, db, clawID, "connected", 0, "", oldEnough)
+	setClawPipelineStage(t, db, clawID, "implement")
+	if _, err := db.Exec(`UPDATE claws SET idle_resume_count=? WHERE id=?`, agentIdleResumeMaxAttempts, clawID); err != nil {
+		t.Fatalf("spend the resume budget: %v", err)
+	}
+
+	// Budget spent in the implement stage: the sessions_yield stretch in the
+	// next stage would sit unpoked forever under a lifetime cap.
+	cc := idleTestConn(clawID, 15*time.Minute)
+	s.checkAgentIdleResume(time.Now(), clawID, cc)
+	if got := idleResumeMessages(t, db, clawID); got != 0 {
+		t.Fatalf("resumed %d times with the budget spent, want 0", got)
+	}
+
+	if !s.claimPipelineStageTransition(clawID, "review_loop") {
+		t.Fatal("transition to review_loop was not claimed")
+	}
+	s.checkAgentIdleResume(time.Now(), clawID, cc)
+	if got := idleResumeMessages(t, db, clawID); got != 1 {
+		t.Fatalf("resumed %d times after the stage transition, want 1", got)
+	}
+	at, count := clawIdleResumeState(t, db, clawID)
+	if at == 0 || count != 1 {
+		t.Fatalf("after the re-armed resume: idle_resume_at=%d count=%d, want a latch and count 1", at, count)
+	}
+
+	// Another transition while the SAME stretch is still latched: the budget
+	// re-arms again, but the latch survives, so the stretch is not re-poked.
+	if !s.claimPipelineStageTransition(clawID, "validate") {
+		t.Fatal("transition to validate was not claimed")
+	}
+	s.checkAgentIdleResume(time.Now(), clawID, cc)
+	if got := idleResumeMessages(t, db, clawID); got != 1 {
+		t.Fatalf("a stage transition re-poked an already-handled stretch: %d messages", got)
+	}
+	if at2, count := clawIdleResumeState(t, db, clawID); at2 != at || count != 0 {
+		t.Fatalf("after the second transition: idle_resume_at=%d count=%d, want latch %d kept and count 0", at2, count, at)
 	}
 }

--- a/pkg/hub/bridge_error.go
+++ b/pkg/hub/bridge_error.go
@@ -76,7 +76,7 @@ func (s *Server) observeBridgeErrorTurn(cc *clawConn, clawID, errText string, de
 	// threshold needs a SECOND turn, and nothing here guarantees one: with the
 	// plan gate no longer answering, the next turn only exists if the idle
 	// auto-resume fires — which is off when liveness.idle_resume is disabled,
-	// when the claw is ineligible, or once its lifetime resume cap is spent. Tie
+	// when the claw is ineligible, or once its per-work-unit resume cap is spent. Tie
 	// the alarm to that and a claw whose transport is dead can sit silent
 	// forever, which is the failure this whole change exists to end. So: tell
 	// the operator on the first one, stop the loop on the second.

--- a/pkg/hub/bridge_error_test.go
+++ b/pkg/hub/bridge_error_test.go
@@ -418,7 +418,7 @@ func TestPauseAutomaticContinuationLatchesOnce(t *testing.T) {
 // turn, and nothing guarantees one once the plan gate stops answering: the next
 // turn only exists if the idle auto-resume fires, which is off when
 // liveness.idle_resume is disabled, when the claw is ineligible, or once its
-// lifetime resume cap is spent. Tied to that, a dead transport could sit silent
+// per-work-unit resume cap is spent. Tied to that, a dead transport could sit silent
 // forever — the exact failure this change exists to end.
 func TestFirstBridgeErrorNotifiesWithoutPausing(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")

--- a/pkg/hub/claw_retry.go
+++ b/pkg/hub/claw_retry.go
@@ -492,11 +492,25 @@ func (s *Server) resetClawForRetry(tenantID, clawID, checkpointID, bootstrapStat
 	// not the conversation, so the reconnect path must re-brief the agent with
 	// its task context. This UPDATE is the only place that arms the flag — a
 	// normal reconnect/bridge flap must never set it.
+	//
+	// The same UPDATE re-arms the idle auto-resume budget (idle_resume_count):
+	// the successor runs a brand-new session, so whatever the predecessor
+	// spent of its per-work-unit cap (agentIdleResumeMaxAttempts) says nothing
+	// about the successor's behaviour, and carrying it over would hand a fresh
+	// sandbox a spent budget and no idle recovery. It lives in this statement
+	// rather than a second one so the reset is bound to the same status guard
+	// and cannot apply to a claw that was not actually replaced.
+	// idle_resume_at is NOT cleared: it keys on the stretch anchor, and the
+	// successor's first finished turn (the re-brief) moves that anchor past it,
+	// which is when checkAgentIdleResume re-arms the latch itself. Clearing it
+	// here would only ever matter for a successor that never finishes a turn,
+	// and a never-turned connection is exactly the state the resume must not
+	// poke on the strength of a stale latch (see the reconnect tests).
 	res, err := s.db.Exec(`
 		UPDATE claws
 		   SET status='provisioning', bootstrap_ok=0, bootstrap_status=?, bootstrap_diagnostic=?,
 		       provider_id='', ssh_host='', ssh_port=0, ssh_user='', restore_checkpoint_id=?,
-		       rebrief_pending=1
+		       rebrief_pending=1, idle_resume_count=0
 		 WHERE id=? AND tenant_id=? AND status IN ('error','offline')`,
 		bootstrapStatus, bootstrapDiagnostic, checkpointID, clawID, tenantID)
 	if err != nil {

--- a/pkg/hub/claw_retry.go
+++ b/pkg/hub/claw_retry.go
@@ -500,17 +500,27 @@ func (s *Server) resetClawForRetry(tenantID, clawID, checkpointID, bootstrapStat
 	// sandbox a spent budget and no idle recovery. It lives in this statement
 	// rather than a second one so the reset is bound to the same status guard
 	// and cannot apply to a claw that was not actually replaced.
-	// idle_resume_at is NOT cleared: it keys on the stretch anchor, and the
-	// successor's first finished turn (the re-brief) moves that anchor past it,
-	// which is when checkAgentIdleResume re-arms the latch itself. Clearing it
-	// here would only ever matter for a successor that never finishes a turn,
-	// and a never-turned connection is exactly the state the resume must not
-	// poke on the strength of a stale latch (see the reconnect tests).
+	//
+	// idle_resume_at is cleared with it. It is the once-per-stretch dedupe
+	// latch, and unlike a stage transition — where the claw keeps its session
+	// and clearing the latch would let the SAME idle stretch be poked twice —
+	// the successor here is a different session whose stretch anchor is not
+	// comparable to the predecessor's. Worse, it can collide with it:
+	// lastTurnFinishedAt is seeded on reconnect from the last claw message
+	// (server.go), so a successor whose re-brief delivery aborts before any
+	// turn finishes can anchor within agentIdleStretchSlack of a latch the
+	// dead session earned, and checkAgentIdleResume would then read "this
+	// stretch was already handled" on every tick and veto the resume forever —
+	// a zeroed budget that cannot be spent. Clearing costs nothing: the state
+	// this latch is sometimes credited with protecting, a connection whose
+	// in-flight turn is invisible, is protected by agentIdleResumeBlindGrace,
+	// which is an upper bound rather than a permanent veto (see
+	// TestAgentIdleResumeFiresAfterTheBlindWindowElapses).
 	res, err := s.db.Exec(`
 		UPDATE claws
 		   SET status='provisioning', bootstrap_ok=0, bootstrap_status=?, bootstrap_diagnostic=?,
 		       provider_id='', ssh_host='', ssh_port=0, ssh_user='', restore_checkpoint_id=?,
-		       rebrief_pending=1, idle_resume_count=0
+		       rebrief_pending=1, idle_resume_count=0, idle_resume_at=0
 		 WHERE id=? AND tenant_id=? AND status IN ('error','offline')`,
 		bootstrapStatus, bootstrapDiagnostic, checkpointID, clawID, tenantID)
 	if err != nil {

--- a/pkg/hub/claw_retry_test.go
+++ b/pkg/hub/claw_retry_test.go
@@ -212,6 +212,30 @@ func TestResetClawForRetryRaceGuard(t *testing.T) {
 	}
 }
 
+// A replacement sandbox runs a brand-new session, so the predecessor's spent
+// auto-resume budget must not follow it: resetClawForRetry zeroes
+// idle_resume_count in the same guarded UPDATE that arms rebrief_pending.
+// idle_resume_at is left as is — the successor's first finished turn moves the
+// stretch anchor past it and re-arms the latch on its own.
+func TestResetClawForRetryResetsIdleResumeBudget(t *testing.T) {
+	s, db, _ := newClawRetryTestServer(t, "error")
+	const latch = int64(1_700_000_000_000)
+	if _, err := db.Exec(`UPDATE claws SET idle_resume_at=?, idle_resume_count=? WHERE id=?`, latch, agentIdleResumeMaxAttempts, "retry-claw"); err != nil {
+		t.Fatalf("seed idle_resume state: %v", err)
+	}
+	reset, err := s.resetClawForRetry("tenant", "retry-claw", "", "retrying", "")
+	if err != nil || !reset {
+		t.Fatalf("reset: reset=%v err=%v", reset, err)
+	}
+	at, count := clawIdleResumeState(t, db, "retry-claw")
+	if count != 0 {
+		t.Fatalf("resetClawForRetry left idle_resume_count=%d, want 0", count)
+	}
+	if at != latch {
+		t.Fatalf("resetClawForRetry moved idle_resume_at to %d, want %d", at, latch)
+	}
+}
+
 func TestReplaceClawInstanceFailsDanglingAttemptWhenClawChangedState(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	s, db, runID := newClawRetryTestServer(t, "connected")

--- a/pkg/hub/claw_retry_test.go
+++ b/pkg/hub/claw_retry_test.go
@@ -215,8 +215,9 @@ func TestResetClawForRetryRaceGuard(t *testing.T) {
 // A replacement sandbox runs a brand-new session, so the predecessor's spent
 // auto-resume budget must not follow it: resetClawForRetry zeroes
 // idle_resume_count in the same guarded UPDATE that arms rebrief_pending.
-// idle_resume_at is left as is — the successor's first finished turn moves the
-// stretch anchor past it and re-arms the latch on its own.
+// idle_resume_at goes with it: the successor is a different session, and a
+// latch the dead session earned can otherwise veto the freshly zeroed budget
+// forever (see the assertion below).
 func TestResetClawForRetryResetsIdleResumeBudget(t *testing.T) {
 	s, db, _ := newClawRetryTestServer(t, "error")
 	const latch = int64(1_700_000_000_000)

--- a/pkg/hub/claw_retry_test.go
+++ b/pkg/hub/claw_retry_test.go
@@ -231,8 +231,14 @@ func TestResetClawForRetryResetsIdleResumeBudget(t *testing.T) {
 	if count != 0 {
 		t.Fatalf("resetClawForRetry left idle_resume_count=%d, want 0", count)
 	}
-	if at != latch {
-		t.Fatalf("resetClawForRetry moved idle_resume_at to %d, want %d", at, latch)
+	// The latch goes too, and this is the half that is easy to get wrong. The
+	// successor is a different session; on reconnect its lastTurnFinishedAt is
+	// seeded from the last claw message, so its first idle stretch can anchor
+	// within agentIdleStretchSlack of a latch the DEAD session earned. Leave
+	// the latch and checkAgentIdleResume reads "already handled" forever — a
+	// budget that was just zeroed and can never be spent.
+	if at != 0 {
+		t.Fatalf("resetClawForRetry left idle_resume_at=%d, want 0", at)
 	}
 }
 

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -142,10 +142,12 @@ func migrate(db *sql.DB) error {
 	if err := addColumn(db, "claws", "idle_resume_at", `INTEGER NOT NULL DEFAULT 0`); err != nil {
 		return err
 	}
-	// idle_resume_count is the lifetime attempt counter behind the runaway cap
-	// (agentIdleResumeMaxAttempts): a claw that wakes, replies nothing, and
-	// idles again would otherwise be poked forever, since each wake clears the
-	// per-stretch latch.
+	// idle_resume_count is the per-work-unit attempt counter behind the
+	// runaway cap (agentIdleResumeMaxAttempts): a claw that wakes, replies
+	// nothing, and idles again would otherwise be poked forever, since each
+	// wake clears the per-stretch latch. It is zeroed on a won pipeline stage
+	// transition and on sandbox replacement — a lifetime count let pokes spent
+	// harmlessly in one stage leave the claw with no recovery in the next.
 	if err := addColumn(db, "claws", "idle_resume_count", `INTEGER NOT NULL DEFAULT 0`); err != nil {
 		return err
 	}

--- a/pkg/hub/db.go
+++ b/pkg/hub/db.go
@@ -146,8 +146,9 @@ func migrate(db *sql.DB) error {
 	// runaway cap (agentIdleResumeMaxAttempts): a claw that wakes, replies
 	// nothing, and idles again would otherwise be poked forever, since each
 	// wake clears the per-stretch latch. It is zeroed on a won pipeline stage
-	// transition and on sandbox replacement — a lifetime count let pokes spent
-	// harmlessly in one stage leave the claw with no recovery in the next.
+	// transition, on sandbox replacement, and on a lost/re-briefed session — a
+	// lifetime count let pokes spent harmlessly in one stage leave the claw
+	// with no recovery in the next.
 	if err := addColumn(db, "claws", "idle_resume_count", `INTEGER NOT NULL DEFAULT 0`); err != nil {
 		return err
 	}

--- a/pkg/hub/pipeline_state.go
+++ b/pkg/hub/pipeline_state.go
@@ -17,7 +17,18 @@ func (s *Server) getPipelineStage(clawID string) string {
 // claw is not already in that stage. It returns true when the caller won the
 // transition and should run on_enter actions.
 func (s *Server) claimPipelineStageTransition(clawID, stageID string) bool {
-	res, err := s.db.Exec(`UPDATE claws SET pipeline_stage=?, stage_entered_at=? WHERE id=? AND pipeline_stage<>?`, stageID, time.Now().UnixMilli(), clawID, stageID)
+	// A won transition re-arms the idle auto-resume budget: idle_resume_count
+	// is a per-work-unit runaway cap (agentIdleResumeMaxAttempts), and a new
+	// stage is a new unit of work. Counting across stages let ten successful,
+	// harmless pokes in a stage with nothing to do exhaust the cap, leaving the
+	// claw with no recovery at all in the next stage (NEXT-647 sat 8h16m on a
+	// sessions_yield in review_loop because the budget had been spent the day
+	// before). The pipeline_stage<>? guard is what keeps this honest: a
+	// re-entry into the same stage changes no row and so resets nothing.
+	// idle_resume_at is deliberately left alone — it is the once-per-stretch
+	// dedupe latch, not budget, and a stage whose on_enter runs nothing that
+	// finishes a turn would otherwise have the SAME idle stretch poked twice.
+	res, err := s.db.Exec(`UPDATE claws SET pipeline_stage=?, stage_entered_at=?, idle_resume_count=0 WHERE id=? AND pipeline_stage<>?`, stageID, time.Now().UnixMilli(), clawID, stageID)
 	if err != nil {
 		log.Printf("[pipeline] failed to set stage %q for claw %s: %v", stageID, clawID[:8], err)
 		return false

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -8959,6 +8959,26 @@ func (s *Server) enqueueSessionLostResume(clawID, prefix, marker string) {
 	// incident even when the rest of the wording is unchanged.
 	b.WriteString(fmt.Sprintf("\n\n<!-- %s -->", marker))
 	log.Printf("[watchdog] enqueueing %s resume for %s", marker, shortID(clawID))
+	// A lost session is a new unit of work, so it re-arms the idle auto-resume
+	// budget for the same reason resetClawForRetry does: what the previous
+	// session spent of the per-work-unit cap (agentIdleResumeMaxAttempts) says
+	// nothing about how the agent that replaces it behaves, and carrying the
+	// count over hands an amnesiac agent a spent budget and no idle recovery.
+	// This funnel covers both callers that produce one — the process restart
+	// and the session rotation — and it sits after the connected/bootstrap_ok
+	// guard above so a claw that is not actually getting a resume is untouched.
+	//
+	// idle_resume_at goes with it here, unlike the stage transition: the latch
+	// keys on the idle stretch's anchor, and lastTurnFinishedAt is seeded on
+	// reconnect from the last claw message, which can land within
+	// agentIdleStretchSlack of a latch the DEAD session earned. Leaving it
+	// would then read as "this stretch was already handled" on every tick and
+	// veto the resume permanently. Nothing is lost by clearing it: what
+	// protects a connection whose turn state is invisible is
+	// agentIdleResumeBlindGrace, not this latch.
+	if _, err := s.db.Exec(`UPDATE claws SET idle_resume_count=0, idle_resume_at=0 WHERE id=?`, clawID); err != nil {
+		log.Printf("[watchdog] re-arm idle resume budget for %s: %v", shortID(clawID), err)
+	}
 	s.injectHubMessageByID(clawID, b.String())
 }
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -9143,7 +9143,18 @@ func (s *Server) sendNextQueuedMessage(cc *clawConn) {
 		// notice and marks the message delivered, after a successful socket
 		// write, so a failed write re-arms nothing and the notice stays durable
 		// for the next attempt.
-		if _, err := tx.Exec(`UPDATE claws SET pending_session_loss_notice='', idle_resume_count=0, idle_resume_at=0 WHERE id=? AND pending_session_loss_notice=?`, clawID, notice); err != nil {
+		//
+		// Only the count. idle_resume_at is cleared on the two paths where the
+		// connection itself is replaced, because a successor's stretch anchor
+		// can collide with a latch the dead session earned; here the connection
+		// never went away, lastTurnFinishedAt is the same live value, and there
+		// is no such collision to break. Clearing it would instead cause the
+		// duplicate poke the latch exists to prevent: the message carrying this
+		// notice is very often the idle auto-resume prompt itself, so the same
+		// statement would refund the attempt checkAgentIdleResume just latched
+		// AND drop its latch, letting the next tick poke the identical stretch
+		// a second time.
+		if _, err := tx.Exec(`UPDATE claws SET pending_session_loss_notice='', idle_resume_count=0 WHERE id=? AND pending_session_loss_notice=?`, clawID, notice); err != nil {
 			log.Printf("[hub] clear pending session-loss notice for %s: %v", shortID(clawID), err)
 			return
 		}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -9127,7 +9127,23 @@ func (s *Server) sendNextQueuedMessage(cc *clawConn) {
 		return
 	}
 	if notice != "" {
-		if _, err := tx.Exec(`UPDATE claws SET pending_session_loss_notice='' WHERE id=? AND pending_session_loss_notice=?`, clawID, notice); err != nil {
+		// Delivering the notice re-arms the idle auto-resume budget, and this is
+		// the only place it can happen for a loss detected while the claw was
+		// idle. noteSessionLoss takes a different branch there: it must not wake
+		// an idle claw into autonomous work, so it only parks the notice and
+		// returns, never reaching enqueueSessionLostResume where the other
+		// session-loss reset lives. The amnesiac session is real either way —
+		// it just learns about itself here, attached to the next genuine prompt
+		// — and without this it would start its unit of work with the previous
+		// session's spent budget and no idle recovery of its own.
+		//
+		// Resetting on delivery rather than on detection is also what keeps the
+		// idle-claw policy intact: nothing is injected here, a prompt was
+		// already on its way. It rides the same transaction that clears the
+		// notice and marks the message delivered, after a successful socket
+		// write, so a failed write re-arms nothing and the notice stays durable
+		// for the next attempt.
+		if _, err := tx.Exec(`UPDATE claws SET pending_session_loss_notice='', idle_resume_count=0, idle_resume_at=0 WHERE id=? AND pending_session_loss_notice=?`, clawID, notice); err != nil {
 			log.Printf("[hub] clear pending session-loss notice for %s: %v", shortID(clawID), err)
 			return
 		}

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -781,6 +781,62 @@ func TestIdleSessionLossNoticePrefixesNextMessageAndKeepsFirstNotice(t *testing.
 	}
 }
 
+// A session lost while the claw was idle never reaches enqueueSessionLostResume
+// — noteSessionLoss parks a notice instead, so as not to wake an idle claw —
+// and the amnesiac session only learns about itself when that notice rides the
+// next real prompt. That delivery is therefore the only place its idle
+// auto-resume budget can be re-armed; without it the new session starts on the
+// predecessor's spent count and has no idle recovery of its own.
+func TestIdleSessionLossNoticeDeliveryRearmsIdleResumeBudget(t *testing.T) {
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
+	const clawID = "watchdog-idle-session-loss-budget"
+	conn := watchdogClaw(t, s, clawID)
+	cc := watchdogClawConn(t, s, clawID)
+	const latch = int64(1_700_000_000_000)
+	if _, err := db.Exec(`UPDATE claws SET status='connected', bootstrap_ok=1, pipeline_stage='review_loop', idle_resume_at=?, idle_resume_count=? WHERE id=?`,
+		latch, agentIdleResumeMaxAttempts, clawID); err != nil {
+		t.Fatal(err)
+	}
+	cc.mu.Lock()
+	cc.streamingStartedAt = time.Time{}
+	cc.awaitingResponse = false
+	cc.lastTurnFinishedAt = now().Add(-autoResumeRecentTurnWindow - time.Second)
+	cc.mu.Unlock()
+
+	s.noteSessionLoss(cc, clawID, "idle-budget-one", "restart_count")
+
+	// The parking branch itself must not re-arm: no prompt went out, and the
+	// idle-claw policy says nothing wakes it here.
+	if at, count := clawIdleResumeState(t, db, clawID); count != agentIdleResumeMaxAttempts || at != latch {
+		t.Fatalf("parking the notice changed idle_resume state: at=%d count=%d, want %d/%d", at, count, latch, agentIdleResumeMaxAttempts)
+	}
+
+	if _, err := db.Exec(`INSERT INTO messages(id,claw_id,tenant_id,role,content,created_at) VALUES(?,?,?,?,?,?)`,
+		uuid.NewString(), clawID, "test-tenant-id", "user", "continue the task", now()); err != nil {
+		t.Fatal(err)
+	}
+	s.sendNextQueuedMessage(cc)
+	readCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	var delivered types.WSMessage
+	for {
+		if err := wsjson.Read(readCtx, conn, &delivered); err != nil {
+			t.Fatal(err)
+		}
+		if delivered.Type == "message" {
+			break
+		}
+	}
+
+	at, count := clawIdleResumeState(t, db, clawID)
+	if count != 0 {
+		t.Fatalf("notice delivery left idle_resume_count=%d, want 0", count)
+	}
+	if at != 0 {
+		t.Fatalf("notice delivery left idle_resume_at=%d, want 0", at)
+	}
+}
+
 func TestSessionPreservedEnqueuesContinuationAndResetsBridgeErrorStreak(t *testing.T) {
 	s, db := NewTestServerWithConfig(t, &types.HubConfig{ClawToken: "claw-token"}, "", "", "")
 	const clawID = "watchdog-session-preserved"

--- a/pkg/hub/watchdog_enforcement_test.go
+++ b/pkg/hub/watchdog_enforcement_test.go
@@ -832,8 +832,12 @@ func TestIdleSessionLossNoticeDeliveryRearmsIdleResumeBudget(t *testing.T) {
 	if count != 0 {
 		t.Fatalf("notice delivery left idle_resume_count=%d, want 0", count)
 	}
-	if at != 0 {
-		t.Fatalf("notice delivery left idle_resume_at=%d, want 0", at)
+	// The latch stays. This path keeps the same connection, so there is no dead
+	// session's anchor to collide with — and the message carrying the notice is
+	// often the idle auto-resume prompt itself, so clearing the latch here would
+	// refund that attempt and let the next tick poke the same stretch again.
+	if at != latch {
+		t.Fatalf("notice delivery moved idle_resume_at to %d, want %d", at, latch)
 	}
 }
 


### PR DESCRIPTION
## Problem

Claw NEXT-647 sat **8h16min in total silence** in the `review_loop` stage, ended only by a human message. It had called `sessions_yield` waiting on spawned reviewers — an open-ended wait the hub has no wake edge for.

The safety net for exactly this is the idle auto-resume, whose prompt says *"If you are blocked waiting on background or spawned work that has not reported back, stop waiting for it and follow your task's degradation path"*. It never fired: `claws.idle_resume_count` was at the `agentIdleResumeMaxAttempts` ceiling of 10.

Those 10 had been spent **the day before**, 8 of them in 42 minutes, in a phase where the claw was legitimately out of work and answered every poke with "nothing to pick up, NO_REPLY". The mechanism working correctly consumed its own budget until it was permanently gone. In between came a sandbox replacement and a stage transition — two work-unit boundaries that re-armed nothing.

The documented primary backstop, `no_progress_paused`, never latched (`similarTurnOutcomes` resets its observation window when the reply text varies, which it did). So the lifetime cap was acting alone.

## Change

`idle_resume_count` becomes a **per-work-unit** ceiling instead of a lifetime one, re-armed wherever the unit of work changes:

- `claimPipelineStageTransition` — the only writer of `pipeline_stage`; its `WHERE pipeline_stage<>?` guard means a re-entry into the same stage resets nothing.
- `resetClawForRetry` — sandbox replacement, folded into the `UPDATE` that already arms `rebrief_pending=1` so the reset inherits the same status guard.
- `enqueueSessionLostResume` — the funnel behind both the process restart and the session rotation, placed after the connected/`bootstrap_ok` guard so an ineligible claw is untouched.

`idle_resume_at` (the once-per-stretch dedupe latch) is treated separately from the budget: **kept** on a stage transition, where the session is the same one and clearing it would poke a single idle stretch twice; **cleared** on both session-replacement paths, where a successor whose re-brief delivery aborts can otherwise anchor within `agentIdleStretchSlack` of a latch the dead session earned and read "already handled" forever — a zeroed budget that can never be spent.

## Verification

- `go build ./...`, `go vet ./pkg/hub/`, `gofmt` clean.
- New tests fail with the production SQL reverted and pass with it.
- Full `go test ./pkg/hub/` has 3 failures, all pre-existing on `origin/main` (confirmed on a detached worktree at `origin/main`): the `[DONE]`-signal tests that reach the real GitHub API from a host with hub config present.

## Still uncovered

- Nothing structurally prevents `sessions_yield`; the ban lives in the agent contract in `next_tooling` (see the companion PR).
- Once 10 pokes are spent **inside** the stuck stage, the claw goes terminally silent again — only `no_progress_paused` remains, and it is unreliable for the reason above. Worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)