### PR TITLE
feat(hub): add cron schedule triggers for workflow v2

### DIFF
--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -203,16 +203,23 @@ func runWorkflowShow(workspace, name string) error {
 func workflowTriggerCmd() *cobra.Command {
 	var workspace string
 	var inputs []string
+	var cron bool
 	cmd := &cobra.Command{
 		Use:   "trigger <name>",
 		Short: "Manually trigger a workflow with inputs",
-		Args:  cobra.ExactArgs(1),
+		Long: `Manually trigger a workflow.
+
+By default the generic workflow trigger endpoint is used. For cron-scheduled
+workflows, use --cron to trigger via the cron endpoint; this works even when
+the workflow does not have manual_trigger: true.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runWorkflowTrigger(workspace, args[0], inputs)
+			return runWorkflowTrigger(workspace, args[0], inputs, cron)
 		},
 	}
 	cmd.Flags().StringVar(&workspace, "workspace", "default", "workspace name")
 	cmd.Flags().StringArrayVar(&inputs, "input", nil, "input values as key=value (can be repeated)")
+	cmd.Flags().BoolVar(&cron, "cron", false, "trigger through the cron endpoint (for cron-scheduled workflows)")
 	return cmd
 }
 
@@ -233,17 +240,24 @@ func workflowPushCmd() *cobra.Command {
 func workflowRunsCmd() *cobra.Command {
 	var workspace string
 	var limit int
+	var cron bool
 	cmd := &cobra.Command{
 		Use:   "runs <name>",
 		Short: "Show recent runs for a workflow",
-		Long:  "List recent execution history for a workflow, including cron and manual triggers.",
-		Args:  cobra.ExactArgs(1),
+		Long: `List recent execution history for a workflow.
+
+For v1 workflows the default view uses the cron run history endpoint. For v2
+workflows the default view uses the v2 durable state machine history. Use
+--cron to force the cron history view, which includes skipped cron ticks and
+works for both v1 and v2 workflows.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runWorkflowRuns(workspace, args[0], limit)
+			return runWorkflowRuns(workspace, args[0], limit, cron)
 		},
 	}
 	cmd.Flags().StringVar(&workspace, "workspace", "default", "workspace name")
 	cmd.Flags().IntVar(&limit, "limit", 50, "maximum number of runs to show")
+	cmd.Flags().BoolVar(&cron, "cron", false, "use the cron run history endpoint (includes skipped ticks)")
 	return cmd
 }
 
@@ -404,7 +418,10 @@ func readWorkflowFiles(paths []string) ([]*types.WorkflowConfig, error) {
 	return workflows, nil
 }
 
-func runWorkflowTrigger(workspace, name string, inputs []string) error {
+func runWorkflowTrigger(workspace, name string, inputs []string, cron bool) error {
+	if cron {
+		return runWorkflowCronTrigger(workspace, name)
+	}
 	hubURL, clawToken, err := resolveHubConn()
 	if err != nil {
 		return err
@@ -442,12 +459,47 @@ func runWorkflowTrigger(workspace, name string, inputs []string) error {
 	return nil
 }
 
-func runWorkflowRuns(workspace, name string, limit int) error {
+func runWorkflowCronTrigger(workspace, name string) error {
+	hubURL, clawToken, err := resolveHubConn()
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/api/workspaces/%s/workflows/%s/cron/trigger", url.PathEscape(workspace), url.PathEscape(name))
+	req, _ := http.NewRequest(http.MethodPost, hubURL+path, nil)
+	req.Header.Set("Authorization", "Bearer "+clawToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("trigger workflow cron run failed: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("hub returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var result struct {
+		Status   string `json:"status"`
+		Workflow string `json:"workflow"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+
+	fmt.Printf("Triggered cron workflow %q in workspace %q (%s)\n", name, workspace, result.Status)
+	return nil
+}
+
+func runWorkflowRuns(workspace, name string, limit int, cron bool) error {
 	if limit <= 0 {
 		limit = 50
 	}
 	if limit > 200 {
 		limit = 200
+	}
+	if cron {
+		return runWorkflowCronRuns(workspace, name, limit)
 	}
 
 	view, err := fetchWorkflowView(workspace, name)
@@ -457,10 +509,10 @@ func runWorkflowRuns(workspace, name string, limit int) error {
 	if v2.IsV2(view.SchemaVersion) {
 		return runWorkflowV2Runs(workspace, name, limit)
 	}
-	return runWorkflowV1Runs(workspace, name, limit)
+	return runWorkflowCronRuns(workspace, name, limit)
 }
 
-func runWorkflowV1Runs(workspace, name string, limit int) error {
+func runWorkflowCronRuns(workspace, name string, limit int) error {
 	hubURL, clawToken, err := resolveHubConn()
 	if err != nil {
 		return err

--- a/cmd/workflow_test.go
+++ b/cmd/workflow_test.go
@@ -400,7 +400,7 @@ func TestRunWorkflowRunsListsRunsAndShortAgentID(t *testing.T) {
 	t.Setenv("ELASTICCLAW_CLAW_TOKEN", "test-token")
 
 	out, err := captureStdout(func() error {
-		return runWorkflowRuns("default", "dependency-update", 10)
+		return runWorkflowRuns("default", "dependency-update", 10, false)
 	})
 	if err != nil {
 		t.Fatalf("runWorkflowRuns returned error: %v", err)
@@ -452,7 +452,7 @@ func TestRunWorkflowV2RunsListsAttempts(t *testing.T) {
 	t.Setenv("ELASTICCLAW_CLAW_TOKEN", "test-token")
 
 	out, err := captureStdout(func() error {
-		return runWorkflowRuns("default", "delivery", 10)
+		return runWorkflowRuns("default", "delivery", 10, false)
 	})
 	if err != nil {
 		t.Fatalf("runWorkflowRuns returned error: %v", err)
@@ -498,6 +498,86 @@ func TestRunWorkflowV2LogsFetchesAttemptLogs(t *testing.T) {
 		t.Fatalf("runWorkflowLogs returned error: %v", err)
 	}
 	for _, want := range []string{"Agent logs for run run-v2-1", "[bash]", "cmd: ls -la"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunWorkflowCronTriggerUsesCronEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/workspaces/prod/workflows/nightly/cron/trigger" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "triggered", "workflow": "prod/nightly"})
+	}))
+	defer server.Close()
+
+	t.Setenv("ELASTICCLAW_HUB_URL", server.URL)
+	t.Setenv("ELASTICCLAW_CLAW_TOKEN", "test-token")
+
+	out, err := captureStdout(func() error {
+		return runWorkflowTrigger("prod", "nightly", nil, true)
+	})
+	if err != nil {
+		t.Fatalf("runWorkflowTrigger returned error: %v", err)
+	}
+	for _, want := range []string{"Triggered cron workflow", "nightly", "prod", "triggered"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunWorkflowV2CronRunsUsesCronEndpoint(t *testing.T) {
+	started := time.Date(2026, 7, 24, 9, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/workspaces/default/workflows/delivery":
+			_ = json.NewEncoder(w).Encode(workflowCLIView{
+				Name:          "delivery",
+				WorkspaceName: "default",
+				SchemaVersion: "2",
+			})
+		case "/api/workspaces/default/workflows/delivery/cron/runs":
+			if r.URL.Query().Get("limit") != "10" {
+				http.Error(w, "unexpected limit", http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"runs": []types.WorkflowRun{{
+					ID:            "cron-run-1",
+					WorkflowName:  "delivery",
+					WorkspaceName: "default",
+					TriggerType:   "cron",
+					Status:        "skipped",
+					ClawID:        "",
+					StartedAt:     &started,
+					CreatedAt:     started,
+				}},
+				"count": 1,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("ELASTICCLAW_HUB_URL", server.URL)
+	t.Setenv("ELASTICCLAW_CLAW_TOKEN", "test-token")
+
+	out, err := captureStdout(func() error {
+		return runWorkflowRuns("default", "delivery", 10, true)
+	})
+	if err != nil {
+		t.Fatalf("runWorkflowRuns returned error: %v", err)
+	}
+	for _, want := range []string{"RUN ID", "cron-run-1", "skipped", "cron", "Showing 1 run"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("output missing %q:\n%s", want, out)
 		}

--- a/examples/workflows/nightly-check-v2.yaml
+++ b/examples/workflows/nightly-check-v2.yaml
@@ -1,0 +1,57 @@
+# Example workflow v2 triggered on a cron schedule.
+# This requires a v2 workspace (elasticclaw-config.yaml) with an execution
+# provider that supports the `execute_command` capability, e.g. daytona or docker.
+
+schema_version: 2
+name: nightly-check
+enabled: true
+
+initial_state: run
+
+# Run at 09:00 every Monday, America/Chicago time. If a previous run is still
+# active, skip the new tick and record a skipped run, matching v1 cron behavior.
+# This workflow is also manually triggerable via the cron trigger endpoint without
+# needing `manual_trigger: true`.
+trigger:
+  cron:
+    schedule: "0 9 * * 1"
+    timezone: "America/Chicago"
+    overlap_policy: skip
+
+states:
+  run:
+    description: Run the nightly maintenance check.
+    phase: build
+    on_enter:
+      effects:
+        - exec.run:
+            command: "make nightly-check"
+            timeout: "10m"
+
+  done:
+    description: Nightly check finished.
+    phase: done
+    terminal: true
+
+transitions:
+  check_succeeded:
+    from: run
+    on: exec.run.completed
+    when:
+      exec.last_run.succeeded:
+        equals: true
+    to: done
+
+  check_failed:
+    from: run
+    on: exec.run.completed
+    when:
+      exec.last_run.succeeded:
+        equals: false
+    to: done
+
+commands:
+  cancel:
+    from: run
+    to: done
+    require_reason: true

--- a/pkg/hub/cron_api.go
+++ b/pkg/hub/cron_api.go
@@ -40,7 +40,7 @@ func (s *Server) handleCronWorkflowTrigger(w http.ResponseWriter, r *http.Reques
 			http.Error(w, "Cron scheduler not available", http.StatusServiceUnavailable)
 			return
 		}
-		key, err = s.cronSchedulerV2.manualTrigger(workspace, workflow)
+		key, err = s.cronSchedulerV2.manualTrigger(workspace, workflow, tenantFromCtx(r))
 	} else {
 		if s.cronScheduler == nil {
 			http.Error(w, "Cron scheduler not available", http.StatusServiceUnavailable)
@@ -103,7 +103,7 @@ func (s *Server) handleCronWorkflowRuns(w http.ResponseWriter, r *http.Request) 
 		runs = append(runs, v1Runs...)
 	}
 	if s.cronSchedulerV2 != nil {
-		v2Runs, err := s.cronSchedulerV2.getRunHistory(workspace, workflow, limit)
+		v2Runs, err := s.cronSchedulerV2.getRunHistory(workspace, workflow, tenantFromCtx(r), limit)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Failed to get run history: %v", err), http.StatusInternalServerError)
 			return
@@ -152,7 +152,7 @@ func (s *Server) handleCronWorkflowRun(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if run == nil && s.cronSchedulerV2 != nil {
-		run, err = s.cronSchedulerV2.getRunByID(workspace, workflow, runID)
+		run, err = s.cronSchedulerV2.getRunByID(workspace, workflow, runID, tenantFromCtx(r))
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Failed to get run: %v", err), http.StatusInternalServerError)
 			return

--- a/pkg/hub/cron_api.go
+++ b/pkg/hub/cron_api.go
@@ -4,12 +4,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
 // handleCronWorkflowTrigger handles POST /api/workspaces/{workspace}/workflows/{workflow}/cron/trigger
-// Manually triggers a cron workflow run.
+// Manually triggers a cron workflow run. It dispatches to the v1 or v2 scheduler
+// depending on the workflow's schema version, matching v1 behavior where any
+// enabled cron workflow is manually triggerable.
 func (s *Server) handleCronWorkflowTrigger(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -19,12 +24,30 @@ func (s *Server) handleCronWorkflowTrigger(w http.ResponseWriter, r *http.Reques
 	workspace := r.PathValue("workspace")
 	workflow := r.PathValue("workflow")
 
-	if s.cronScheduler == nil {
-		http.Error(w, "Cron scheduler not available", http.StatusServiceUnavailable)
+	isV2, err := s.cronWorkflowIsV2(workspace, workflow)
+	if err != nil {
+		if _, ok := err.(*cronTriggerNotFoundError); ok {
+			http.Error(w, err.Error(), http.StatusNotFound)
+		} else {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
 		return
 	}
 
-	key, err := s.cronScheduler.manualTrigger(workspace, workflow)
+	var key string
+	if isV2 {
+		if s.cronSchedulerV2 == nil {
+			http.Error(w, "Cron scheduler not available", http.StatusServiceUnavailable)
+			return
+		}
+		key, err = s.cronSchedulerV2.manualTrigger(workspace, workflow)
+	} else {
+		if s.cronScheduler == nil {
+			http.Error(w, "Cron scheduler not available", http.StatusServiceUnavailable)
+			return
+		}
+		key, err = s.cronScheduler.manualTrigger(workspace, workflow)
+	}
 	if err != nil {
 		if _, ok := err.(*cronTriggerNotFoundError); ok {
 			http.Error(w, err.Error(), http.StatusNotFound)
@@ -46,7 +69,8 @@ func (s *Server) handleCronWorkflowTrigger(w http.ResponseWriter, r *http.Reques
 }
 
 // handleCronWorkflowRuns handles GET /api/workspaces/{workspace}/workflows/{workflow}/cron/runs
-// Returns the run history for a cron workflow.
+// Returns the run history for a cron workflow. Queries both v1 and v2 history
+// so runs are returned even if the workspace configuration has been removed.
 func (s *Server) handleCronWorkflowRuns(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -56,7 +80,7 @@ func (s *Server) handleCronWorkflowRuns(w http.ResponseWriter, r *http.Request) 
 	workspace := r.PathValue("workspace")
 	workflow := r.PathValue("workflow")
 
-	if s.cronScheduler == nil {
+	if s.cronScheduler == nil && s.cronSchedulerV2 == nil {
 		http.Error(w, "Cron scheduler not available", http.StatusServiceUnavailable)
 		return
 	}
@@ -69,10 +93,29 @@ func (s *Server) handleCronWorkflowRuns(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	runs, err := s.cronScheduler.getRunHistory(workspace, workflow, limit)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to get run history: %v", err), http.StatusInternalServerError)
-		return
+	var runs []types.WorkflowRun
+	if s.cronScheduler != nil {
+		v1Runs, err := s.cronScheduler.getRunHistory(workspace, workflow, limit)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Failed to get run history: %v", err), http.StatusInternalServerError)
+			return
+		}
+		runs = append(runs, v1Runs...)
+	}
+	if s.cronSchedulerV2 != nil {
+		v2Runs, err := s.cronSchedulerV2.getRunHistory(workspace, workflow, limit)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Failed to get run history: %v", err), http.StatusInternalServerError)
+			return
+		}
+		runs = append(runs, v2Runs...)
+	}
+
+	sort.Slice(runs, func(i, j int) bool {
+		return runs[i].CreatedAt.After(runs[j].CreatedAt)
+	})
+	if len(runs) > limit {
+		runs = runs[:limit]
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -83,7 +126,7 @@ func (s *Server) handleCronWorkflowRuns(w http.ResponseWriter, r *http.Request) 
 }
 
 // handleCronWorkflowRun handles GET /api/workspaces/{workspace}/workflows/{workflow}/cron/runs/{runId}
-// Returns a single workflow run by ID.
+// Returns a single workflow run by ID. Queries both v1 and v2 history.
 func (s *Server) handleCronWorkflowRun(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -94,15 +137,26 @@ func (s *Server) handleCronWorkflowRun(w http.ResponseWriter, r *http.Request) {
 	workflow := r.PathValue("workflow")
 	runID := r.PathValue("runId")
 
-	if s.cronScheduler == nil {
+	if s.cronScheduler == nil && s.cronSchedulerV2 == nil {
 		http.Error(w, "Cron scheduler not available", http.StatusServiceUnavailable)
 		return
 	}
 
-	run, err := s.cronScheduler.getRunByID(workspace, workflow, runID)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to get run: %v", err), http.StatusInternalServerError)
-		return
+	var run *types.WorkflowRun
+	var err error
+	if s.cronScheduler != nil {
+		run, err = s.cronScheduler.getRunByID(workspace, workflow, runID)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Failed to get run: %v", err), http.StatusInternalServerError)
+			return
+		}
+	}
+	if run == nil && s.cronSchedulerV2 != nil {
+		run, err = s.cronSchedulerV2.getRunByID(workspace, workflow, runID)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Failed to get run: %v", err), http.StatusInternalServerError)
+			return
+		}
 	}
 	if run == nil {
 		http.Error(w, "Run not found", http.StatusNotFound)
@@ -114,7 +168,7 @@ func (s *Server) handleCronWorkflowRun(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleCronWorkflowNextRun handles GET /api/workspaces/{workspace}/workflows/{workflow}/cron/next
-// Returns the next scheduled run time for a cron workflow.
+// Returns the next scheduled run time for a cron workflow. Dispatches to v1 or v2 scheduler.
 func (s *Server) handleCronWorkflowNextRun(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -124,12 +178,30 @@ func (s *Server) handleCronWorkflowNextRun(w http.ResponseWriter, r *http.Reques
 	workspace := r.PathValue("workspace")
 	workflow := r.PathValue("workflow")
 
-	if s.cronScheduler == nil {
-		http.Error(w, "Cron scheduler not available", http.StatusServiceUnavailable)
+	isV2, err := s.cronWorkflowIsV2(workspace, workflow)
+	if err != nil {
+		if _, ok := err.(*cronTriggerNotFoundError); ok {
+			http.Error(w, "Workflow not found or not cron-triggered", http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	nextRuns := s.cronScheduler.getNextRuns()
+	var nextRuns map[string]time.Time
+	if isV2 {
+		if s.cronSchedulerV2 == nil {
+			http.Error(w, "Cron scheduler not available", http.StatusServiceUnavailable)
+			return
+		}
+		nextRuns = s.cronSchedulerV2.getNextRuns()
+	} else {
+		if s.cronScheduler == nil {
+			http.Error(w, "Cron scheduler not available", http.StatusServiceUnavailable)
+			return
+		}
+		nextRuns = s.cronScheduler.getNextRuns()
+	}
 	key := workspace + "/" + workflow
 
 	nextRun, ok := nextRuns[key]
@@ -143,4 +215,26 @@ func (s *Server) handleCronWorkflowNextRun(w http.ResponseWriter, r *http.Reques
 		"workflow": key,
 		"next_run": nextRun.Format(time.RFC3339),
 	})
+}
+
+// cronWorkflowIsV2 returns true if the named workflow exists and is a v2
+// document. It is used by the cron endpoints to dispatch to the correct
+// scheduler. A non-existent workflow is reported as a *cronTriggerNotFoundError.
+func (s *Server) cronWorkflowIsV2(workspaceName, workflowName string) (bool, error) {
+	workspaces, err := s.loadAllWorkspaces()
+	if err != nil {
+		return false, err
+	}
+	for _, ws := range workspaces {
+		if ws.Name != workspaceName {
+			continue
+		}
+		for _, wf := range ws.Workflows {
+			if wf == nil || wf.Name != workflowName {
+				continue
+			}
+			return isWorkflowV2(wf), nil
+		}
+	}
+	return false, &cronTriggerNotFoundError{msg: fmt.Sprintf("workflow %s/%s not found", workspaceName, workflowName)}
 }

--- a/pkg/hub/cron_scheduler_test.go
+++ b/pkg/hub/cron_scheduler_test.go
@@ -565,11 +565,6 @@ func TestCronSchedulerV2ReloadRefreshesJobWorkflowSnapshot(t *testing.T) {
 	if !ok {
 		t.Fatal("engineering/delivery not scheduled")
 	}
-	job, ok := s.cronSchedulerV2.cron.Entry(entryID).Job.(*cronJobV2)
-	if !ok {
-		t.Fatalf("scheduled job is not a cronJobV2: %T", s.cronSchedulerV2.cron.Entry(entryID).Job)
-	}
-	firstTimeout := job.workflow.trigger.Timeout
 
 	updatedYAML := strings.ReplaceAll(cronWorkflowV2YAML, `schedule: "0 9 * * *"`, "schedule: \"0 9 * * *\"\n    timeout: \"30m\"")
 	SaveWorkspaceForTest(t, &types.WorkspaceConfig{
@@ -583,14 +578,23 @@ func TestCronSchedulerV2ReloadRefreshesJobWorkflowSnapshot(t *testing.T) {
 		t.Fatalf("reload v2 workflows again: %v", err)
 	}
 
+	newEntryID, ok := s.cronSchedulerV2.entries["engineering/delivery"]
+	if !ok {
+		t.Fatal("engineering/delivery not scheduled after reload")
+	}
+	// Replacing the entry avoids mutating the live job and removes the old entry.
+	if newEntryID == entryID {
+		t.Fatal("cron entry was not replaced after reload")
+	}
+	job, ok := s.cronSchedulerV2.cron.Entry(newEntryID).Job.(*cronJobV2)
+	if !ok {
+		t.Fatalf("scheduled job is not a cronJobV2: %T", s.cronSchedulerV2.cron.Entry(newEntryID).Job)
+	}
 	if job.workflow.trigger.Timeout != "30m" {
-		t.Fatalf("cron job still holds stale workflow snapshot: timeout=%q, want 30m", job.workflow.trigger.Timeout)
+		t.Fatalf("cron job holds stale workflow snapshot: timeout=%q, want 30m", job.workflow.trigger.Timeout)
 	}
 	if s.cronSchedulerV2.workflows["engineering/delivery"].trigger.Timeout != "30m" {
 		t.Fatalf("workflow map not refreshed: timeout=%q, want 30m", s.cronSchedulerV2.workflows["engineering/delivery"].trigger.Timeout)
-	}
-	if firstTimeout == job.workflow.trigger.Timeout {
-		t.Fatal("timeout did not change after reload")
 	}
 }
 

--- a/pkg/hub/cron_scheduler_test.go
+++ b/pkg/hub/cron_scheduler_test.go
@@ -582,19 +582,41 @@ func TestCronSchedulerV2ReloadRefreshesJobWorkflowSnapshot(t *testing.T) {
 	if !ok {
 		t.Fatal("engineering/delivery not scheduled after reload")
 	}
-	// Replacing the entry avoids mutating the live job and removes the old entry.
-	if newEntryID == entryID {
-		t.Fatal("cron entry was not replaced after reload")
+	// The schedule/timezone are unchanged, so the entry must be preserved to
+	// avoid missing ticks or double-scheduling parallel runs.
+	if newEntryID != entryID {
+		t.Fatal("cron entry was replaced even though schedule/timezone are unchanged")
 	}
 	job, ok := s.cronSchedulerV2.cron.Entry(newEntryID).Job.(*cronJobV2)
 	if !ok {
 		t.Fatalf("scheduled job is not a cronJobV2: %T", s.cronSchedulerV2.cron.Entry(newEntryID).Job)
 	}
-	if job.workflow.trigger.Timeout != "30m" {
-		t.Fatalf("cron job holds stale workflow snapshot: timeout=%q, want 30m", job.workflow.trigger.Timeout)
+	if job.workflowSnapshot().trigger.Timeout != "30m" {
+		t.Fatalf("cron job holds stale workflow snapshot: timeout=%q, want 30m", job.workflowSnapshot().trigger.Timeout)
 	}
 	if s.cronSchedulerV2.workflows["engineering/delivery"].trigger.Timeout != "30m" {
 		t.Fatalf("workflow map not refreshed: timeout=%q, want 30m", s.cronSchedulerV2.workflows["engineering/delivery"].trigger.Timeout)
+	}
+
+	// A schedule change should replace the entry.
+	updatedYAMLSchedule := strings.ReplaceAll(cronWorkflowV2YAML, `schedule: "0 9 * * *"`, "schedule: \"0 10 * * *\"")
+	SaveWorkspaceForTest(t, &types.WorkspaceConfig{
+		Name: "engineering",
+		Files: map[string]string{
+			"elasticclaw-config.yaml": cronWorkspaceV2YAML,
+		},
+	}, []*types.WorkflowConfig{{Name: "delivery", RawConfig: updatedYAMLSchedule}})
+
+	if err := s.cronSchedulerV2.reloadWorkflows(); err != nil {
+		t.Fatalf("reload v2 workflows with schedule change: %v", err)
+	}
+
+	scheduleChangedID, ok := s.cronSchedulerV2.entries["engineering/delivery"]
+	if !ok {
+		t.Fatal("engineering/delivery not scheduled after schedule change")
+	}
+	if scheduleChangedID == entryID {
+		t.Fatal("cron entry was not replaced after schedule change")
 	}
 }
 

--- a/pkg/hub/cron_scheduler_test.go
+++ b/pkg/hub/cron_scheduler_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -511,6 +512,85 @@ func TestCronSchedulerV2SkipOverlap(t *testing.T) {
 	}
 	if skipped != 1 {
 		t.Fatalf("expected 1 skipped cron run, got %d", skipped)
+	}
+}
+
+func TestCronSchedulerV2TenantResolvedFromWorkspaceAssociation(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token: "test-token",
+	}, "", "", "")
+	if _, err := db.Exec(`INSERT INTO tenants(id,name,token,claw_token,created_at) VALUES('alpha','Alpha','alpha-token','alpha-claw',?)`, now()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO tenants(id,name,token,claw_token,created_at) VALUES('beta','Beta','beta-token','beta-claw',?)`, now()); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a manual trigger/workspace association for engineering under tenant beta.
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,provider,status,created_at) VALUES(?,?,?,?,?,?,?)`,
+		"claw-eng", "beta", "eng", "engineering", "noop", "deleted", now()); err != nil {
+		t.Fatal(err)
+	}
+
+	s.cronSchedulerV2 = newCronSchedulerV2(s)
+	got, err := s.cronSchedulerV2.tenantIDForWorkspace("engineering")
+	if err != nil {
+		t.Fatalf("tenantIDForWorkspace: %v", err)
+	}
+	if got != "beta" {
+		t.Fatalf("tenant = %q, want beta", got)
+	}
+}
+
+func TestCronSchedulerV2ReloadRefreshesJobWorkflowSnapshot(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+
+	SaveWorkspaceForTest(t, &types.WorkspaceConfig{
+		Name: "engineering",
+		Files: map[string]string{
+			"elasticclaw-config.yaml": cronWorkspaceV2YAML,
+		},
+	}, []*types.WorkflowConfig{{Name: "delivery", RawConfig: cronWorkflowV2YAML}})
+
+	s.cronSchedulerV2 = newCronSchedulerV2(s)
+	s.cronSchedulerV2.cron = cron.New(cron.WithSeconds())
+	if err := s.cronSchedulerV2.reloadWorkflows(); err != nil {
+		t.Fatalf("reload v2 workflows: %v", err)
+	}
+
+	entryID, ok := s.cronSchedulerV2.entries["engineering/delivery"]
+	if !ok {
+		t.Fatal("engineering/delivery not scheduled")
+	}
+	job, ok := s.cronSchedulerV2.cron.Entry(entryID).Job.(*cronJobV2)
+	if !ok {
+		t.Fatalf("scheduled job is not a cronJobV2: %T", s.cronSchedulerV2.cron.Entry(entryID).Job)
+	}
+	firstTimeout := job.workflow.trigger.Timeout
+
+	updatedYAML := strings.ReplaceAll(cronWorkflowV2YAML, `schedule: "0 9 * * *"`, "schedule: \"0 9 * * *\"\n    timeout: \"30m\"")
+	SaveWorkspaceForTest(t, &types.WorkspaceConfig{
+		Name: "engineering",
+		Files: map[string]string{
+			"elasticclaw-config.yaml": cronWorkspaceV2YAML,
+		},
+	}, []*types.WorkflowConfig{{Name: "delivery", RawConfig: updatedYAML}})
+
+	if err := s.cronSchedulerV2.reloadWorkflows(); err != nil {
+		t.Fatalf("reload v2 workflows again: %v", err)
+	}
+
+	if job.workflow.trigger.Timeout != "30m" {
+		t.Fatalf("cron job still holds stale workflow snapshot: timeout=%q, want 30m", job.workflow.trigger.Timeout)
+	}
+	if s.cronSchedulerV2.workflows["engineering/delivery"].trigger.Timeout != "30m" {
+		t.Fatalf("workflow map not refreshed: timeout=%q, want 30m", s.cronSchedulerV2.workflows["engineering/delivery"].trigger.Timeout)
+	}
+	if firstTimeout == job.workflow.trigger.Timeout {
+		t.Fatal("timeout did not change after reload")
 	}
 }
 

--- a/pkg/hub/cron_scheduler_test.go
+++ b/pkg/hub/cron_scheduler_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
+	v2types "github.com/elasticclaw/elasticclaw/pkg/types/v2"
 	"github.com/robfig/cron/v3"
 )
 
@@ -322,6 +324,194 @@ func mustLoadLocation(name string) *time.Location {
 		panic(err)
 	}
 	return loc
+}
+
+const cronWorkspaceV2YAML = `
+schema_version: 2
+name: engineering
+execution:
+  provider: noop
+`
+
+const cronWorkflowV2YAML = `
+schema_version: 2
+name: delivery
+enabled: true
+initial_state: s
+states:
+  s:
+    phase: build
+  done:
+    phase: done
+    terminal: true
+trigger:
+  cron:
+    schedule: "0 9 * * *"
+`
+
+const cronWorkflowV2SkipYAML = `
+schema_version: 2
+name: delivery
+enabled: true
+initial_state: s
+states:
+  s:
+    phase: build
+  done:
+    phase: done
+    terminal: true
+trigger:
+  cron:
+    schedule: "0 9 * * *"
+    overlap_policy: skip
+`
+
+func TestCronSchedulerV2StartLoadsWorkflow(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	s, _ := NewTestServerWithConfig(t, &types.HubConfig{Token: "test-token"}, "", "", "")
+
+	SaveWorkspaceForTest(t, &types.WorkspaceConfig{
+		Name: "engineering",
+		Files: map[string]string{
+			"elasticclaw-config.yaml": cronWorkspaceV2YAML,
+		},
+	}, []*types.WorkflowConfig{{Name: "delivery", RawConfig: cronWorkflowV2YAML}})
+
+	s.cronSchedulerV2 = newCronSchedulerV2(s)
+	s.cronSchedulerV2.cron = cron.New(cron.WithSeconds())
+	if err := s.cronSchedulerV2.reloadWorkflows(); err != nil {
+		t.Fatalf("reload v2 workflows: %v", err)
+	}
+
+	next := s.cronSchedulerV2.getNextRuns()
+	if _, ok := next["engineering/delivery"]; !ok {
+		t.Fatalf("expected engineering/delivery scheduled, got %v", next)
+	}
+}
+
+func TestCronSchedulerV2ManualTriggerAndHistory(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token: "test-token", ClawToken: "claw-token",
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}},
+	}, "", "", "")
+
+	SaveWorkspaceForTest(t, &types.WorkspaceConfig{
+		Name: "engineering",
+		Files: map[string]string{
+			"elasticclaw-config.yaml": cronWorkspaceV2YAML,
+		},
+	}, []*types.WorkflowConfig{{Name: "delivery", RawConfig: cronWorkflowV2YAML}})
+
+	s.cronSchedulerV2 = newCronSchedulerV2(s)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces/engineering/workflows/delivery/cron/trigger", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("trigger status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	var triggered map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &triggered); err != nil {
+		t.Fatalf("decode trigger: %v", err)
+	}
+	if triggered["workflow"] != "engineering/delivery" {
+		t.Fatalf("unexpected trigger response: %#v", triggered)
+	}
+
+	var cronStatus, v2RunID string
+	if err := db.QueryRow(`SELECT status, v2_run_id FROM workflow_v2_cron_runs WHERE workspace_name=? AND workflow_name=?`,
+		"engineering", "delivery").Scan(&cronStatus, &v2RunID); err != nil {
+		t.Fatalf("lookup cron history: %v", err)
+	}
+	if cronStatus != "running" {
+		t.Fatalf("cron history status = %q, want running", cronStatus)
+	}
+	if v2RunID == "" {
+		t.Fatalf("cron history missing v2_run_id")
+	}
+	var v2Count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_runs WHERE id=?`, v2RunID).Scan(&v2Count); err != nil {
+		t.Fatalf("lookup v2 run: %v", err)
+	}
+	if v2Count != 1 {
+		t.Fatalf("expected one v2 run, got %d", v2Count)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/workspaces/engineering/workflows/delivery/cron/runs", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr = httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("runs status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var history struct {
+		Runs  []types.WorkflowRun `json:"runs"`
+		Count int                 `json:"count"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &history); err != nil {
+		t.Fatalf("decode history: %v", err)
+	}
+	if history.Count != 1 || len(history.Runs) != 1 || history.Runs[0].ID == "" {
+		t.Fatalf("unexpected history: %#v", history)
+	}
+}
+
+func TestCronSchedulerV2SkipOverlap(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token: "test-token", ClawToken: "claw-token",
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}},
+	}, "", "", "")
+
+	SaveWorkspaceForTest(t, &types.WorkspaceConfig{
+		Name: "engineering",
+		Files: map[string]string{
+			"elasticclaw-config.yaml": cronWorkspaceV2YAML,
+		},
+	}, []*types.WorkflowConfig{{Name: "delivery", RawConfig: cronWorkflowV2SkipYAML}})
+
+	s.cronSchedulerV2 = newCronSchedulerV2(s)
+
+	// Seed an active v2 run for the same workflow so the next manual tick is skipped.
+	now := time.Now().UTC()
+	v2RunID := "run-active"
+	if _, err := db.Exec(`INSERT INTO workflow_v2_runs(
+			id,tenant_id,workspace_name,workflow_name,workspace_revision,workflow_revision,
+			workspace_yaml,workflow_yaml,state,display_phase,state_version,status,
+			waiting_reason,current_attempt_id,current_task_id,context_bundle_id,trigger_type,task_run_id,
+			created_at,updated_at,finished_at)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		v2RunID, "test-tenant-id", "engineering", "delivery", "rev-1", "rev-1",
+		"ws", "wf", "s", v2types.PhaseBuild, 1, string(workflowv2.RunActive),
+		"", "attempt-1", "", "", "cron", "",
+		now, now, 0); err != nil {
+		t.Fatalf("seed active run: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces/engineering/workflows/delivery/cron/trigger", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409 conflict, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var skipped int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_v2_cron_runs WHERE workspace_name=? AND workflow_name=? AND status='skipped'`,
+		"engineering", "delivery").Scan(&skipped); err != nil {
+		t.Fatalf("lookup skipped run: %v", err)
+	}
+	if skipped != 1 {
+		t.Fatalf("expected 1 skipped cron run, got %d", skipped)
+	}
 }
 
 // Ensure cron.Schedule interface is satisfied

--- a/pkg/hub/cron_scheduler_test.go
+++ b/pkg/hub/cron_scheduler_test.go
@@ -367,6 +367,29 @@ trigger:
     overlap_policy: skip
 `
 
+const cronWorkflowV2ActivationFailureYAML = `
+schema_version: 2
+name: delivery
+enabled: true
+initial_state: start
+states:
+  start:
+    phase: build
+  bad:
+    phase: build
+    invariant:
+      impossible:
+        equals: true
+trigger:
+  cron:
+    schedule: "0 9 * * *"
+transitions:
+  ready:
+    from: [start]
+    on: context.bundle.ready
+    to: bad
+`
+
 func TestCronSchedulerV2StartLoadsWorkflow(t *testing.T) {
 	configDir := t.TempDir()
 	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
@@ -512,6 +535,60 @@ func TestCronSchedulerV2SkipOverlap(t *testing.T) {
 	}
 	if skipped != 1 {
 		t.Fatalf("expected 1 skipped cron run, got %d", skipped)
+	}
+}
+
+func TestCronSchedulerV2ActivationFailureReleasesOverlapSlot(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ELASTICCLAW_HUB_CONFIG", configDir+"/hub.yaml")
+	t.Setenv("ELASTICCLAW_NOOP_PROVIDER", "1")
+	s, db := NewTestServerWithConfig(t, &types.HubConfig{
+		Token: "test-token", ClawToken: "claw-token",
+		Providers: map[string]types.ProviderConfig{"noop": {Type: "noop"}},
+	}, "", "", "")
+
+	SaveWorkspaceForTest(t, &types.WorkspaceConfig{
+		Name: "engineering",
+		Files: map[string]string{
+			"elasticclaw-config.yaml": cronWorkspaceV2YAML,
+		},
+	}, []*types.WorkflowConfig{{Name: "delivery", RawConfig: cronWorkflowV2ActivationFailureYAML}})
+
+	s.cronSchedulerV2 = newCronSchedulerV2(s)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/workspaces/engineering/workflows/delivery/cron/trigger", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 activation failure, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var v2RunID, cronStatus, cronRunContext string
+	if err := db.QueryRow(`SELECT v2_run_id, status, run_context FROM workflow_v2_cron_runs WHERE workspace_name=? AND workflow_name=?`,
+		"engineering", "delivery").Scan(&v2RunID, &cronStatus, &cronRunContext); err != nil {
+		t.Fatalf("lookup cron history: %v", err)
+	}
+	if cronStatus != "failed" {
+		t.Fatalf("cron history status = %q, want failed", cronStatus)
+	}
+	if !strings.Contains(cronRunContext, "failure_reason") {
+		t.Fatalf("cron history missing failure_reason in run_context: %s", cronRunContext)
+	}
+
+	var runStatus string
+	if err := db.QueryRow(`SELECT status FROM workflow_v2_runs WHERE id=?`, v2RunID).Scan(&runStatus); err != nil {
+		t.Fatalf("lookup v2 run: %v", err)
+	}
+	if runStatus != string(workflowv2.RunCancelled) {
+		t.Fatalf("v2 run status = %q, want cancelled", runStatus)
+	}
+
+	s.cronSchedulerV2.runningMu.Lock()
+	inMem := s.cronSchedulerV2.running["engineering/delivery"]
+	s.cronSchedulerV2.runningMu.Unlock()
+	if inMem != 0 {
+		t.Fatalf("overlap slot not released: running=%d", inMem)
 	}
 }
 

--- a/pkg/hub/cron_scheduler_v2.go
+++ b/pkg/hub/cron_scheduler_v2.go
@@ -144,10 +144,17 @@ func (cs *cronSchedulerV2) reloadWorkflows() error {
 	for key, sw := range newWorkflows {
 		if _, ok := cs.entries[key]; ok {
 			old := cs.workflows[key]
-			if old != nil && old.trigger.Schedule == sw.trigger.Schedule && old.trigger.Timezone == sw.trigger.Timezone {
-				cs.workflows[key] = sw
-				continue
+		if old != nil && old.trigger.Schedule == sw.trigger.Schedule && old.trigger.Timezone == sw.trigger.Timezone {
+			// Refresh the snapshot held by the existing cron job, not just the map,
+			// so scheduled runs pick up workflow body/policy edits without a restart.
+			cs.workflows[key] = sw
+			if entry := cs.cron.Entry(cs.entries[key]); entry.Valid() {
+				if job, ok := entry.Job.(*cronJobV2); ok {
+					job.workflow = sw
+				}
 			}
+			continue
+		}
 			cs.cron.Remove(cs.entries[key])
 			delete(cs.entries, key)
 		}
@@ -202,7 +209,7 @@ func (cs *cronSchedulerV2) runWorkflow(sw *scheduledWorkflowV2, tenantID string)
 	key := sw.key
 	if strings.TrimSpace(tenantID) == "" {
 		var err error
-		tenantID, err = cs.firstTenantID()
+		tenantID, err = cs.tenantIDForWorkspace(sw.workspace.Name)
 		if err != nil {
 			log.Printf("[cron-v2] no tenant for %s: %v", key, err)
 			return workflowRunFailed, err
@@ -253,6 +260,7 @@ func (cs *cronSchedulerV2) runWorkflow(sw *scheduledWorkflowV2, tenantID string)
 		"trigger_type":   "cron",
 	})
 	if err != nil {
+		cs.decrementRunning(key)
 		log.Printf("[cron-v2] failed to record start for %s: %v", key, err)
 		return workflowRunFailed, err
 	}
@@ -374,6 +382,30 @@ func (cs *cronSchedulerV2) firstTenantID() (string, error) {
 		return "", err
 	}
 	return tenantID, nil
+}
+
+// tenantIDForWorkspace resolves the tenant that owns a workspace for unattended
+// cron ticks. It prefers any prior claw or task_run association for the workspace,
+// so scheduled runs stay attributed to the same tenant as manual triggers and
+// webhooks. Only workspaces with no recorded activity fall back to the first
+// tenant (matching v1 behavior for single-tenant deployments).
+func (cs *cronSchedulerV2) tenantIDForWorkspace(workspaceName string) (string, error) {
+	var tenantID string
+	err := cs.srv.db.QueryRow(`
+		SELECT tenant_id FROM (
+			SELECT tenant_id, created_at FROM claws WHERE template=? AND tenant_id != ''
+			UNION ALL
+			SELECT tenant_id, created_at FROM task_runs WHERE workspace_name=? AND tenant_id != ''
+		)
+		ORDER BY created_at DESC
+		LIMIT 1`, workspaceName, workspaceName).Scan(&tenantID)
+	if err == nil {
+		return tenantID, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return cs.firstTenantID()
+	}
+	return "", err
 }
 
 func (cs *cronSchedulerV2) countActiveV2Runs(store *workflowv2.Store, workspaceName, workflowName string) (int, error) {

--- a/pkg/hub/cron_scheduler_v2.go
+++ b/pkg/hub/cron_scheduler_v2.go
@@ -25,6 +25,11 @@ type cronSchedulerV2 struct {
 	cron      *cron.Cron
 	entries   map[string]cron.EntryID         // workflow key -> cron entry ID
 	workflows map[string]*scheduledWorkflowV2 // workflow key -> workflow
+
+	// running tracks in-flight runs per workflow key to serialize overlap
+	// checks and admissions within a single process, matching the v1 scheduler.
+	runningMu sync.Mutex
+	running   map[string]int // workflow key -> in-flight run count
 }
 
 type scheduledWorkflowV2 struct {
@@ -39,6 +44,7 @@ func newCronSchedulerV2(srv *Server) *cronSchedulerV2 {
 		srv:       srv,
 		entries:   make(map[string]cron.EntryID),
 		workflows: make(map[string]*scheduledWorkflowV2),
+		running:   make(map[string]int),
 	}
 }
 
@@ -132,11 +138,14 @@ func (cs *cronSchedulerV2) reloadWorkflows() error {
 		}
 	}
 
-	// Add or update entries
+	// Add or update entries. Always refresh the stored workflow snapshot so a
+	// reload picks up body/policy changes even when the cron expression is
+	// unchanged.
 	for key, sw := range newWorkflows {
 		if _, ok := cs.entries[key]; ok {
 			old := cs.workflows[key]
 			if old != nil && old.trigger.Schedule == sw.trigger.Schedule && old.trigger.Timezone == sw.trigger.Timezone {
+				cs.workflows[key] = sw
 				continue
 			}
 			cs.cron.Remove(cs.entries[key])
@@ -186,50 +195,55 @@ type cronJobV2 struct {
 }
 
 func (j *cronJobV2) Run() {
-	_, _ = j.scheduler.runWorkflow(j.workflow)
+	_, _ = j.scheduler.runWorkflow(j.workflow, "")
 }
 
-func (cs *cronSchedulerV2) runWorkflow(sw *scheduledWorkflowV2) (workflowRunStartStatus, error) {
+func (cs *cronSchedulerV2) runWorkflow(sw *scheduledWorkflowV2, tenantID string) (workflowRunStartStatus, error) {
 	key := sw.key
-	tenantID, err := cs.firstTenantID()
-	if err != nil {
-		log.Printf("[cron-v2] no tenant for %s: %v", key, err)
-		return workflowRunFailed, err
+	if strings.TrimSpace(tenantID) == "" {
+		var err error
+		tenantID, err = cs.firstTenantID()
+		if err != nil {
+			log.Printf("[cron-v2] no tenant for %s: %v", key, err)
+			return workflowRunFailed, err
+		}
 	}
 
 	store := workflowv2.NewStore(cs.srv.db)
 	now := time.Now().UTC()
 
-	active, err := cs.countActiveV2Runs(store, sw.workspace.Name, sw.workflow.Name)
-	if err != nil {
-		log.Printf("[cron-v2] failed to count active runs for %s: %v", key, err)
-		return workflowRunFailed, err
-	}
-
 	overlapPolicy := strings.ToLower(strings.TrimSpace(sw.trigger.OverlapPolicy))
 	if overlapPolicy == "" {
 		overlapPolicy = "skip"
 	}
-	if active > 0 {
-		switch overlapPolicy {
-		case "skip":
-			reason := fmt.Sprintf("%d run(s) still active", active)
-			_, _ = store.RecordCronRunSkipped(context.Background(), tenantID, sw.workspace.Name, sw.workflow.Name, "cron", map[string]interface{}{
-				"reason": reason,
-			})
-			log.Printf("[cron-v2] skipping %s (%s)", key, reason)
-			return workflowRunSkipped, nil
-		case "parallel":
-			// allow parallel execution
-		default:
-			reason := fmt.Sprintf("unknown overlap policy %q", sw.trigger.OverlapPolicy)
-			_, _ = store.RecordCronRunSkipped(context.Background(), tenantID, sw.workspace.Name, sw.workflow.Name, "cron", map[string]interface{}{
-				"reason": reason,
-			})
-			log.Printf("[cron-v2] skipping %s (%s)", key, reason)
-			return workflowRunSkipped, nil
-		}
+
+	// Serialize overlap admission. The in-memory lock prevents concurrent ticks
+	// and manual triggers from racing; the DB count catches runs that were active
+	// before a restart.
+	cs.runningMu.Lock()
+	inMemActive := cs.running[key]
+	var dbActive int
+	var dbErr error
+	if inMemActive == 0 || overlapPolicy == "parallel" {
+		dbActive, dbErr = cs.countActiveV2Runs(store, sw.workspace.Name, sw.workflow.Name)
 	}
+	if dbErr != nil {
+		cs.runningMu.Unlock()
+		log.Printf("[cron-v2] failed to count active runs for %s: %v", key, dbErr)
+		return workflowRunFailed, dbErr
+	}
+	active := inMemActive + dbActive
+	if active > 0 && overlapPolicy != "parallel" {
+		cs.runningMu.Unlock()
+		reason := fmt.Sprintf("%d run(s) still active", active)
+		_, _ = store.RecordCronRunSkipped(context.Background(), tenantID, sw.workspace.Name, sw.workflow.Name, "cron", map[string]interface{}{
+			"reason": reason,
+		})
+		log.Printf("[cron-v2] skipping %s (%s)", key, reason)
+		return workflowRunSkipped, nil
+	}
+	cs.running[key]++
+	cs.runningMu.Unlock()
 
 	// Record the cron history row before provisioning so a failure is still visible.
 	cronRunID, err := store.RecordCronRunStarted(context.Background(), tenantID, sw.workspace.Name, sw.workflow.Name, "cron", map[string]interface{}{
@@ -246,10 +260,12 @@ func (cs *cronSchedulerV2) runWorkflow(sw *scheduledWorkflowV2) (workflowRunStar
 	workspaceYAML := []byte(sw.workspace.Files["elasticclaw-config.yaml"])
 	workflowYAML := []byte(sw.workflow.RawConfig)
 
+	createdV2Run := false
 	clawID, _, err := cs.srv.createClawFromWorkflowWithOptions(
 		sw.workspace,
 		sw.workflow,
 		workflowCreateOptions{
+			tenantID: tenantID,
 			reason:   fmt.Sprintf("cron run %s at %s", cronRunID, now.Format(time.RFC3339)),
 			clawName: fmt.Sprintf("%s-%s", sw.workflow.Name, now.Format("20060102-150405")),
 			beforeProvision: func(ctx context.Context, clawID, provisionTenantID string) error {
@@ -265,6 +281,7 @@ func (cs *cronSchedulerV2) runWorkflow(sw *scheduledWorkflowV2) (workflowRunStar
 				if err != nil {
 					return err
 				}
+				createdV2Run = true
 				if err := store.UpdateCronRunForV2Run(ctx, cronRunID, run.ID, clawID); err != nil {
 					return err
 				}
@@ -289,6 +306,11 @@ func (cs *cronSchedulerV2) runWorkflow(sw *scheduledWorkflowV2) (workflowRunStar
 		if failErr := store.FailCronRun(context.Background(), cronRunID, err.Error()); failErr != nil {
 			log.Printf("[cron-v2] failed to mark run %s as failed: %v", cronRunID, failErr)
 		}
+		if !createdV2Run {
+			// A v2 run was never created, so the terminal cleanup hook will not
+			// run to release our admission slot.
+			cs.decrementRunning(key)
+		}
 		return workflowRunFailed, err
 	}
 
@@ -296,9 +318,17 @@ func (cs *cronSchedulerV2) runWorkflow(sw *scheduledWorkflowV2) (workflowRunStar
 	return workflowRunStarted, nil
 }
 
+func (cs *cronSchedulerV2) decrementRunning(key string) {
+	cs.runningMu.Lock()
+	defer cs.runningMu.Unlock()
+	if cs.running[key] > 0 {
+		cs.running[key]--
+	}
+}
+
 // manualTrigger triggers a v2 cron workflow run manually. It matches v1
 // cronScheduler.manualTrigger: any enabled cron workflow can be triggered.
-func (cs *cronSchedulerV2) manualTrigger(workspaceName, workflowName string) (string, error) {
+func (cs *cronSchedulerV2) manualTrigger(workspaceName, workflowName, tenantID string) (string, error) {
 	workspaces, err := cs.srv.loadAllWorkspaces()
 	if err != nil {
 		return "", err
@@ -324,7 +354,7 @@ func (cs *cronSchedulerV2) manualTrigger(workspaceName, workflowName string) (st
 				trigger:   trigger,
 				key:       workspaceName + "/" + workflowName,
 			}
-			status, err := cs.runWorkflow(sw)
+			status, err := cs.runWorkflow(sw, tenantID)
 			if status == workflowRunSkipped {
 				return "", &cronTriggerSkippedError{msg: fmt.Sprintf("workflow %s/%s: run skipped due to overlap policy", workspaceName, workflowName)}
 			}
@@ -375,14 +405,18 @@ func (cs *cronSchedulerV2) getNextRuns() map[string]time.Time {
 	return result
 }
 
-// getRunHistory returns the cron run history for a v2 workflow.
-func (cs *cronSchedulerV2) getRunHistory(workspaceName, workflowName string, limit int) ([]types.WorkflowRun, error) {
+// getRunHistory returns the cron run history for a v2 workflow in the given
+// tenant. An empty tenantID falls back to the first tenant for unattended ticks.
+func (cs *cronSchedulerV2) getRunHistory(workspaceName, workflowName, tenantID string, limit int) ([]types.WorkflowRun, error) {
 	if limit <= 0 {
 		limit = 50
 	}
-	tenantID, err := cs.firstTenantID()
-	if err != nil {
-		return nil, err
+	if strings.TrimSpace(tenantID) == "" {
+		var err error
+		tenantID, err = cs.firstTenantID()
+		if err != nil {
+			return nil, err
+		}
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -397,11 +431,15 @@ func (cs *cronSchedulerV2) getRunHistory(workspaceName, workflowName string, lim
 	return runs, nil
 }
 
-// getRunByID returns a single v2 cron run by ID.
-func (cs *cronSchedulerV2) getRunByID(workspaceName, workflowName, runID string) (*types.WorkflowRun, error) {
-	tenantID, err := cs.firstTenantID()
-	if err != nil {
-		return nil, err
+// getRunByID returns a single v2 cron run by ID in the given tenant. An empty
+// tenantID falls back to the first tenant for unattended ticks.
+func (cs *cronSchedulerV2) getRunByID(workspaceName, workflowName, runID, tenantID string) (*types.WorkflowRun, error) {
+	if strings.TrimSpace(tenantID) == "" {
+		var err error
+		tenantID, err = cs.firstTenantID()
+		if err != nil {
+			return nil, err
+		}
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/pkg/hub/cron_scheduler_v2.go
+++ b/pkg/hub/cron_scheduler_v2.go
@@ -316,6 +316,10 @@ func (cs *cronSchedulerV2) runWorkflow(sw *scheduledWorkflowV2, tenantID string)
 					if cleanupErr := store.CancelActivation(cleanupCtx, run.ID, err.Error()); cleanupErr != nil {
 						return errors.Join(err, fmt.Errorf("cancel failed workflow v2 activation: %w", cleanupErr))
 					}
+					// The v2 run is now cancelled. Release the cron overlap slot
+					// immediately; the terminal cleanup hook will not run because
+					// cancelWorkflowV2RunForClaw only looks for active/suspended runs.
+					cs.srv.releaseWorkflowV2CronSlot(cleanupCtx, run.ID)
 					return err
 				}
 				return nil

--- a/pkg/hub/cron_scheduler_v2.go
+++ b/pkg/hub/cron_scheduler_v2.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
@@ -138,13 +139,24 @@ func (cs *cronSchedulerV2) reloadWorkflows() error {
 		}
 	}
 
-	// Add or update entries. Always replace the existing cron entry so a reload
-	// picks up body/policy edits without mutating a live job (which would race
-	// with a concurrently executing tick). Re-adding with the same schedule
-	// recomputes the next run time from the current moment, which is acceptable
-	// because reloads are infrequent.
+	// Add or update entries. Preserve the cron entry and its next execution time
+	// for workflows whose schedule/timezone have not changed; only replace the
+	// entry when the schedule changes. The workflow snapshot is updated atomically
+	// inside the existing job, so body/policy edits are picked up without
+	// rescheduling and without racing a concurrently executing tick.
 	for key, sw := range newWorkflows {
 		if entryID, ok := cs.entries[key]; ok {
+			old := cs.workflows[key]
+			if old != nil && old.trigger.Schedule == sw.trigger.Schedule && old.trigger.Timezone == sw.trigger.Timezone {
+				entry := cs.cron.Entry(entryID)
+				if entry.Valid() {
+					if job, ok := entry.Job.(*cronJobV2); ok {
+						job.workflow.Store(sw)
+						cs.workflows[key] = sw
+						continue
+					}
+				}
+			}
 			cs.cron.Remove(entryID)
 			delete(cs.entries, key)
 		}
@@ -163,7 +175,7 @@ func (cs *cronSchedulerV2) reloadWorkflows() error {
 			log.Printf("[cron-v2] invalid schedule %q for %s: %v", sw.trigger.Schedule, key, err)
 			continue
 		}
-		entryID := cs.cron.Schedule(schedule, &cronJobV2{scheduler: cs, workflow: sw})
+		entryID := cs.cron.Schedule(schedule, newCronJobV2(cs, sw))
 		cs.entries[key] = entryID
 		cs.workflows[key] = sw
 		log.Printf("[cron-v2] scheduled %s with %q (timezone: %s)", key, sw.trigger.Schedule, sw.trigger.Timezone)
@@ -188,11 +200,21 @@ func cronTriggerFromV2Workflow(wf *types.WorkflowConfig) (*v2.CronTrigger, bool)
 
 type cronJobV2 struct {
 	scheduler *cronSchedulerV2
-	workflow  *scheduledWorkflowV2
+	workflow  atomic.Value // *scheduledWorkflowV2
+}
+
+func newCronJobV2(cs *cronSchedulerV2, sw *scheduledWorkflowV2) *cronJobV2 {
+	j := &cronJobV2{scheduler: cs}
+	j.workflow.Store(sw)
+	return j
+}
+
+func (j *cronJobV2) workflowSnapshot() *scheduledWorkflowV2 {
+	return j.workflow.Load().(*scheduledWorkflowV2)
 }
 
 func (j *cronJobV2) Run() {
-	_, _ = j.scheduler.runWorkflow(j.workflow, "")
+	_, _ = j.scheduler.runWorkflow(j.workflowSnapshot(), "")
 }
 
 func (cs *cronSchedulerV2) runWorkflow(sw *scheduledWorkflowV2, tenantID string) (workflowRunStartStatus, error) {

--- a/pkg/hub/cron_scheduler_v2.go
+++ b/pkg/hub/cron_scheduler_v2.go
@@ -138,24 +138,14 @@ func (cs *cronSchedulerV2) reloadWorkflows() error {
 		}
 	}
 
-	// Add or update entries. Always refresh the stored workflow snapshot so a
-	// reload picks up body/policy changes even when the cron expression is
-	// unchanged.
+	// Add or update entries. Always replace the existing cron entry so a reload
+	// picks up body/policy edits without mutating a live job (which would race
+	// with a concurrently executing tick). Re-adding with the same schedule
+	// recomputes the next run time from the current moment, which is acceptable
+	// because reloads are infrequent.
 	for key, sw := range newWorkflows {
-		if _, ok := cs.entries[key]; ok {
-			old := cs.workflows[key]
-		if old != nil && old.trigger.Schedule == sw.trigger.Schedule && old.trigger.Timezone == sw.trigger.Timezone {
-			// Refresh the snapshot held by the existing cron job, not just the map,
-			// so scheduled runs pick up workflow body/policy edits without a restart.
-			cs.workflows[key] = sw
-			if entry := cs.cron.Entry(cs.entries[key]); entry.Valid() {
-				if job, ok := entry.Job.(*cronJobV2); ok {
-					job.workflow = sw
-				}
-			}
-			continue
-		}
-			cs.cron.Remove(cs.entries[key])
+		if entryID, ok := cs.entries[key]; ok {
+			cs.cron.Remove(entryID)
 			delete(cs.entries, key)
 		}
 

--- a/pkg/hub/cron_scheduler_v2.go
+++ b/pkg/hub/cron_scheduler_v2.go
@@ -1,0 +1,459 @@
+package hub
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+	"github.com/elasticclaw/elasticclaw/pkg/types"
+	v2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+	"github.com/google/uuid"
+	"github.com/robfig/cron/v3"
+)
+
+// cronSchedulerV2 manages scheduled workflow v2 runs using cron expressions.
+// It mirrors the behavior of v1 cronScheduler while using the v2 runtime.
+type cronSchedulerV2 struct {
+	srv       *Server
+	mu        sync.RWMutex
+	cron      *cron.Cron
+	entries   map[string]cron.EntryID         // workflow key -> cron entry ID
+	workflows map[string]*scheduledWorkflowV2 // workflow key -> workflow
+}
+
+type scheduledWorkflowV2 struct {
+	workspace *types.WorkspaceConfig // v1 shell with Files and RawConfig
+	workflow  *types.WorkflowConfig  // v1 shell with RawConfig
+	trigger   *v2.CronTrigger
+	key       string // workspaceName/workflowName
+}
+
+func newCronSchedulerV2(srv *Server) *cronSchedulerV2 {
+	return &cronSchedulerV2{
+		srv:       srv,
+		entries:   make(map[string]cron.EntryID),
+		workflows: make(map[string]*scheduledWorkflowV2),
+	}
+}
+
+func (cs *cronSchedulerV2) start() error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	cs.cron = cron.New(cron.WithSeconds(), cron.WithChain(cron.Recover(cron.DefaultLogger)))
+	if err := cs.reloadWorkflows(); err != nil {
+		return fmt.Errorf("reload v2 cron workflows: %w", err)
+	}
+	cs.cron.Start()
+	log.Println("[cron-v2] scheduler started")
+	return nil
+}
+
+func (cs *cronSchedulerV2) stop() {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	if cs.cron != nil {
+		ctx := cs.cron.Stop()
+		<-ctx.Done()
+		log.Println("[cron-v2] scheduler stopped")
+	}
+}
+
+func (cs *cronSchedulerV2) reload() error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	if cs.cron == nil {
+		return nil
+	}
+	return cs.reloadWorkflows()
+}
+
+// removeWorkflow stops the schedule for a single workflow without reloading.
+func (cs *cronSchedulerV2) removeWorkflow(workspaceName, workflowName string) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	if cs.cron == nil {
+		return
+	}
+	key := workspaceName + "/" + workflowName
+	for entryKey, entryID := range cs.entries {
+		if strings.EqualFold(entryKey, key) {
+			cs.cron.Remove(entryID)
+			delete(cs.entries, entryKey)
+			delete(cs.workflows, entryKey)
+			log.Printf("[cron-v2] removed schedule for %s", entryKey)
+			return
+		}
+	}
+}
+
+func (cs *cronSchedulerV2) reloadWorkflows() error {
+	workspaces, err := cs.srv.loadAllWorkspaces()
+	if err != nil {
+		return err
+	}
+
+	newWorkflows := make(map[string]*scheduledWorkflowV2)
+	for _, ws := range workspaces {
+		for _, wf := range ws.Workflows {
+			if wf == nil || !isWorkflowV2(wf) {
+				continue
+			}
+			trigger, ok := cronTriggerFromV2Workflow(wf)
+			if !ok {
+				continue
+			}
+			if !isWorkflowEnabled(wf) {
+				continue
+			}
+			key := ws.Name + "/" + wf.Name
+			newWorkflows[key] = &scheduledWorkflowV2{
+				workspace: ws,
+				workflow:  wf,
+				trigger:   trigger,
+				key:       key,
+			}
+		}
+	}
+
+	// Remove old entries not in new set
+	for key, entryID := range cs.entries {
+		if _, ok := newWorkflows[key]; !ok {
+			cs.cron.Remove(entryID)
+			delete(cs.entries, key)
+			delete(cs.workflows, key)
+			log.Printf("[cron-v2] removed schedule for %s", key)
+		}
+	}
+
+	// Add or update entries
+	for key, sw := range newWorkflows {
+		if _, ok := cs.entries[key]; ok {
+			old := cs.workflows[key]
+			if old != nil && old.trigger.Schedule == sw.trigger.Schedule && old.trigger.Timezone == sw.trigger.Timezone {
+				continue
+			}
+			cs.cron.Remove(cs.entries[key])
+			delete(cs.entries, key)
+		}
+
+		loc := time.UTC
+		if sw.trigger.Timezone != "" {
+			var err error
+			loc, err = time.LoadLocation(sw.trigger.Timezone)
+			if err != nil {
+				log.Printf("[cron-v2] invalid timezone %q for %s, using UTC: %v", sw.trigger.Timezone, key, err)
+				loc = time.UTC
+			}
+		}
+		schedule, err := parseCronSchedule(sw.trigger.Schedule, loc)
+		if err != nil {
+			log.Printf("[cron-v2] invalid schedule %q for %s: %v", sw.trigger.Schedule, key, err)
+			continue
+		}
+		entryID := cs.cron.Schedule(schedule, &cronJobV2{scheduler: cs, workflow: sw})
+		cs.entries[key] = entryID
+		cs.workflows[key] = sw
+		log.Printf("[cron-v2] scheduled %s with %q (timezone: %s)", key, sw.trigger.Schedule, sw.trigger.Timezone)
+	}
+	return nil
+}
+
+func cronTriggerFromV2Workflow(wf *types.WorkflowConfig) (*v2.CronTrigger, bool) {
+	if wf == nil || strings.TrimSpace(wf.RawConfig) == "" {
+		return nil, false
+	}
+	resolved, err := v2.ParseWorkflow([]byte(wf.RawConfig))
+	if err != nil {
+		log.Printf("[cron-v2] could not parse v2 workflow %q: %v", wf.Name, err)
+		return nil, false
+	}
+	if resolved.Trigger == nil || resolved.Trigger.Cron == nil {
+		return nil, false
+	}
+	return resolved.Trigger.Cron, true
+}
+
+type cronJobV2 struct {
+	scheduler *cronSchedulerV2
+	workflow  *scheduledWorkflowV2
+}
+
+func (j *cronJobV2) Run() {
+	_, _ = j.scheduler.runWorkflow(j.workflow)
+}
+
+func (cs *cronSchedulerV2) runWorkflow(sw *scheduledWorkflowV2) (workflowRunStartStatus, error) {
+	key := sw.key
+	tenantID, err := cs.firstTenantID()
+	if err != nil {
+		log.Printf("[cron-v2] no tenant for %s: %v", key, err)
+		return workflowRunFailed, err
+	}
+
+	store := workflowv2.NewStore(cs.srv.db)
+	now := time.Now().UTC()
+
+	active, err := cs.countActiveV2Runs(store, sw.workspace.Name, sw.workflow.Name)
+	if err != nil {
+		log.Printf("[cron-v2] failed to count active runs for %s: %v", key, err)
+		return workflowRunFailed, err
+	}
+
+	overlapPolicy := strings.ToLower(strings.TrimSpace(sw.trigger.OverlapPolicy))
+	if overlapPolicy == "" {
+		overlapPolicy = "skip"
+	}
+	if active > 0 {
+		switch overlapPolicy {
+		case "skip":
+			reason := fmt.Sprintf("%d run(s) still active", active)
+			_, _ = store.RecordCronRunSkipped(context.Background(), tenantID, sw.workspace.Name, sw.workflow.Name, "cron", map[string]interface{}{
+				"reason": reason,
+			})
+			log.Printf("[cron-v2] skipping %s (%s)", key, reason)
+			return workflowRunSkipped, nil
+		case "parallel":
+			// allow parallel execution
+		default:
+			reason := fmt.Sprintf("unknown overlap policy %q", sw.trigger.OverlapPolicy)
+			_, _ = store.RecordCronRunSkipped(context.Background(), tenantID, sw.workspace.Name, sw.workflow.Name, "cron", map[string]interface{}{
+				"reason": reason,
+			})
+			log.Printf("[cron-v2] skipping %s (%s)", key, reason)
+			return workflowRunSkipped, nil
+		}
+	}
+
+	// Record the cron history row before provisioning so a failure is still visible.
+	cronRunID, err := store.RecordCronRunStarted(context.Background(), tenantID, sw.workspace.Name, sw.workflow.Name, "cron", map[string]interface{}{
+		"scheduled_at":   now.Format(time.RFC3339),
+		"workflow_name":  sw.workflow.Name,
+		"workspace_name": sw.workspace.Name,
+		"trigger_type":   "cron",
+	})
+	if err != nil {
+		log.Printf("[cron-v2] failed to record start for %s: %v", key, err)
+		return workflowRunFailed, err
+	}
+
+	workspaceYAML := []byte(sw.workspace.Files["elasticclaw-config.yaml"])
+	workflowYAML := []byte(sw.workflow.RawConfig)
+
+	clawID, _, err := cs.srv.createClawFromWorkflowWithOptions(
+		sw.workspace,
+		sw.workflow,
+		workflowCreateOptions{
+			reason:   fmt.Sprintf("cron run %s at %s", cronRunID, now.Format(time.RFC3339)),
+			clawName: fmt.Sprintf("%s-%s", sw.workflow.Name, now.Format("20060102-150405")),
+			beforeProvision: func(ctx context.Context, clawID, provisionTenantID string) error {
+				var taskRunID string
+				if err := cs.srv.db.QueryRow(`SELECT id FROM task_runs WHERE claw_id=? ORDER BY created_at DESC LIMIT 1`, clawID).Scan(&taskRunID); err != nil && !errors.Is(err, sql.ErrNoRows) {
+					return fmt.Errorf("lookup parent task run for claw %s: %w", clawID, err)
+				}
+				run, err := store.CreateRun(ctx, workflowv2.CreateRunRequest{
+					ID: uuid.NewString(), TenantID: provisionTenantID, InitialClawID: clawID, TaskRunID: taskRunID,
+					WorkspaceYAML: workspaceYAML, WorkflowYAML: workflowYAML, ActivationPending: true,
+					TriggerType: "cron",
+				})
+				if err != nil {
+					return err
+				}
+				if err := store.UpdateCronRunForV2Run(ctx, cronRunID, run.ID, clawID); err != nil {
+					return err
+				}
+				_, err = store.AssembleOrganizationContext(ctx, run.ID, workspaceFileKnowledgeResolver(sw.workspace.Files))
+				if err == nil {
+					err = store.CompleteActivation(ctx, run.ID)
+				}
+				if err != nil {
+					cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+					defer cancel()
+					if cleanupErr := store.CancelActivation(cleanupCtx, run.ID, err.Error()); cleanupErr != nil {
+						return errors.Join(err, fmt.Errorf("cancel failed workflow v2 activation: %w", cleanupErr))
+					}
+					return err
+				}
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		log.Printf("[cron-v2] failed to create run for %s: %v", key, err)
+		if failErr := store.FailCronRun(context.Background(), cronRunID, err.Error()); failErr != nil {
+			log.Printf("[cron-v2] failed to mark run %s as failed: %v", cronRunID, failErr)
+		}
+		return workflowRunFailed, err
+	}
+
+	log.Printf("[cron-v2] started run %s for %s (claw %s)", cronRunID, key, clawID)
+	return workflowRunStarted, nil
+}
+
+// manualTrigger triggers a v2 cron workflow run manually. It matches v1
+// cronScheduler.manualTrigger: any enabled cron workflow can be triggered.
+func (cs *cronSchedulerV2) manualTrigger(workspaceName, workflowName string) (string, error) {
+	workspaces, err := cs.srv.loadAllWorkspaces()
+	if err != nil {
+		return "", err
+	}
+	for _, ws := range workspaces {
+		if ws.Name != workspaceName {
+			continue
+		}
+		for _, wf := range ws.Workflows {
+			if wf == nil || wf.Name != workflowName || !isWorkflowV2(wf) {
+				continue
+			}
+			trigger, ok := cronTriggerFromV2Workflow(wf)
+			if !ok {
+				return "", &cronTriggerNotFoundError{msg: fmt.Sprintf("workflow %s/%s is not cron-triggered", workspaceName, workflowName)}
+			}
+			if !isWorkflowEnabled(wf) {
+				return "", &cronTriggerDisabledError{msg: fmt.Sprintf("workflow %s/%s is disabled", workspaceName, workflowName)}
+			}
+			sw := &scheduledWorkflowV2{
+				workspace: ws,
+				workflow:  wf,
+				trigger:   trigger,
+				key:       workspaceName + "/" + workflowName,
+			}
+			status, err := cs.runWorkflow(sw)
+			if status == workflowRunSkipped {
+				return "", &cronTriggerSkippedError{msg: fmt.Sprintf("workflow %s/%s: run skipped due to overlap policy", workspaceName, workflowName)}
+			}
+			if err != nil {
+				return "", err
+			}
+			return sw.key, nil
+		}
+	}
+	return "", &cronTriggerNotFoundError{msg: fmt.Sprintf("workflow %s/%s not found", workspaceName, workflowName)}
+}
+
+func (cs *cronSchedulerV2) firstTenantID() (string, error) {
+	var tenantID string
+	if err := cs.srv.db.QueryRow(`SELECT id FROM tenants LIMIT 1`).Scan(&tenantID); err != nil {
+		return "", err
+	}
+	return tenantID, nil
+}
+
+func (cs *cronSchedulerV2) countActiveV2Runs(store *workflowv2.Store, workspaceName, workflowName string) (int, error) {
+	var count int
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := cs.srv.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM workflow_v2_runs
+		WHERE workspace_name=? AND workflow_name=? AND status IN ('active','suspended')`,
+		workspaceName, workflowName).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// getNextRuns returns the next scheduled run times for all v2 cron workflows.
+func (cs *cronSchedulerV2) getNextRuns() map[string]time.Time {
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	result := make(map[string]time.Time)
+	if cs.cron == nil {
+		return result
+	}
+	for key, entryID := range cs.entries {
+		entry := cs.cron.Entry(entryID)
+		if entry.Valid() {
+			result[key] = entry.Next
+		}
+	}
+	return result
+}
+
+// getRunHistory returns the cron run history for a v2 workflow.
+func (cs *cronSchedulerV2) getRunHistory(workspaceName, workflowName string, limit int) ([]types.WorkflowRun, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	tenantID, err := cs.firstTenantID()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	history, err := workflowv2.NewStore(cs.srv.db).ListCronRunHistory(ctx, tenantID, workspaceName, workflowName, limit)
+	if err != nil {
+		return nil, err
+	}
+	runs := make([]types.WorkflowRun, 0, len(history))
+	for _, h := range history {
+		runs = append(runs, cronHistoryToWorkflowRun(h))
+	}
+	return runs, nil
+}
+
+// getRunByID returns a single v2 cron run by ID.
+func (cs *cronSchedulerV2) getRunByID(workspaceName, workflowName, runID string) (*types.WorkflowRun, error) {
+	tenantID, err := cs.firstTenantID()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	h, err := workflowv2.NewStore(cs.srv.db).GetCronRun(ctx, tenantID, workspaceName, workflowName, runID)
+	if err != nil || h == nil {
+		return nil, err
+	}
+	run := cronHistoryToWorkflowRun(*h)
+	return &run, nil
+}
+
+// finishRunByV2RunID marks the cron history row for a finished v2 run.
+func (cs *cronSchedulerV2) finishRunByV2RunID(runID string, status workflowv2.RunStatus) {
+	if cs == nil || runID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := workflowv2.NewStore(cs.srv.db).FinishCronRunByV2RunID(ctx, runID, status); err != nil {
+		log.Printf("[cron-v2] failed to finish cron run for v2 run %s: %v", runID, err)
+	}
+}
+
+// finishRunByClawID marks the cron history row for a finished claw.
+func (cs *cronSchedulerV2) finishRunByClawID(clawID string, status workflowv2.RunStatus) {
+	if cs == nil || clawID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := workflowv2.NewStore(cs.srv.db).FinishCronRunByClawID(ctx, clawID, status); err != nil {
+		log.Printf("[cron-v2] failed to finish cron run for claw %s: %v", clawID, err)
+	}
+}
+
+func cronHistoryToWorkflowRun(h workflowv2.CronRunHistory) types.WorkflowRun {
+	run := types.WorkflowRun{
+		ID:            h.ID,
+		TenantID:      h.TenantID,
+		WorkflowName:  h.WorkflowName,
+		WorkspaceName: h.WorkspaceName,
+		TriggerType:   h.TriggerType,
+		Status:        h.Status,
+		Result:        h.Result,
+		ClawID:        h.ClawID,
+		RunContext:    h.RunContext,
+		CreatedAt:     h.CreatedAt,
+		StartedAt:     &h.CreatedAt,
+	}
+	if h.FinishedAt != nil {
+		finished := *h.FinishedAt
+		run.FinishedAt = &finished
+	}
+	return run
+}

--- a/pkg/hub/cron_scheduler_v2.go
+++ b/pkg/hub/cron_scheduler_v2.go
@@ -277,6 +277,7 @@ func (cs *cronSchedulerV2) runWorkflow(sw *scheduledWorkflowV2, tenantID string)
 					ID: uuid.NewString(), TenantID: provisionTenantID, InitialClawID: clawID, TaskRunID: taskRunID,
 					WorkspaceYAML: workspaceYAML, WorkflowYAML: workflowYAML, ActivationPending: true,
 					TriggerType: "cron",
+					Timeout:     workflowV2RunTimeout(sw.workflow.RawConfig),
 				})
 				if err != nil {
 					return err

--- a/pkg/hub/reaper.go
+++ b/pkg/hub/reaper.go
@@ -2,10 +2,10 @@ package hub
 
 import (
 	"context"
-	"database/sql"
 	"log"
 	"time"
 
+	"github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
 	"github.com/elasticclaw/elasticclaw/pkg/types"
 )
 
@@ -379,16 +379,16 @@ func (s *Server) reapOnce() {
 	}
 }
 
-// reapWorkflowV2RunTimeouts cancels v2 workflow runs that exceeded their
-// timeout_at (or, for legacy rows without one, their created_at plus the default
-// run timeout). A cancelled run then triggers the normal parent-cleanup path.
+// reapWorkflowV2RunTimeouts cancels v2 workflow runs whose explicit timeout_at
+// has passed. Rows without a timeout_at are intentionally left alone so an
+// operator can recover legacy runs instead of having the reaper cancel them
+// automatically.
 func (s *Server) reapWorkflowV2RunTimeouts(n time.Time, take func() bool) {
-	defaultDeadline := n.Add(-workflowV2DefaultRunTimeout).UnixMilli()
 	rows, err := s.db.Query(`
 		SELECT r.id FROM workflow_v2_runs r
 		WHERE r.status IN ('active','suspended')
-		AND ((r.timeout_at > 0 AND r.timeout_at < ?) OR (r.timeout_at = 0 AND r.created_at < ?))
-		ORDER BY r.created_at`, n.UnixMilli(), defaultDeadline)
+		AND r.timeout_at > 0 AND r.timeout_at < ?
+		ORDER BY r.created_at`, n.UnixMilli())
 	if err != nil {
 		log.Printf("[reaper] workflow v2 timeout query: %v", err)
 		return
@@ -408,41 +408,14 @@ func (s *Server) reapWorkflowV2RunTimeouts(n time.Time, take func() bool) {
 		if !take() {
 			return
 		}
-		if err := s.cancelWorkflowV2RunByID(context.Background(), n, r.id, "run timed out"); err != nil {
+		// Use the existing activation-cancellation path so child effects,
+		// effect attempts, control messages, and agent tasks are all cancelled
+		// transactionally with the parent run.
+		if err := workflowv2.NewStore(s.db).CancelActivation(context.Background(), r.id, "run timed out"); err != nil {
 			log.Printf("[reaper] failed to cancel timed-out workflow v2 run %s: %v", r.id, err)
 			continue
 		}
 		log.Printf("[reaper] cancelled timed-out workflow v2 run %s", r.id)
 		s.maybeFinishWorkflowV2Parent(context.Background(), r.id)
 	}
-}
-
-// cancelWorkflowV2RunByID marks a run and its active attempt as cancelled/lost.
-// It is idempotent when the run is already terminal.
-func (s *Server) cancelWorkflowV2RunByID(ctx context.Context, n time.Time, runID, reason string) error {
-	now := n.UnixMilli()
-	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-
-	res, err := tx.ExecContext(ctx, `
-		UPDATE workflow_v2_runs
-		SET status='cancelled', state='cancelled', display_phase='done', waiting_reason=?, finished_at=?, updated_at=?
-		WHERE id=? AND status IN ('active','suspended')`, reason, now, now, runID)
-	if err != nil {
-		return err
-	}
-	if changed, _ := res.RowsAffected(); changed == 0 {
-		return nil
-	}
-	_, err = tx.ExecContext(ctx, `
-		UPDATE workflow_v2_attempts
-		SET status='lost', finished_at=?, reason=?
-		WHERE run_id=? AND status='active'`, now, reason, runID)
-	if err != nil {
-		return err
-	}
-	return tx.Commit()
 }

--- a/pkg/hub/reaper.go
+++ b/pkg/hub/reaper.go
@@ -1,6 +1,8 @@
 package hub
 
 import (
+	"context"
+	"database/sql"
 	"log"
 	"time"
 
@@ -369,7 +371,78 @@ func (s *Server) reapOnce() {
 		}
 	}
 	s.reaperMu.Unlock()
+
+	s.reapWorkflowV2RunTimeouts(n, take)
+
 	if actions > 0 {
 		s.promotePendingClaws()
 	}
+}
+
+// reapWorkflowV2RunTimeouts cancels v2 workflow runs that exceeded their
+// timeout_at (or, for legacy rows without one, their created_at plus the default
+// run timeout). A cancelled run then triggers the normal parent-cleanup path.
+func (s *Server) reapWorkflowV2RunTimeouts(n time.Time, take func() bool) {
+	defaultDeadline := n.Add(-workflowV2DefaultRunTimeout).UnixMilli()
+	rows, err := s.db.Query(`
+		SELECT r.id FROM workflow_v2_runs r
+		WHERE r.status IN ('active','suspended')
+		AND ((r.timeout_at > 0 AND r.timeout_at < ?) OR (r.timeout_at = 0 AND r.created_at < ?))
+		ORDER BY r.created_at`, n.UnixMilli(), defaultDeadline)
+	if err != nil {
+		log.Printf("[reaper] workflow v2 timeout query: %v", err)
+		return
+	}
+	defer rows.Close()
+	type run struct{ id string }
+	var runs []run
+	for rows.Next() {
+		var r run
+		if err := rows.Scan(&r.id); err == nil {
+			runs = append(runs, r)
+		}
+	}
+	rows.Close()
+
+	for _, r := range runs {
+		if !take() {
+			return
+		}
+		if err := s.cancelWorkflowV2RunByID(context.Background(), n, r.id, "run timed out"); err != nil {
+			log.Printf("[reaper] failed to cancel timed-out workflow v2 run %s: %v", r.id, err)
+			continue
+		}
+		log.Printf("[reaper] cancelled timed-out workflow v2 run %s", r.id)
+		s.maybeFinishWorkflowV2Parent(context.Background(), r.id)
+	}
+}
+
+// cancelWorkflowV2RunByID marks a run and its active attempt as cancelled/lost.
+// It is idempotent when the run is already terminal.
+func (s *Server) cancelWorkflowV2RunByID(ctx context.Context, n time.Time, runID, reason string) error {
+	now := n.UnixMilli()
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	res, err := tx.ExecContext(ctx, `
+		UPDATE workflow_v2_runs
+		SET status='cancelled', state='cancelled', display_phase='done', waiting_reason=?, finished_at=?, updated_at=?
+		WHERE id=? AND status IN ('active','suspended')`, reason, now, now, runID)
+	if err != nil {
+		return err
+	}
+	if changed, _ := res.RowsAffected(); changed == 0 {
+		return nil
+	}
+	_, err = tx.ExecContext(ctx, `
+		UPDATE workflow_v2_attempts
+		SET status='lost', finished_at=?, reason=?
+		WHERE run_id=? AND status='active'`, now, reason, runID)
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
 }

--- a/pkg/hub/reaper_test.go
+++ b/pkg/hub/reaper_test.go
@@ -497,3 +497,56 @@ func TestCancelWorkflowV2RunForClawCancelsActiveRun(t *testing.T) {
 		t.Fatalf("attempt status = %q, want cancelled", attemptStatus)
 	}
 }
+
+func TestReleaseWorkflowV2CronSlotLoadsBeforeMarker(t *testing.T) {
+	s, db := newReaperTestServer(t, &types.HubConfig{})
+	s.cronSchedulerV2 = newCronSchedulerV2(s)
+	s.cronSchedulerV2.running["ws/wf"] = 1
+	now := time.Now().UTC()
+
+	if _, err := db.Exec(`INSERT INTO workflow_v2_runs(
+		id,tenant_id,workspace_name,workflow_name,workspace_revision,workflow_revision,
+		workspace_yaml,workflow_yaml,state,display_phase,state_version,status,waiting_reason,
+		current_attempt_id,task_run_id,trigger_type,timeout_at,created_at,updated_at,finished_at,
+		cron_slot_released
+	) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		"run-cron", "tenant", "ws", "wf", "rev", "rev", "", "", "done", "done", 1, "cancelled", "",
+		"att-cron", "", "cron", 0, now.UnixMilli(), now.UnixMilli(), now.UnixMilli(), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// A cancelled context should fail the run load before the marker is flipped,
+	// so the slot can still be released on retry.
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	s.releaseWorkflowV2CronSlot(cancelledCtx, "run-cron")
+
+	var marker int
+	if err := db.QueryRow(`SELECT cron_slot_released FROM workflow_v2_runs WHERE id='run-cron'`).Scan(&marker); err != nil {
+		t.Fatal(err)
+	}
+	if marker != 0 {
+		t.Fatalf("cron_slot_released = %d, want 0 (marker consumed before load succeeded)", marker)
+	}
+	if s.cronSchedulerV2.running["ws/wf"] != 1 {
+		t.Fatalf("running counter was decremented despite load failure")
+	}
+
+	// On a valid context the slot is released exactly once.
+	s.releaseWorkflowV2CronSlot(context.Background(), "run-cron")
+	if err := db.QueryRow(`SELECT cron_slot_released FROM workflow_v2_runs WHERE id='run-cron'`).Scan(&marker); err != nil {
+		t.Fatal(err)
+	}
+	if marker != 1 {
+		t.Fatalf("cron_slot_released = %d, want 1", marker)
+	}
+	if s.cronSchedulerV2.running["ws/wf"] != 0 {
+		t.Fatalf("running counter = %d, want 0", s.cronSchedulerV2.running["ws/wf"])
+	}
+
+	// Idempotent: a second call does not decrement below zero.
+	s.releaseWorkflowV2CronSlot(context.Background(), "run-cron")
+	if s.cronSchedulerV2.running["ws/wf"] != 0 {
+		t.Fatalf("running counter decremented twice, got %d", s.cronSchedulerV2.running["ws/wf"])
+	}
+}

--- a/pkg/hub/reaper_test.go
+++ b/pkg/hub/reaper_test.go
@@ -406,12 +406,12 @@ func TestReaperCancelsTimedOutWorkflowV2Run(t *testing.T) {
 	if err := db.QueryRow(`SELECT status FROM workflow_v2_attempts WHERE id='att-timeout'`).Scan(&attemptStatus); err != nil {
 		t.Fatal(err)
 	}
-	if attemptStatus != "lost" {
-		t.Fatalf("attempt status = %q, want lost", attemptStatus)
+	if attemptStatus != "cancelled" {
+		t.Fatalf("attempt status = %q, want cancelled", attemptStatus)
 	}
 }
 
-func TestReaperCancelsLegacyWorkflowV2RunWithoutTimeout(t *testing.T) {
+func TestReaperLeavesLegacyWorkflowV2RunWithoutTimeout(t *testing.T) {
 	s, db := newReaperTestServer(t, &types.HubConfig{})
 	tm := time.Now().UTC()
 	s.nowFunc = func() time.Time { return tm }
@@ -424,8 +424,8 @@ func TestReaperCancelsLegacyWorkflowV2RunWithoutTimeout(t *testing.T) {
 	if err := db.QueryRow(`SELECT status FROM workflow_v2_runs WHERE id='run-legacy'`).Scan(&status); err != nil {
 		t.Fatal(err)
 	}
-	if status != "cancelled" {
-		t.Fatalf("run status = %q, want cancelled", status)
+	if status != "active" {
+		t.Fatalf("run status = %q, want active (legacy rows without timeout_at must not be auto-cancelled)", status)
 	}
 }
 
@@ -493,7 +493,7 @@ func TestCancelWorkflowV2RunForClawCancelsActiveRun(t *testing.T) {
 	if err := db.QueryRow(`SELECT status FROM workflow_v2_attempts WHERE id='att-dead'`).Scan(&attemptStatus); err != nil {
 		t.Fatal(err)
 	}
-	if attemptStatus != "lost" {
-		t.Fatalf("attempt status = %q, want lost", attemptStatus)
+	if attemptStatus != "cancelled" {
+		t.Fatalf("attempt status = %q, want cancelled", attemptStatus)
 	}
 }

--- a/pkg/hub/reaper_test.go
+++ b/pkg/hub/reaper_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"net/http"
@@ -465,5 +466,34 @@ func insertWorkflowV2Run(t *testing.T, db *sql.DB, runID, attemptID string, time
 		VALUES(?,?,?,?,?,?,?)`,
 		attemptID, runID, "claw-"+runID, 1, "active", createdAt.UnixMilli(), createdAt.UnixMilli()); err != nil {
 		t.Fatalf("insert attempt: %v", err)
+	}
+}
+
+func TestCancelWorkflowV2RunForClawCancelsActiveRun(t *testing.T) {
+	s, db := newReaperTestServer(t, &types.HubConfig{})
+	now := time.Now().UTC()
+	if _, err := db.Exec(`INSERT INTO claws(id,tenant_id,name,template,provider,status,created_at) VALUES(?,?,?,?,?,?,?)`,
+		"claw-dead", "tenant", "dead", "ws", "replicated", "deleted", now); err != nil {
+		t.Fatal(err)
+	}
+	insertWorkflowV2Run(t, db, "run-dead", "att-dead", now.Add(time.Hour), now)
+	if _, err := db.Exec(`UPDATE workflow_v2_attempts SET claw_id=? WHERE id=?`, "claw-dead", "att-dead"); err != nil {
+		t.Fatal(err)
+	}
+
+	s.cancelWorkflowV2RunForClaw(context.Background(), "claw-dead", "claw deleted")
+
+	var status, attemptStatus string
+	if err := db.QueryRow(`SELECT status FROM workflow_v2_runs WHERE id='run-dead'`).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "cancelled" {
+		t.Fatalf("run status = %q, want cancelled", status)
+	}
+	if err := db.QueryRow(`SELECT status FROM workflow_v2_attempts WHERE id='att-dead'`).Scan(&attemptStatus); err != nil {
+		t.Fatal(err)
+	}
+	if attemptStatus != "lost" {
+		t.Fatalf("attempt status = %q, want lost", attemptStatus)
 	}
 }

--- a/pkg/hub/reaper_test.go
+++ b/pkg/hub/reaper_test.go
@@ -385,3 +385,85 @@ stages:
 		}
 	})
 }
+
+func TestReaperCancelsTimedOutWorkflowV2Run(t *testing.T) {
+	s, db := newReaperTestServer(t, &types.HubConfig{})
+	tm := time.Now().UTC()
+	s.nowFunc = func() time.Time { return tm }
+
+	insertWorkflowV2Run(t, db, "run-timeout", "att-timeout", tm.Add(-time.Hour), tm.Add(-time.Hour))
+
+	s.reapOnce()
+
+	var status, attemptStatus string
+	if err := db.QueryRow(`SELECT status FROM workflow_v2_runs WHERE id='run-timeout'`).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "cancelled" {
+		t.Fatalf("run status = %q, want cancelled", status)
+	}
+	if err := db.QueryRow(`SELECT status FROM workflow_v2_attempts WHERE id='att-timeout'`).Scan(&attemptStatus); err != nil {
+		t.Fatal(err)
+	}
+	if attemptStatus != "lost" {
+		t.Fatalf("attempt status = %q, want lost", attemptStatus)
+	}
+}
+
+func TestReaperCancelsLegacyWorkflowV2RunWithoutTimeout(t *testing.T) {
+	s, db := newReaperTestServer(t, &types.HubConfig{})
+	tm := time.Now().UTC()
+	s.nowFunc = func() time.Time { return tm }
+
+	insertWorkflowV2Run(t, db, "run-legacy", "att-legacy", time.Time{}, tm.Add(-workflowV2DefaultRunTimeout-time.Hour))
+
+	s.reapOnce()
+
+	var status string
+	if err := db.QueryRow(`SELECT status FROM workflow_v2_runs WHERE id='run-legacy'`).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "cancelled" {
+		t.Fatalf("run status = %q, want cancelled", status)
+	}
+}
+
+func TestReaperLeavesWorkflowV2RunWithinTimeout(t *testing.T) {
+	s, db := newReaperTestServer(t, &types.HubConfig{})
+	tm := time.Now().UTC()
+	s.nowFunc = func() time.Time { return tm }
+
+	insertWorkflowV2Run(t, db, "run-fresh", "att-fresh", tm.Add(time.Hour), tm)
+
+	s.reapOnce()
+
+	var status string
+	if err := db.QueryRow(`SELECT status FROM workflow_v2_runs WHERE id='run-fresh'`).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "active" {
+		t.Fatalf("run status = %q, want active", status)
+	}
+}
+
+func insertWorkflowV2Run(t *testing.T, db *sql.DB, runID, attemptID string, timeoutAt, createdAt time.Time) {
+	t.Helper()
+	timeoutMillis := int64(0)
+	if !timeoutAt.IsZero() {
+		timeoutMillis = timeoutAt.UnixMilli()
+	}
+	if _, err := db.Exec(`INSERT INTO workflow_v2_runs(
+		id,tenant_id,workspace_name,workflow_name,workspace_revision,workflow_revision,
+		workspace_yaml,workflow_yaml,state,display_phase,state_version,status,waiting_reason,
+		current_attempt_id,task_run_id,trigger_type,timeout_at,created_at,updated_at,finished_at
+	) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		runID, "tenant", "ws", "wf", "rev", "rev", "", "", "building", "build", 1, "active", "",
+		attemptID, "", "manual", timeoutMillis, createdAt.UnixMilli(), createdAt.UnixMilli(), 0); err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO workflow_v2_attempts(id,run_id,claw_id,number,status,started_at,heartbeat_at)
+		VALUES(?,?,?,?,?,?,?)`,
+		attemptID, runID, "claw-"+runID, 1, "active", createdAt.UnixMilli(), createdAt.UnixMilli()); err != nil {
+		t.Fatalf("insert attempt: %v", err)
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -174,6 +174,9 @@ type Server struct {
 	// cronScheduler manages scheduled workflow runs
 	cronScheduler *cronScheduler
 
+	// cronSchedulerV2 manages scheduled workflow v2 runs
+	cronSchedulerV2 *cronSchedulerV2
+
 	// Reaper state is deliberately in-memory: its conservative timers reset on
 	// a hub restart rather than treating an uncertain outage as an agent failure.
 	reaperMu            sync.Mutex
@@ -595,6 +598,10 @@ func NewServer(addr, dbPath, identityDir string, hubCfg *types.HubConfig) (*Serv
 	srv.cronScheduler = newCronScheduler(srv)
 	if err := srv.cronScheduler.start(); err != nil {
 		log.Printf("[cron] failed to start scheduler: %v", err)
+	}
+	srv.cronSchedulerV2 = newCronSchedulerV2(srv)
+	if err := srv.cronSchedulerV2.start(); err != nil {
+		log.Printf("[cron-v2] failed to start scheduler: %v", err)
 	}
 	srv.startIntegrationPoller()
 	srv.startLifecycleNotifier()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -681,11 +681,17 @@ func (s *Server) run(ctx context.Context, opts ...RunOptions) error {
 		// ListenAndServe returns as soon as Shutdown starts. Wait for it to
 		// finish draining active requests before closing their database.
 		<-shutdownDone
-		// Stop the notifier loops and dependency watcher before the DB closes: a tick in flight
-		// could otherwise complete an external Slack send and then fail the
-		// delivery-row insert (or scheduled dedupe-state upsert) against the
-		// closed DB, re-sending the event after restart (the in-memory retry
-		// stash dies with the process).
+		// Stop the notifier loops, cron schedulers, and dependency watcher
+		// before the DB closes: a tick in flight could otherwise complete an
+		// external send and then fail the delivery-row insert (or scheduled
+		// dedupe-state upsert) against the closed DB, re-sending the event
+		// after restart (the in-memory retry stash dies with the process).
+		if s.cronScheduler != nil {
+			s.cronScheduler.stop()
+		}
+		if s.cronSchedulerV2 != nil {
+			s.cronSchedulerV2.stop()
+		}
 		s.stopLifecycleNotifier(10 * time.Second)
 		s.stopScheduledNotifier(10 * time.Second)
 		s.stopInfraNotifier(10 * time.Second)

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -288,6 +288,7 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 		if err := opts.beforeProvision(callbackCtx, clawID, tenantID); err != nil {
 			_, _ = s.finishClawTerminalTx(clawID, "deleted", "", "failed",
 				"workflow v2 activation failed: "+err.Error(), terminalTxOpts{})
+			s.cancelWorkflowV2RunForClaw(callbackCtx, clawID, "workflow v2 activation failed")
 			go s.promotePendingClaws()
 			return "", false, fmt.Errorf("activate workflow v2 run: %w", err)
 		}
@@ -352,6 +353,7 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 		if provErr != nil {
 			log.Printf("[workflow] provision failed for %s: %v", clawID, provErr)
 			s.stopAgentWithReason(clawID, fmt.Sprintf("Workflow provision failed: %v", provErr), false)
+			s.cancelWorkflowV2RunForClaw(context.Background(), clawID, "claw provision failed")
 		}
 	}()
 

--- a/pkg/hub/workflow_creator.go
+++ b/pkg/hub/workflow_creator.go
@@ -29,6 +29,9 @@ type workflowCreateOptions struct {
 	issueCreatedAt       time.Time
 	reason               string
 	triggerActor         *triggerActor
+	// tenantID, if set, overrides the default first-tenant fallback for the
+	// claw/task-run creation. Empty values keep the existing behavior.
+	tenantID string
 	// beforeProvision runs after the claw and analytics row exist but before
 	// provider work begins. Workflow v2 uses it to atomically create the run and
 	// initial attempt, closing the bridge-registration race.
@@ -100,9 +103,11 @@ func (s *Server) createClawFromWorkflowWithOptions(workspace *types.WorkspaceCon
 		}
 	}
 
-	var tenantID string
-	if err := s.db.QueryRow(`SELECT id FROM tenants LIMIT 1`).Scan(&tenantID); err != nil {
-		return "", false, fmt.Errorf("no tenant: %w", err)
+	tenantID := opts.tenantID
+	if strings.TrimSpace(tenantID) == "" {
+		if err := s.db.QueryRow(`SELECT id FROM tenants LIMIT 1`).Scan(&tenantID); err != nil {
+			return "", false, fmt.Errorf("no tenant: %w", err)
+		}
 	}
 
 	provider := workflow.Provider

--- a/pkg/hub/workflow_v2_activation.go
+++ b/pkg/hub/workflow_v2_activation.go
@@ -75,6 +75,7 @@ func (s *Server) triggerWorkflowV2Config(w http.ResponseWriter, r *http.Request,
 				ID: runID, TenantID: tenantID, InitialClawID: clawID, TaskRunID: taskRunID,
 				WorkspaceYAML: workspaceYAML, WorkflowYAML: workflowYAML, ActivationPending: true,
 				TriggerType: "manual",
+				Timeout:     workflowV2RunTimeout(workflow.RawConfig),
 			})
 			if err != nil {
 				return err

--- a/pkg/hub/workflow_v2_activation.go
+++ b/pkg/hub/workflow_v2_activation.go
@@ -92,6 +92,10 @@ func (s *Server) triggerWorkflowV2Config(w http.ResponseWriter, r *http.Request,
 			if cleanupErr := store.CancelActivation(cleanupCtx, run.ID, err.Error()); cleanupErr != nil {
 				return errors.Join(err, fmt.Errorf("cancel failed workflow v2 activation: %w", cleanupErr))
 			}
+			// Release the cron overlap slot immediately for cron-triggered runs. The
+			// terminal cleanup hook will not run because cancelWorkflowV2RunForClaw
+			// only looks for active/suspended runs.
+			s.releaseWorkflowV2CronSlot(cleanupCtx, run.ID)
 			return err
 		},
 	})

--- a/pkg/hub/workflow_v2_terminal.go
+++ b/pkg/hub/workflow_v2_terminal.go
@@ -29,9 +29,17 @@ func (s *Server) maybeFinishWorkflowV2Parent(ctx context.Context, runID string) 
 	if run.Status != workflowv2.RunCompleted && run.Status != workflowv2.RunCancelled {
 		return
 	}
-	if s.cronSchedulerV2 != nil {
+	if s.cronSchedulerV2 != nil && run.TriggerType == "cron" {
 		s.cronSchedulerV2.finishRunByV2RunID(run.ID, run.Status)
-		s.cronSchedulerV2.decrementRunning(run.WorkspaceName + "/" + run.WorkflowName)
+		// Only release the in-memory overlap slot once. A run observed as
+		// terminal multiple times must not decrement the counter for another
+		// active cron execution of the same workflow.
+		res, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_runs SET cron_slot_released=1 WHERE id=? AND cron_slot_released=0`, run.ID)
+		if err != nil {
+			log.Printf("[workflow-v2] failed to mark cron slot released for run %s: %v", runID, err)
+		} else if changed, _ := res.RowsAffected(); changed == 1 {
+			s.cronSchedulerV2.decrementRunning(run.WorkspaceName + "/" + run.WorkflowName)
+		}
 	}
 	if strings.TrimSpace(run.TaskRunID) == "" {
 		// No parent task run; nothing to finish.
@@ -101,8 +109,9 @@ func (s *Server) maybeFinishWorkflowV2Parent(ctx context.Context, runID string) 
 }
 
 // cancelWorkflowV2RunForClaw cancels the active/suspended workflow v2 run bound
-// to the given claw. It is used when a claw fails before the v2 run can reach a
-// terminal state on its own (e.g. provisioning failed).
+// to the given claw, including all child effects/tasks so nothing remains
+// assigned to the dead claw. It is used when a claw fails before the v2 run
+// can reach a terminal state on its own (e.g. provisioning failed).
 func (s *Server) cancelWorkflowV2RunForClaw(ctx context.Context, clawID, reason string) {
 	if s == nil || s.db == nil {
 		return
@@ -119,7 +128,7 @@ func (s *Server) cancelWorkflowV2RunForClaw(ctx context.Context, clawID, reason 
 		}
 		return
 	}
-	if err := s.cancelWorkflowV2RunByID(ctx, now().UTC(), runID, reason); err != nil {
+	if err := workflowv2.NewStore(s.db).CancelActivation(ctx, runID, reason); err != nil {
 		log.Printf("[workflow-v2] failed to cancel run %s for claw %s: %v", runID[:8], clawID[:8], err)
 		return
 	}

--- a/pkg/hub/workflow_v2_terminal.go
+++ b/pkg/hub/workflow_v2_terminal.go
@@ -31,16 +31,8 @@ func (s *Server) maybeFinishWorkflowV2Parent(ctx context.Context, runID string) 
 	}
 	if s.cronSchedulerV2 != nil && run.TriggerType == "cron" {
 		s.cronSchedulerV2.finishRunByV2RunID(run.ID, run.Status)
-		// Only release the in-memory overlap slot once. A run observed as
-		// terminal multiple times must not decrement the counter for another
-		// active cron execution of the same workflow.
-		res, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_runs SET cron_slot_released=1 WHERE id=? AND cron_slot_released=0`, run.ID)
-		if err != nil {
-			log.Printf("[workflow-v2] failed to mark cron slot released for run %s: %v", runID, err)
-		} else if changed, _ := res.RowsAffected(); changed == 1 {
-			s.cronSchedulerV2.decrementRunning(run.WorkspaceName + "/" + run.WorkflowName)
-		}
 	}
+	s.releaseWorkflowV2CronSlot(ctx, run.ID)
 	if strings.TrimSpace(run.TaskRunID) == "" {
 		// No parent task run; nothing to finish.
 		return
@@ -106,6 +98,36 @@ func (s *Server) maybeFinishWorkflowV2Parent(ctx context.Context, runID string) 
 		delete(s.claws, clawID)
 	}
 	s.mu.Unlock()
+}
+
+// releaseWorkflowV2CronSlot releases the in-memory overlap slot for a terminal
+// v2 cron run exactly once. It does not update the cron history row; callers
+// that need to record a failure reason should finish that row separately. The
+// release is idempotent via cron_slot_released.
+func (s *Server) releaseWorkflowV2CronSlot(ctx context.Context, runID string) {
+	if s == nil || s.db == nil || s.cronSchedulerV2 == nil || runID == "" {
+		return
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_runs SET cron_slot_released=1 WHERE id=? AND cron_slot_released=0`, runID)
+	if err != nil {
+		log.Printf("[workflow-v2] failed to mark cron slot released for run %s: %v", runID, err)
+		return
+	}
+	if changed, _ := res.RowsAffected(); changed != 1 {
+		return
+	}
+	run, err := workflowv2.NewStore(s.db).GetRun(ctx, runID)
+	if err != nil {
+		log.Printf("[workflow-v2] cannot load run %s for slot release: %v", runID, err)
+		return
+	}
+	if run.TriggerType != "cron" {
+		return
+	}
+	if run.Status != workflowv2.RunCompleted && run.Status != workflowv2.RunCancelled {
+		return
+	}
+	s.cronSchedulerV2.decrementRunning(run.WorkspaceName + "/" + run.WorkflowName)
 }
 
 // cancelWorkflowV2RunForClaw cancels the active/suspended workflow v2 run bound

--- a/pkg/hub/workflow_v2_terminal.go
+++ b/pkg/hub/workflow_v2_terminal.go
@@ -28,6 +28,9 @@ func (s *Server) maybeFinishWorkflowV2Parent(ctx context.Context, runID string) 
 	if run.Status != workflowv2.RunCompleted && run.Status != workflowv2.RunCancelled {
 		return
 	}
+	if s.cronSchedulerV2 != nil {
+		s.cronSchedulerV2.finishRunByV2RunID(run.ID, run.Status)
+	}
 	if strings.TrimSpace(run.TaskRunID) == "" {
 		// No parent task run; nothing to finish.
 		return

--- a/pkg/hub/workflow_v2_terminal.go
+++ b/pkg/hub/workflow_v2_terminal.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"log"
 	"strings"
 	"time"
@@ -97,4 +98,31 @@ func (s *Server) maybeFinishWorkflowV2Parent(ctx context.Context, runID string) 
 		delete(s.claws, clawID)
 	}
 	s.mu.Unlock()
+}
+
+// cancelWorkflowV2RunForClaw cancels the active/suspended workflow v2 run bound
+// to the given claw. It is used when a claw fails before the v2 run can reach a
+// terminal state on its own (e.g. provisioning failed).
+func (s *Server) cancelWorkflowV2RunForClaw(ctx context.Context, clawID, reason string) {
+	if s == nil || s.db == nil {
+		return
+	}
+	var runID string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT a.run_id FROM workflow_v2_attempts a
+		JOIN workflow_v2_runs r ON r.id=a.run_id
+		WHERE a.claw_id=? AND a.status='active' AND r.status IN ('active','suspended')
+		LIMIT 1`, clawID).Scan(&runID)
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			log.Printf("[workflow-v2] failed to find active run for claw %s: %v", clawID[:8], err)
+		}
+		return
+	}
+	if err := s.cancelWorkflowV2RunByID(ctx, now().UTC(), runID, reason); err != nil {
+		log.Printf("[workflow-v2] failed to cancel run %s for claw %s: %v", runID[:8], clawID[:8], err)
+		return
+	}
+	log.Printf("[workflow-v2] cancelled run %s because claw %s %s", runID[:8], clawID[:8], reason)
+	s.maybeFinishWorkflowV2Parent(ctx, runID)
 }

--- a/pkg/hub/workflow_v2_terminal.go
+++ b/pkg/hub/workflow_v2_terminal.go
@@ -30,6 +30,7 @@ func (s *Server) maybeFinishWorkflowV2Parent(ctx context.Context, runID string) 
 	}
 	if s.cronSchedulerV2 != nil {
 		s.cronSchedulerV2.finishRunByV2RunID(run.ID, run.Status)
+		s.cronSchedulerV2.decrementRunning(run.WorkspaceName + "/" + run.WorkflowName)
 	}
 	if strings.TrimSpace(run.TaskRunID) == "" {
 		// No parent task run; nothing to finish.

--- a/pkg/hub/workflow_v2_terminal.go
+++ b/pkg/hub/workflow_v2_terminal.go
@@ -108,14 +108,9 @@ func (s *Server) releaseWorkflowV2CronSlot(ctx context.Context, runID string) {
 	if s == nil || s.db == nil || s.cronSchedulerV2 == nil || runID == "" {
 		return
 	}
-	res, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_runs SET cron_slot_released=1 WHERE id=? AND cron_slot_released=0`, runID)
-	if err != nil {
-		log.Printf("[workflow-v2] failed to mark cron slot released for run %s: %v", runID, err)
-		return
-	}
-	if changed, _ := res.RowsAffected(); changed != 1 {
-		return
-	}
+	// Load and validate the run before consuming the idempotency marker. If the
+	// read fails, a retry can still finish the release because the marker has not
+	// been flipped.
 	run, err := workflowv2.NewStore(s.db).GetRun(ctx, runID)
 	if err != nil {
 		log.Printf("[workflow-v2] cannot load run %s for slot release: %v", runID, err)
@@ -125,6 +120,14 @@ func (s *Server) releaseWorkflowV2CronSlot(ctx context.Context, runID string) {
 		return
 	}
 	if run.Status != workflowv2.RunCompleted && run.Status != workflowv2.RunCancelled {
+		return
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE workflow_v2_runs SET cron_slot_released=1 WHERE id=? AND cron_slot_released=0`, runID)
+	if err != nil {
+		log.Printf("[workflow-v2] failed to mark cron slot released for run %s: %v", runID, err)
+		return
+	}
+	if changed, _ := res.RowsAffected(); changed != 1 {
 		return
 	}
 	s.cronSchedulerV2.decrementRunning(run.WorkspaceName + "/" + run.WorkflowName)

--- a/pkg/hub/workflow_v2_timeout.go
+++ b/pkg/hub/workflow_v2_timeout.go
@@ -1,0 +1,33 @@
+package hub
+
+import (
+	"strings"
+	"time"
+
+	typesv2 "github.com/elasticclaw/elasticclaw/pkg/types/v2"
+)
+
+// workflowV2DefaultRunTimeout is the safety-net bound for how long a v2 run may
+// stay active/suspended before the reaper cancels it. A workflow can set a
+// stricter per-run timeout via trigger.cron.timeout.
+const workflowV2DefaultRunTimeout = 24 * time.Hour
+
+// workflowV2RunTimeout returns the timeout for a workflow v2 run. If the
+// workflow has a cron trigger with a valid timeout duration, that value is used;
+// otherwise a conservative default keeps long-running agent tasks safe.
+func workflowV2RunTimeout(rawConfig string) time.Duration {
+	resolved, err := typesv2.ParseAndValidateWorkflow([]byte(rawConfig))
+	if err != nil || resolved == nil || resolved.Workflow == nil ||
+		resolved.Workflow.Trigger == nil || resolved.Workflow.Trigger.Cron == nil {
+		return workflowV2DefaultRunTimeout
+	}
+	timeout := strings.TrimSpace(resolved.Workflow.Trigger.Cron.Timeout)
+	if timeout == "" {
+		return workflowV2DefaultRunTimeout
+	}
+	d, err := time.ParseDuration(timeout)
+	if err != nil || d <= 0 {
+		return workflowV2DefaultRunTimeout
+	}
+	return d
+}

--- a/pkg/hub/workflow_v2_timeout.go
+++ b/pkg/hub/workflow_v2_timeout.go
@@ -14,7 +14,8 @@ const workflowV2DefaultRunTimeout = 24 * time.Hour
 
 // workflowV2RunTimeout returns the timeout for a workflow v2 run. If the
 // workflow has a cron trigger with a valid timeout duration, that value is used;
-// otherwise a conservative default keeps long-running agent tasks safe.
+// an explicit zero duration disables the run-level timeout; otherwise a
+// conservative default keeps long-running agent tasks safe.
 func workflowV2RunTimeout(rawConfig string) time.Duration {
 	resolved, err := typesv2.ParseAndValidateWorkflow([]byte(rawConfig))
 	if err != nil || resolved == nil || resolved.Workflow == nil ||
@@ -26,7 +27,7 @@ func workflowV2RunTimeout(rawConfig string) time.Duration {
 		return workflowV2DefaultRunTimeout
 	}
 	d, err := time.ParseDuration(timeout)
-	if err != nil || d <= 0 {
+	if err != nil || d < 0 {
 		return workflowV2DefaultRunTimeout
 	}
 	return d

--- a/pkg/hub/workflow_v2_timeout_test.go
+++ b/pkg/hub/workflow_v2_timeout_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -58,6 +59,36 @@ trigger:
 		got := workflowV2RunTimeout(raw)
 		if got != workflowV2DefaultRunTimeout {
 			t.Fatalf("timeout for %q = %v, want default %v", raw, got, workflowV2DefaultRunTimeout)
+		}
+	}
+}
+
+func TestWorkflowV2RunTimeoutZeroDisables(t *testing.T) {
+	cases := []string{
+		"0",
+		"0s",
+		"0m",
+		"0h",
+	}
+	base := `
+schema_version: 2
+name: disabled-timeout
+enabled: true
+initial_state: done
+states:
+  done:
+    phase: done
+    terminal: true
+trigger:
+  cron:
+    schedule: "0 0 * * *"
+    timeout: %q
+`
+	for _, timeout := range cases {
+		raw := fmt.Sprintf(base, timeout)
+		got := workflowV2RunTimeout(raw)
+		if got != 0 {
+			t.Fatalf("timeout for %q = %v, want 0", timeout, got)
 		}
 	}
 }

--- a/pkg/hub/workflow_v2_timeout_test.go
+++ b/pkg/hub/workflow_v2_timeout_test.go
@@ -1,0 +1,63 @@
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWorkflowV2RunTimeoutUsesCronTriggerTimeout(t *testing.T) {
+	raw := `
+schema_version: 2
+name: timed
+enabled: true
+initial_state: done
+states:
+  done:
+    phase: done
+    terminal: true
+trigger:
+  cron:
+    schedule: "0 0 * * *"
+    timeout: "90m"
+`
+	got := workflowV2RunTimeout(raw)
+	if got != 90*time.Minute {
+		t.Fatalf("timeout = %v, want 90m", got)
+	}
+}
+
+func TestWorkflowV2RunTimeoutFallsBackToDefault(t *testing.T) {
+	cases := []string{
+		"",
+		`
+schema_version: 2
+name: no-trigger
+enabled: true
+initial_state: done
+states:
+  done:
+    phase: done
+    terminal: true
+`,
+		`
+schema_version: 2
+name: bad-timeout
+enabled: true
+initial_state: done
+states:
+  done:
+    phase: done
+    terminal: true
+trigger:
+  cron:
+    schedule: "0 0 * * *"
+    timeout: "not-a-duration"
+`,
+	}
+	for _, raw := range cases {
+		got := workflowV2RunTimeout(raw)
+		if got != workflowV2DefaultRunTimeout {
+			t.Fatalf("timeout for %q = %v, want default %v", raw, got, workflowV2DefaultRunTimeout)
+		}
+	}
+}

--- a/pkg/hub/workflowv2/cron_history.go
+++ b/pkg/hub/workflowv2/cron_history.go
@@ -1,0 +1,244 @@
+package workflowv2
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// CronRunHistory is one row of cron history for a v2 workflow, matching the
+// shape and semantics of v1's workflow_runs table.
+type CronRunHistory struct {
+	ID            string                 `json:"id"`
+	TenantID      string                 `json:"tenant_id"`
+	WorkspaceName string                 `json:"workspace_name"`
+	WorkflowName  string                 `json:"workflow_name"`
+	TriggerType   string                 `json:"trigger_type"`
+	Status        string                 `json:"status"`
+	Result        string                 `json:"result"`
+	ClawID        string                 `json:"claw_id"`
+	V2RunID       string                 `json:"v2_run_id"`
+	RunContext    map[string]interface{} `json:"run_context"`
+	CreatedAt     time.Time              `json:"created_at"`
+	FinishedAt    *time.Time             `json:"finished_at,omitempty"`
+}
+
+// RecordCronRunStarted inserts a new cron history row in the 'running' state.
+// It returns the generated cron run ID.
+func (s *Store) RecordCronRunStarted(ctx context.Context, tenantID, workspaceName, workflowName, triggerType string, runContext map[string]interface{}) (string, error) {
+	if s == nil || s.db == nil {
+		return "", fmt.Errorf("workflow v2 store is not configured")
+	}
+	id := uuid.NewString()
+	now := s.now().UTC().UnixMilli()
+	runContextJSON, err := marshalRunContext(runContext)
+	if err != nil {
+		return "", err
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO workflow_v2_cron_runs(id, tenant_id, workspace_name, workflow_name, trigger_type, status, run_context, created_at)
+		VALUES(?,?,?,?,?,?,?,?)`,
+		id, tenantID, workspaceName, workflowName, triggerType, "running", runContextJSON, now)
+	if err != nil {
+		return "", fmt.Errorf("record cron run started: %w", err)
+	}
+	return id, nil
+}
+
+// RecordCronRunSkipped inserts a cron history row for a skipped tick.
+func (s *Store) RecordCronRunSkipped(ctx context.Context, tenantID, workspaceName, workflowName, triggerType string, runContext map[string]interface{}) (string, error) {
+	if s == nil || s.db == nil {
+		return "", fmt.Errorf("workflow v2 store is not configured")
+	}
+	id := uuid.NewString()
+	now := s.now().UTC().UnixMilli()
+	runContextJSON, err := marshalRunContext(runContext)
+	if err != nil {
+		return "", err
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO workflow_v2_cron_runs(id, tenant_id, workspace_name, workflow_name, trigger_type, status, result, run_context, created_at, finished_at)
+		VALUES(?,?,?,?,?,?,?,?,?,?)`,
+		id, tenantID, workspaceName, workflowName, triggerType, "skipped", "skipped", runContextJSON, now, now)
+	if err != nil {
+		return "", fmt.Errorf("record cron run skipped: %w", err)
+	}
+	return id, nil
+}
+
+// UpdateCronRunForV2Run links a cron history row to its v2 run and claw.
+func (s *Store) UpdateCronRunForV2Run(ctx context.Context, cronRunID, v2RunID, clawID string) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("workflow v2 store is not configured")
+	}
+	if strings.TrimSpace(cronRunID) == "" {
+		return fmt.Errorf("cron run id is required")
+	}
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE workflow_v2_cron_runs SET v2_run_id=?, claw_id=?, updated_at=?
+		WHERE id=?`, v2RunID, clawID, s.now().UTC().UnixMilli(), cronRunID)
+	if err != nil {
+		return fmt.Errorf("update cron run: %w", err)
+	}
+	return nil
+}
+
+// FinishCronRunByV2RunID marks a cron history row as finished based on the v2
+// run's terminal status. It is a no-op if no matching row exists.
+func (s *Store) FinishCronRunByV2RunID(ctx context.Context, v2RunID string, runStatus RunStatus) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("workflow v2 store is not configured")
+	}
+	if strings.TrimSpace(v2RunID) == "" {
+		return fmt.Errorf("v2 run id is required")
+	}
+	status, result := cronHistoryStatus(runStatus)
+	now := s.now().UTC().UnixMilli()
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE workflow_v2_cron_runs SET status=?, result=?, finished_at=?
+		WHERE v2_run_id=? AND status='running'`, status, result, now, v2RunID)
+	if err != nil {
+		return fmt.Errorf("finish cron run: %w", err)
+	}
+	return nil
+}
+
+// FinishCronRunByClawID marks a cron history row as finished by claw ID. It is
+// a no-op if no matching row exists.
+func (s *Store) FinishCronRunByClawID(ctx context.Context, clawID string, runStatus RunStatus) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("workflow v2 store is not configured")
+	}
+	if strings.TrimSpace(clawID) == "" {
+		return fmt.Errorf("claw id is required")
+	}
+	status, result := cronHistoryStatus(runStatus)
+	now := s.now().UTC().UnixMilli()
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE workflow_v2_cron_runs SET status=?, result=?, finished_at=?
+		WHERE claw_id=? AND status='running'`, status, result, now, clawID)
+	if err != nil {
+		return fmt.Errorf("finish cron run by claw: %w", err)
+	}
+	return nil
+}
+
+// FailCronRun marks a running cron history row as failed.
+func (s *Store) FailCronRun(ctx context.Context, cronRunID, reason string) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("workflow v2 store is not configured")
+	}
+	if strings.TrimSpace(cronRunID) == "" {
+		return fmt.Errorf("cron run id is required")
+	}
+	now := s.now().UTC().UnixMilli()
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE workflow_v2_cron_runs SET status='failed', result='failure', finished_at=?
+		WHERE id=? AND status='running'`, now, cronRunID)
+	if err != nil {
+		return fmt.Errorf("fail cron run: %w", err)
+	}
+	return nil
+}
+
+// ListCronRunHistory returns cron history rows for a workflow, newest first.
+func (s *Store) ListCronRunHistory(ctx context.Context, tenantID, workspaceName, workflowName string, limit int) ([]CronRunHistory, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("workflow v2 store is not configured")
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, tenant_id, workspace_name, workflow_name, trigger_type, status, result, claw_id, v2_run_id, run_context, created_at, finished_at
+		FROM workflow_v2_cron_runs
+		WHERE tenant_id=? AND workspace_name=? AND workflow_name=?
+		ORDER BY created_at DESC, id DESC
+		LIMIT ?`, tenantID, workspaceName, workflowName, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list cron run history: %w", err)
+	}
+	defer rows.Close()
+	var result []CronRunHistory
+	for rows.Next() {
+		h, err := scanCronRunHistory(rows)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, h)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list cron run history: %w", err)
+	}
+	return result, nil
+}
+
+// GetCronRun returns a single cron history row by ID, or nil if not found.
+func (s *Store) GetCronRun(ctx context.Context, tenantID, workspaceName, workflowName, cronRunID string) (*CronRunHistory, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("workflow v2 store is not configured")
+	}
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, tenant_id, workspace_name, workflow_name, trigger_type, status, result, claw_id, v2_run_id, run_context, created_at, finished_at
+		FROM workflow_v2_cron_runs
+		WHERE tenant_id=? AND workspace_name=? AND workflow_name=? AND id=?`, tenantID, workspaceName, workflowName, cronRunID)
+	h, err := scanCronRunHistory(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get cron run: %w", err)
+	}
+	return &h, nil
+}
+
+func scanCronRunHistory(row scanner) (CronRunHistory, error) {
+	var h CronRunHistory
+	var runContextJSON string
+	var created, finished int64
+	err := row.Scan(&h.ID, &h.TenantID, &h.WorkspaceName, &h.WorkflowName, &h.TriggerType, &h.Status, &h.Result,
+		&h.ClawID, &h.V2RunID, &runContextJSON, &created, &finished)
+	if err != nil {
+		return CronRunHistory{}, err
+	}
+	if runContextJSON != "" && runContextJSON != "{}" {
+		_ = json.Unmarshal([]byte(runContextJSON), &h.RunContext)
+	}
+	h.CreatedAt = time.UnixMilli(created).UTC()
+	if finished > 0 {
+		t := time.UnixMilli(finished).UTC()
+		h.FinishedAt = &t
+	}
+	return h, nil
+}
+
+func cronHistoryStatus(runStatus RunStatus) (status, result string) {
+	switch runStatus {
+	case RunCompleted:
+		return "completed", "success"
+	case RunCancelled:
+		return "canceled", "canceled"
+	default:
+		return "failed", "failure"
+	}
+}
+
+func marshalRunContext(runContext map[string]interface{}) (string, error) {
+	if runContext == nil {
+		return "{}", nil
+	}
+	b, err := json.Marshal(runContext)
+	if err != nil {
+		return "{}", fmt.Errorf("marshal run context: %w", err)
+	}
+	return string(b), nil
+}

--- a/pkg/hub/workflowv2/cron_history.go
+++ b/pkg/hub/workflowv2/cron_history.go
@@ -129,7 +129,8 @@ func (s *Store) FinishCronRunByClawID(ctx context.Context, clawID string, runSta
 	return nil
 }
 
-// FailCronRun marks a running cron history row as failed.
+// FailCronRun marks a running cron history row as failed and records the
+// failure reason in its run_context.
 func (s *Store) FailCronRun(ctx context.Context, cronRunID, reason string) error {
 	if s == nil || s.db == nil {
 		return fmt.Errorf("workflow v2 store is not configured")
@@ -138,13 +139,34 @@ func (s *Store) FailCronRun(ctx context.Context, cronRunID, reason string) error
 		return fmt.Errorf("cron run id is required")
 	}
 	now := s.now().UTC().UnixMilli()
-	_, err := s.db.ExecContext(ctx, `
-		UPDATE workflow_v2_cron_runs SET status='failed', result='failure', finished_at=?
-		WHERE id=? AND status='running'`, now, cronRunID)
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
 		return fmt.Errorf("fail cron run: %w", err)
 	}
-	return nil
+	defer tx.Rollback()
+	var runContextJSON string
+	if err := tx.QueryRowContext(ctx, `SELECT run_context FROM workflow_v2_cron_runs WHERE id=? AND status='running'`, cronRunID).Scan(&runContextJSON); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return tx.Commit()
+		}
+		return fmt.Errorf("fail cron run: %w", err)
+	}
+	runContext, err := unmarshalRunContext(runContextJSON)
+	if err != nil {
+		return fmt.Errorf("fail cron run: %w", err)
+	}
+	runContext["failure_reason"] = reason
+	updatedRunContextJSON, err := marshalRunContext(runContext)
+	if err != nil {
+		return fmt.Errorf("fail cron run: %w", err)
+	}
+	_, err = tx.ExecContext(ctx, `
+		UPDATE workflow_v2_cron_runs SET status='failed', result='failure', finished_at=?, run_context=?
+		WHERE id=? AND status='running'`, now, updatedRunContextJSON, cronRunID)
+	if err != nil {
+		return fmt.Errorf("fail cron run: %w", err)
+	}
+	return tx.Commit()
 }
 
 // ListCronRunHistory returns cron history rows for a workflow, newest first.
@@ -241,4 +263,18 @@ func marshalRunContext(runContext map[string]interface{}) (string, error) {
 		return "{}", fmt.Errorf("marshal run context: %w", err)
 	}
 	return string(b), nil
+}
+
+func unmarshalRunContext(runContextJSON string) (map[string]interface{}, error) {
+	if strings.TrimSpace(runContextJSON) == "" || runContextJSON == "{}" {
+		return map[string]interface{}{}, nil
+	}
+	var runContext map[string]interface{}
+	if err := json.Unmarshal([]byte(runContextJSON), &runContext); err != nil {
+		return nil, fmt.Errorf("unmarshal run context: %w", err)
+	}
+	if runContext == nil {
+		return map[string]interface{}{}, nil
+	}
+	return runContext, nil
 }

--- a/pkg/hub/workflowv2/cron_history_test.go
+++ b/pkg/hub/workflowv2/cron_history_test.go
@@ -1,0 +1,102 @@
+package workflowv2_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	workflowv2 "github.com/elasticclaw/elasticclaw/pkg/hub/workflowv2"
+)
+
+func TestFailCronRunRecordsReason(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	fixed := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	store.SetClock(func() time.Time { return fixed })
+
+	cronRunID, err := store.RecordCronRunStarted(context.Background(), "tenant-1", "ws", "wf", "cron", map[string]interface{}{
+		"scheduled_at": fixed.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("record cron run: %v", err)
+	}
+
+	reason := "activation failed: missing knowledge file"
+	if err := store.FailCronRun(context.Background(), cronRunID, reason); err != nil {
+		t.Fatalf("fail cron run: %v", err)
+	}
+
+	row, err := store.GetCronRun(context.Background(), "tenant-1", "ws", "wf", cronRunID)
+	if err != nil {
+		t.Fatalf("get cron run: %v", err)
+	}
+	if row == nil {
+		t.Fatal("expected cron run row, got nil")
+	}
+	if row.Status != "failed" {
+		t.Fatalf("status = %q, want failed", row.Status)
+	}
+	if row.Result != "failure" {
+		t.Fatalf("result = %q, want failure", row.Result)
+	}
+	if row.FinishedAt == nil || !row.FinishedAt.Equal(fixed) {
+		t.Fatalf("finished_at = %v, want %v", row.FinishedAt, fixed)
+	}
+	gotReason, ok := row.RunContext["failure_reason"].(string)
+	if !ok || gotReason != reason {
+		t.Fatalf("run_context.failure_reason = %q (%v), want %q", gotReason, row.RunContext["failure_reason"], reason)
+	}
+	if gotScheduled, ok := row.RunContext["scheduled_at"].(string); !ok || gotScheduled != fixed.Format(time.RFC3339) {
+		t.Fatalf("run_context.scheduled_at lost or changed: %v", row.RunContext["scheduled_at"])
+	}
+}
+
+func TestFailCronRunIdempotentWhenAlreadyTerminal(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+
+	cronRunID, err := store.RecordCronRunSkipped(context.Background(), "tenant-1", "ws", "wf", "cron", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("record skipped cron run: %v", err)
+	}
+
+	if err := store.FailCronRun(context.Background(), cronRunID, "should not overwrite"); err != nil {
+		t.Fatalf("fail cron run on skipped row: %v", err)
+	}
+
+	row, err := store.GetCronRun(context.Background(), "tenant-1", "ws", "wf", cronRunID)
+	if err != nil {
+		t.Fatalf("get cron run: %v", err)
+	}
+	if row == nil {
+		t.Fatal("expected cron run row, got nil")
+	}
+	if row.Status != "skipped" {
+		t.Fatalf("status changed from skipped to %q", row.Status)
+	}
+}
+
+func TestRecordCronRunStartedStoresRunContext(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+
+	ctx := map[string]interface{}{"trigger": "cron", "scheduled_at": "2026-08-08T12:00:00Z"}
+	cronRunID, err := store.RecordCronRunStarted(context.Background(), "tenant-1", "ws", "wf", "cron", ctx)
+	if err != nil {
+		t.Fatalf("record cron run: %v", err)
+	}
+
+	row, err := store.GetCronRun(context.Background(), "tenant-1", "ws", "wf", cronRunID)
+	if err != nil {
+		t.Fatalf("get cron run: %v", err)
+	}
+	if row == nil {
+		t.Fatal("expected cron run row, got nil")
+	}
+	expected, _ := json.Marshal(ctx)
+	actual, _ := json.Marshal(row.RunContext)
+	if string(expected) != string(actual) {
+		t.Fatalf("run_context = %s, want %s", actual, expected)
+	}
+}

--- a/pkg/hub/workflowv2/runtime.go
+++ b/pkg/hub/workflowv2/runtime.go
@@ -78,6 +78,9 @@ type CreateRunRequest struct {
 	// TaskRunID links the v2 run to its parent v1 task run so the hub can
 	// finish the parent and disconnect the claw when the v2 run terminates.
 	TaskRunID string
+	// Timeout bounds how long a run may stay active/suspended before the hub
+	// reaper cancels it. Zero disables the run-level timeout.
+	Timeout time.Duration
 }
 
 type EventInput struct {
@@ -157,6 +160,10 @@ func (s *Store) CreateRun(ctx context.Context, req CreateRunRequest) (Run, error
 	status := RunActive
 	waitingReason := ""
 	finishedAt := int64(0)
+	timeoutAt := int64(0)
+	if req.Timeout > 0 {
+		timeoutAt = now.Add(req.Timeout).UnixMilli()
+	}
 	triggerType := strings.TrimSpace(req.TriggerType)
 	if triggerType == "" {
 		triggerType = "manual"
@@ -183,11 +190,11 @@ func (s *Store) CreateRun(ctx context.Context, req CreateRunRequest) (Run, error
 	}
 	_, err = tx.ExecContext(ctx, `INSERT INTO workflow_v2_runs(
 		id,tenant_id,workspace_name,workflow_name,workspace_revision,workflow_revision,
-		workspace_yaml,workflow_yaml,state,display_phase,state_version,status,waiting_reason,current_attempt_id,task_run_id,trigger_type,created_at,updated_at,finished_at
-	) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		workspace_yaml,workflow_yaml,state,display_phase,state_version,status,waiting_reason,current_attempt_id,task_run_id,trigger_type,timeout_at,created_at,updated_at,finished_at
+	) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		runID, req.TenantID, rws.Workspace.Name, rwf.Workflow.Name, string(rws.Revision), string(rwf.Revision),
 		string(req.WorkspaceYAML), string(req.WorkflowYAML), rwf.Workflow.InitialState, string(initial.Phase), 1, string(status), waitingReason, currentAttemptID,
-		strings.TrimSpace(req.TaskRunID), triggerType,
+		strings.TrimSpace(req.TaskRunID), triggerType, timeoutAt,
 		now.UnixMilli(), now.UnixMilli(), finishedAt)
 	if err != nil {
 		return Run{}, fmt.Errorf("create workflow v2 run: %w", err)

--- a/pkg/hub/workflowv2/runtime_test.go
+++ b/pkg/hub/workflowv2/runtime_test.go
@@ -180,6 +180,30 @@ func TestCreateRunAtomicallyBindsInitialAttempt(t *testing.T) {
 	}
 }
 
+func TestCreateRunStoresTimeoutAt(t *testing.T) {
+	db := openRuntimeDB(t)
+	store := workflowv2.NewStore(db)
+	fixed := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	store.SetClock(func() time.Time { return fixed })
+
+	run, err := store.CreateRun(context.Background(), workflowv2.CreateRunRequest{
+		ID: "run-timeout", TenantID: "tenant-1", InitialClawID: "claw-timeout",
+		WorkspaceYAML: []byte(runtimeWorkspaceYAML), WorkflowYAML: []byte(runtimeWorkflowYAML),
+		Timeout: 90 * time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var timeoutAt int64
+	if err := db.QueryRow(`SELECT timeout_at FROM workflow_v2_runs WHERE id=?`, run.ID).Scan(&timeoutAt); err != nil {
+		t.Fatal(err)
+	}
+	want := fixed.Add(90 * time.Minute).UnixMilli()
+	if timeoutAt != want {
+		t.Fatalf("timeout_at = %d, want %d", timeoutAt, want)
+	}
+}
+
 func TestActivationPendingBlocksEffectsUntilContextIsPinned(t *testing.T) {
 	db := openRuntimeDB(t)
 	store := workflowv2.NewStore(db)

--- a/pkg/hub/workflowv2/schema.go
+++ b/pkg/hub/workflowv2/schema.go
@@ -32,10 +32,11 @@ func Migrate(db *sql.DB) error {
 		current_attempt_id TEXT NOT NULL DEFAULT '',
 		current_task_id    TEXT NOT NULL DEFAULT '',
 		context_bundle_id  TEXT NOT NULL DEFAULT '',
-		trigger_type       TEXT NOT NULL DEFAULT 'manual',
-		task_run_id        TEXT NOT NULL DEFAULT '',
-		timeout_at         INTEGER NOT NULL DEFAULT 0,
-		created_at         INTEGER NOT NULL,
+		trigger_type          TEXT NOT NULL DEFAULT 'manual',
+		task_run_id           TEXT NOT NULL DEFAULT '',
+		timeout_at            INTEGER NOT NULL DEFAULT 0,
+		cron_slot_released    INTEGER NOT NULL DEFAULT 0,
+		created_at            INTEGER NOT NULL,
 		updated_at         INTEGER NOT NULL,
 		finished_at        INTEGER NOT NULL DEFAULT 0
 	);
@@ -302,6 +303,9 @@ func Migrate(db *sql.DB) error {
 		return fmt.Errorf("workflow v2 migrate: %w", err)
 	}
 	if err := addColumnIfMissing(db, "workflow_v2_runs", "timeout_at", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return fmt.Errorf("workflow v2 migrate: %w", err)
+	}
+	if err := addColumnIfMissing(db, "workflow_v2_runs", "cron_slot_released", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return fmt.Errorf("workflow v2 migrate: %w", err)
 	}
 	return nil

--- a/pkg/hub/workflowv2/schema.go
+++ b/pkg/hub/workflowv2/schema.go
@@ -265,11 +265,36 @@ func Migrate(db *sql.DB) error {
 		acknowledged_at  INTEGER NOT NULL DEFAULT 0
 	);
 	CREATE INDEX IF NOT EXISTS idx_workflow_v2_control_ready ON workflow_v2_control_outbox(status, next_attempt_at);
+
+	CREATE TABLE IF NOT EXISTS workflow_v2_cron_runs (
+		id             TEXT PRIMARY KEY,
+		tenant_id      TEXT NOT NULL,
+		workspace_name TEXT NOT NULL,
+		workflow_name  TEXT NOT NULL,
+		trigger_type   TEXT NOT NULL DEFAULT 'cron',
+		status         TEXT NOT NULL DEFAULT 'pending',  -- 'pending','running','completed','failed','skipped','canceled'
+		result         TEXT NOT NULL DEFAULT '',           -- 'success','failure','skipped','canceled'
+		claw_id        TEXT NOT NULL DEFAULT '',
+		v2_run_id      TEXT NOT NULL DEFAULT '',
+		run_context    TEXT NOT NULL DEFAULT '{}' CHECK(json_valid(run_context) AND json_type(run_context)='object'),
+		created_at     INTEGER NOT NULL,
+		updated_at     INTEGER NOT NULL DEFAULT 0,
+		finished_at    INTEGER NOT NULL DEFAULT 0
+	);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_cron_runs_tenant ON workflow_v2_cron_runs(tenant_id, created_at);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_cron_runs_workflow ON workflow_v2_cron_runs(tenant_id, workspace_name, workflow_name, created_at);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_cron_runs_status ON workflow_v2_cron_runs(tenant_id, status, created_at);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_cron_runs_claw ON workflow_v2_cron_runs(claw_id);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_cron_runs_v2_run ON workflow_v2_cron_runs(v2_run_id);
+
 	`)
 	if err != nil {
 		return fmt.Errorf("workflow v2 migrate: %w", err)
 	}
 	if err := addColumnIfMissing(db, "workflow_v2_runs", "trigger_type", "TEXT NOT NULL DEFAULT 'manual'"); err != nil {
+		return fmt.Errorf("workflow v2 migrate: %w", err)
+	}
+	if err := addColumnIfMissing(db, "workflow_v2_cron_runs", "updated_at", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return fmt.Errorf("workflow v2 migrate: %w", err)
 	}
 	if err := addColumnIfMissing(db, "workflow_v2_runs", "task_run_id", "TEXT NOT NULL DEFAULT ''"); err != nil {

--- a/pkg/hub/workflowv2/schema.go
+++ b/pkg/hub/workflowv2/schema.go
@@ -43,6 +43,7 @@ func Migrate(db *sql.DB) error {
 	CREATE INDEX IF NOT EXISTS idx_workflow_v2_runs_tenant_updated ON workflow_v2_runs(tenant_id, updated_at DESC, id);
 	CREATE INDEX IF NOT EXISTS idx_workflow_v2_runs_workflow ON workflow_v2_runs(tenant_id, workspace_name, workflow_name, updated_at DESC);
 	CREATE INDEX IF NOT EXISTS idx_workflow_v2_runs_status ON workflow_v2_runs(tenant_id, status, updated_at DESC);
+	CREATE INDEX IF NOT EXISTS idx_workflow_v2_runs_timeout ON workflow_v2_runs(status, timeout_at, created_at);
 
 	CREATE TABLE IF NOT EXISTS workflow_v2_attempts (
 		id          TEXT PRIMARY KEY,

--- a/pkg/hub/workflowv2/schema.go
+++ b/pkg/hub/workflowv2/schema.go
@@ -34,6 +34,7 @@ func Migrate(db *sql.DB) error {
 		context_bundle_id  TEXT NOT NULL DEFAULT '',
 		trigger_type       TEXT NOT NULL DEFAULT 'manual',
 		task_run_id        TEXT NOT NULL DEFAULT '',
+		timeout_at         INTEGER NOT NULL DEFAULT 0,
 		created_at         INTEGER NOT NULL,
 		updated_at         INTEGER NOT NULL,
 		finished_at        INTEGER NOT NULL DEFAULT 0
@@ -298,6 +299,9 @@ func Migrate(db *sql.DB) error {
 		return fmt.Errorf("workflow v2 migrate: %w", err)
 	}
 	if err := addColumnIfMissing(db, "workflow_v2_runs", "task_run_id", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		return fmt.Errorf("workflow v2 migrate: %w", err)
+	}
+	if err := addColumnIfMissing(db, "workflow_v2_runs", "timeout_at", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return fmt.Errorf("workflow v2 migrate: %w", err)
 	}
 	return nil

--- a/pkg/hub/workspace_api.go
+++ b/pkg/hub/workspace_api.go
@@ -255,11 +255,7 @@ func (s *Server) handleWorkspaceWorkflowsPush(w http.ResponseWriter, r *http.Req
 		http.Error(w, "save workflows: "+err.Error(), status)
 		return
 	}
-	if s.cronScheduler != nil {
-		if err := s.cronScheduler.reload(); err != nil {
-			log.Printf("[cron] failed to reload workflows after workflow push for workspace %s: %v", name, err)
-		}
-	}
+	s.reloadCronSchedulers("workflow push", name, "")
 	workflows := make([]WorkflowView, 0, len(req.Workflows))
 	for _, workflow := range req.Workflows {
 		workflows = append(workflows, workflowToView(name, workflow))
@@ -359,11 +355,7 @@ func (s *Server) handleWorkspaceWorkflowPatch(w http.ResponseWriter, r *http.Req
 		http.Error(w, "save workflow: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	if s.cronScheduler != nil {
-		if err := s.cronScheduler.reload(); err != nil {
-			log.Printf("[cron] failed to reload workflows after workflow patch for workspace %s workflow %s: %v", workspace.Name, workflow.Name, err)
-		}
-	}
+	s.reloadCronSchedulers("workflow patch", workspace.Name, workflow.Name)
 	jsonOK(w, workflowToView(workspace.Name, workflow))
 }
 
@@ -400,10 +392,11 @@ func (s *Server) handleWorkspaceWorkflowDelete(w http.ResponseWriter, r *http.Re
 	}
 	if s.cronScheduler != nil {
 		s.cronScheduler.removeWorkflow(deletedWorkspaceName, deletedWorkflowName)
-		if err := s.cronScheduler.reload(); err != nil {
-			log.Printf("[cron] failed to reload workflows after workflow delete for workspace %s workflow %s: %v", deletedWorkspaceName, deletedWorkflowName, err)
-		}
 	}
+	if s.cronSchedulerV2 != nil {
+		s.cronSchedulerV2.removeWorkflow(deletedWorkspaceName, deletedWorkflowName)
+	}
+	s.reloadCronSchedulers("workflow delete", deletedWorkspaceName, deletedWorkflowName)
 	jsonOK(w, map[string]string{"deleted": deletedWorkflowName})
 }
 
@@ -676,6 +669,19 @@ func (s *Server) resolveWorkflowConfig(workspaceName, workflowName string) (*typ
 		}
 	}
 	return nil, nil, false, nil
+}
+
+func (s *Server) reloadCronSchedulers(reason, workspaceName, workflowName string) {
+	if s.cronScheduler != nil {
+		if err := s.cronScheduler.reload(); err != nil {
+			log.Printf("[cron] failed to reload workflows after %s for workspace %s workflow %s: %v", reason, workspaceName, workflowName, err)
+		}
+	}
+	if s.cronSchedulerV2 != nil {
+		if err := s.cronSchedulerV2.reload(); err != nil {
+			log.Printf("[cron-v2] failed to reload workflows after %s for workspace %s workflow %s: %v", reason, workspaceName, workflowName, err)
+		}
+	}
 }
 
 func cloneStringMap(values map[string]string) map[string]string {

--- a/pkg/types/convert/workflow_v1_v2.go
+++ b/pkg/types/convert/workflow_v1_v2.go
@@ -129,9 +129,6 @@ func convertWorkflowV1ToV2(data []byte, opts Options) (Result, error) {
 	if wf.Integration != "" {
 		appendWarning(&warnings, "integration %q: v2 workflows are event/state driven; re-bind trigger sources via workspace connections and runtime adapters (not embedded as v1 integration)", wf.Integration)
 	}
-	if wf.Trigger != nil {
-		appendWarning(&warnings, "trigger: v1 trigger block not copied into v2 — configure run creation / issue association outside the v2 state machine (hub trigger adapters)")
-	}
 	if len(wf.Inputs) > 0 {
 		appendWarning(&warnings, "inputs: %d v1 input(s) not represented in workflow v2 schema yet; preserve separately if still needed for manual trigger UX", len(wf.Inputs))
 	}
@@ -151,6 +148,18 @@ func convertWorkflowV1ToV2(data []byte, opts Options) (Result, error) {
 	}
 	if len(transitions) > 0 {
 		out.Transitions = transitions
+	}
+	if wf.Trigger != nil && wf.Trigger.Cron != nil {
+		out.Trigger = &v2.WorkflowTrigger{
+			Cron: &v2.CronTrigger{
+				Schedule:      wf.Trigger.Cron.Schedule,
+				Timezone:      wf.Trigger.Cron.Timezone,
+				OverlapPolicy: wf.Trigger.Cron.OverlapPolicy,
+				Timeout:       wf.Trigger.Cron.Timeout,
+			},
+		}
+	} else if wf.Trigger != nil {
+		appendWarning(&warnings, "trigger: only v1 trigger.cron is copied into v2; other trigger kinds are not represented in workflow v2 schema yet")
 	}
 
 	// Validate structurally; pair-validate when workspace YAML provided.

--- a/pkg/types/convert/workflow_v1_v2.go
+++ b/pkg/types/convert/workflow_v1_v2.go
@@ -150,12 +150,18 @@ func convertWorkflowV1ToV2(data []byte, opts Options) (Result, error) {
 		out.Transitions = transitions
 	}
 	if wf.Trigger != nil && wf.Trigger.Cron != nil {
+		ct := wf.Trigger.Cron
+		overlapPolicy := ct.OverlapPolicy
+		if strings.EqualFold(overlapPolicy, "queue") {
+			overlapPolicy = "skip"
+			appendWarning(&warnings, "trigger.cron.overlap_policy %q is not supported in workflow v2; converted to %q", ct.OverlapPolicy, overlapPolicy)
+		}
 		out.Trigger = &v2.WorkflowTrigger{
 			Cron: &v2.CronTrigger{
-				Schedule:      wf.Trigger.Cron.Schedule,
-				Timezone:      wf.Trigger.Cron.Timezone,
-				OverlapPolicy: wf.Trigger.Cron.OverlapPolicy,
-				Timeout:       wf.Trigger.Cron.Timeout,
+				Schedule:      ct.Schedule,
+				Timezone:      ct.Timezone,
+				OverlapPolicy: overlapPolicy,
+				Timeout:       ct.Timeout,
 			},
 		}
 	} else if wf.Trigger != nil {

--- a/pkg/types/v2/workflow.go
+++ b/pkg/types/v2/workflow.go
@@ -19,7 +19,22 @@ type Workflow struct {
 	Review        *WorkflowReview            `yaml:"review,omitempty" json:"review,omitempty"`
 	Delivery      *WorkflowDelivery          `yaml:"delivery,omitempty" json:"delivery,omitempty"`
 	Events        map[string]EventDefinition `yaml:"events,omitempty" json:"events,omitempty"`
+	Trigger       *WorkflowTrigger           `yaml:"trigger,omitempty" json:"trigger,omitempty"`
 	Raw           map[string]interface{}     `yaml:"-" json:"-"`
+}
+
+// WorkflowTrigger declares how the hub may create new runs outside the state
+// machine. Currently only cron schedules are supported, matching v1 behavior.
+type WorkflowTrigger struct {
+	Cron *CronTrigger `yaml:"cron,omitempty" json:"cron,omitempty"`
+}
+
+// CronTrigger is a v1-compatible cron schedule for workflow v2.
+type CronTrigger struct {
+	Schedule      string `yaml:"schedule" json:"schedule"`
+	Timezone      string `yaml:"timezone,omitempty" json:"timezone,omitempty"`
+	OverlapPolicy string `yaml:"overlap_policy,omitempty" json:"overlap_policy,omitempty"`
+	Timeout       string `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 }
 
 // State is an explicit workflow state.

--- a/pkg/types/v2/workflow_test.go
+++ b/pkg/types/v2/workflow_test.go
@@ -759,6 +759,95 @@ states:
 	}
 }
 
+func TestWorkflowV2CronTriggerValidation(t *testing.T) {
+	base := `
+schema_version: 2
+name: cron-wf
+enabled: true
+initial_state: s
+states:
+  s:
+    phase: build
+  done:
+    phase: done
+    terminal: true
+`
+	tests := []struct {
+		name    string
+		trigger string
+		wantErr string
+	}{
+		{
+			name: "valid skip",
+			trigger: `trigger:
+  cron:
+    schedule: "0 9 * * *"
+    timezone: "America/New_York"
+    overlap_policy: skip
+    timeout: 30m`,
+		},
+		{
+			name: "valid parallel without timezone",
+			trigger: `trigger:
+  cron:
+    schedule: "0 9 * * *"
+    overlap_policy: parallel`,
+		},
+		{
+			name: "missing schedule",
+			trigger: `trigger:
+  cron:
+    overlap_policy: skip`,
+			wantErr: "schedule is required",
+		},
+		{
+			name: "invalid schedule",
+			trigger: `trigger:
+  cron:
+    schedule: "not-a-cron"`,
+			wantErr: "schedule",
+		},
+		{
+			name: "invalid overlap policy",
+			trigger: `trigger:
+  cron:
+    schedule: "0 9 * * *"
+    overlap_policy: queue`,
+			wantErr: "overlap_policy",
+		},
+		{
+			name: "invalid timezone",
+			trigger: `trigger:
+  cron:
+    schedule: "0 9 * * *"
+    timezone: "Mars/Phobos"`,
+			wantErr: "timezone",
+		},
+		{
+			name: "invalid timeout",
+			trigger: `trigger:
+  cron:
+    schedule: "0 9 * * *"
+    timeout: "forever"`,
+			wantErr: "timeout",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := v2.ParseAndValidateWorkflow([]byte(base + "\n" + tt.trigger))
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestWorkflowV2ExecRunRejectsMissingCapability(t *testing.T) {
 	ws := `
 schema_version: 2

--- a/pkg/types/v2/workflow_validate.go
+++ b/pkg/types/v2/workflow_validate.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/robfig/cron/v3"
 	"gopkg.in/yaml.v3"
 )
 
@@ -38,6 +40,7 @@ var knownWorkflowKeys = map[string]bool{
 	"review":          true,
 	"delivery":        true,
 	"events":          true,
+	"trigger":         true,
 }
 
 // ParseWorkflow unmarshals workflow v2 YAML. It does not validate.
@@ -251,6 +254,9 @@ func ValidateWorkflow(wf *Workflow) (*ResolvedWorkflow, error) {
 			}
 		}
 	}
+	if err := validateTrigger(wf); err != nil {
+		return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
+	}
 	if err := validateDelivery(wf); err != nil {
 		return nil, fmt.Errorf("workflow %q: %w", wf.Name, err)
 	}
@@ -366,6 +372,41 @@ func validateEvidencePolicyNode(path string, node interface{}, mode string, root
 		return fmt.Errorf("%s.approvals.minimum must be a non-negative integer", path)
 	}
 	return nil
+}
+
+func validateTrigger(wf *Workflow) error {
+	if wf == nil || wf.Trigger == nil {
+		return nil
+	}
+	if wf.Trigger.Cron == nil {
+		return fmt.Errorf("trigger: only cron is supported")
+	}
+	ct := wf.Trigger.Cron
+	if strings.TrimSpace(ct.Schedule) == "" {
+		return fmt.Errorf("trigger.cron.schedule is required")
+	}
+	if _, err := parseCronSchedule(ct.Schedule); err != nil {
+		return fmt.Errorf("trigger.cron.schedule %q is invalid: %w", ct.Schedule, err)
+	}
+	if ct.OverlapPolicy != "" && ct.OverlapPolicy != "skip" && ct.OverlapPolicy != "parallel" {
+		return fmt.Errorf("trigger.cron.overlap_policy %q is invalid (must be skip or parallel)", ct.OverlapPolicy)
+	}
+	if ct.Timezone != "" {
+		if _, err := time.LoadLocation(ct.Timezone); err != nil {
+			return fmt.Errorf("trigger.cron.timezone %q is invalid: %w", ct.Timezone, err)
+		}
+	}
+	if ct.Timeout != "" {
+		if _, err := time.ParseDuration(ct.Timeout); err != nil {
+			return fmt.Errorf("trigger.cron.timeout %q is invalid: %w", ct.Timeout, err)
+		}
+	}
+	return nil
+}
+
+func parseCronSchedule(schedule string) (cron.Schedule, error) {
+	parser := cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+	return parser.Parse(schedule)
 }
 
 func evidencePolicyMap(value interface{}) (map[string]interface{}, bool) {


### PR DESCRIPTION
Implements v1-compatible `trigger.cron` for workflow v2.

### What changed
- Added `trigger.cron` schema and validation to `pkg/types/v2`.
- Added a dedicated v2 cron scheduler (`pkg/hub/cron_scheduler_v2.go`) with skip/parallel overlap policies and skipped-run history in a new `workflow_v2_cron_runs` table.
- Wired v2 scheduler startup/reload/delete into the server lifecycle.
- Existing `/cron/*` endpoints now dispatch to v1 or v2 and return both histories for run listings/lookups.
- Any enabled v2 cron workflow can be manually triggered via `/cron/trigger` without `manual_trigger: true`.
- Terminal v2 runs finish their cron history row.
- v1→v2 converter preserves `trigger.cron`.
- CLI: added `workflow trigger --cron` and `workflow runs --cron`.
- Added example workflow and unit tests.

### Test command
```
go test ./pkg/types/v2/... ./pkg/types/convert/... ./pkg/hub/... ./cmd/... -count=1
```

Closes the implementation gap described in `docs/v2-schedule-trigger-rfc.md` (docs intentionally left out of this commit).